### PR TITLE
go: container server and replicator

### DIFF
--- a/bench/cbench.go
+++ b/bench/cbench.go
@@ -1,0 +1,256 @@
+//  Copyright (c) 2015 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package bench
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+)
+
+type ContainerObject struct {
+	Url string
+}
+
+func (obj *ContainerObject) Put() bool {
+	req, err := http.NewRequest("PUT", obj.Url, nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Content-Type", "application/octet-stream")
+	req.Header.Set("X-Size", "0")
+	req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+	resp, err := http.DefaultClient.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	return err == nil && resp.StatusCode/100 == 2
+}
+
+func (obj *ContainerObject) Delete() bool {
+	req, _ := http.NewRequest("DELETE", obj.Url, nil)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	resp, err := http.DefaultClient.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	return err == nil && resp.StatusCode/100 == 2
+}
+
+func RunCBench(args []string) {
+	if len(args) < 1 {
+		fmt.Println("Usage: [configuration file]")
+		fmt.Println("The configuration file should look something like:")
+		fmt.Println("    [cbench]")
+		fmt.Println("    address = http://127.0.0.1:6011/")
+		fmt.Println("    containers = 5")
+		fmt.Println("    concurrency = 10")
+		fmt.Println("    num_objects = 10000")
+		fmt.Println("    num_gets = 500")
+		fmt.Println("    delete = yes")
+		fmt.Println("    check_mounted = false")
+		fmt.Println("    #drive_list = sdb1,sdb2")
+		os.Exit(1)
+	}
+
+	benchconf, err := conf.LoadConfig(args[0])
+	if err != nil {
+		fmt.Println("Error parsing ini file:", err)
+		os.Exit(1)
+	}
+
+	address := benchconf.GetDefault("cbench", "address", "http://127.0.0.1:6011/")
+	if !strings.HasSuffix(address, "/") {
+		address = address + "/"
+	}
+	concurrency := int(benchconf.GetInt("cbench", "concurrency", 10))
+	containerCount := int(benchconf.GetInt("cbench", "containers", 5))
+	numObjects := benchconf.GetInt("cbench", "num_objects", 10000)
+	numGets := int(benchconf.GetInt("cbench", "num_gets", 500))
+	checkMounted := benchconf.GetBool("cbench", "check_mounted", false)
+	driveList := benchconf.GetDefault("cbench", "drive_list", "")
+	numPartitions := int64(100)
+	delete := benchconf.GetBool("cbench", "delete", true)
+
+	deviceList := GetDevices(address, checkMounted)
+	if driveList != "" {
+		deviceList = strings.Split(driveList, ",")
+	}
+
+	containers := make([]string, containerCount)
+	for i := 0; i < containerCount; i++ {
+		device := strings.Trim(deviceList[i%len(deviceList)], " ")
+		part := rand.Int63() % numPartitions
+		cid := rand.Int63()
+		containers[i] = fmt.Sprintf("%s%s/%d/%s/%d", address, device, part, "a", cid)
+		req, _ := http.NewRequest("PUT", containers[i], nil)
+		req.Header.Set("X-Timestamp", common.GetTimestamp())
+		resp, err := http.DefaultClient.Do(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err != nil || resp.StatusCode/100 != 2 {
+			fmt.Println("Container PUT failed: ", resp.StatusCode, err)
+			os.Exit(1)
+		}
+	}
+
+	objects := make([]*ContainerObject, numObjects)
+	for i, _ := range objects {
+		container := containers[i%len(containers)]
+		objects[i] = &ContainerObject{
+			Url: fmt.Sprintf("%s/%d", container, rand.Int63()),
+		}
+	}
+
+	work := make([]func() bool, len(objects))
+	for i, _ := range objects {
+		work[i] = objects[i].Put
+	}
+	DoJobs("OBJECT PUT", work, concurrency)
+
+	time.Sleep(time.Second * 2)
+
+	getContainer := func() bool {
+		container := containers[rand.Int()%len(containers)]
+		req, _ := http.NewRequest("GET", container+"?format=json", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			defer resp.Body.Close()
+			w, err := io.Copy(ioutil.Discard, resp.Body)
+			if err != nil || w < 2 {
+				return false
+			}
+		}
+		return err == nil && resp.StatusCode/100 == 2 && resp.Header.Get("Content-Type") == "application/json; charset=utf-8"
+	}
+	work = make([]func() bool, numGets)
+	for i := 0; i < numGets; i++ {
+		work[i] = getContainer
+	}
+	DoJobs("CONTAINER GET", work, concurrency)
+
+	time.Sleep(time.Second * 2)
+
+	if delete {
+		work = make([]func() bool, len(objects))
+		for i, _ := range objects {
+			work[i] = objects[i].Delete
+		}
+		DoJobs("OBJECT DELETE", work, concurrency)
+	}
+}
+
+func RunCGBench(args []string) {
+	if len(args) < 1 {
+		fmt.Println("Usage: [configuration file]")
+		fmt.Println("The configuration file should look something like:")
+		fmt.Println("    [cgbench]")
+		fmt.Println("    address = http://127.0.0.1:6011/")
+		fmt.Println("    concurrency = 5")
+		fmt.Println("    num_objects = 5000000")
+		fmt.Println("    report_interval = 100000")
+		fmt.Println("    num_gets = 10")
+		fmt.Println("    check_mounted = false")
+		fmt.Println("    #drive_list = sdb1,sdb2")
+		os.Exit(1)
+	}
+
+	benchconf, err := conf.LoadConfig(args[0])
+	if err != nil {
+		fmt.Println("Error parsing ini file:", err)
+		os.Exit(1)
+	}
+
+	address := benchconf.GetDefault("cgbench", "address", "http://127.0.0.1:6011/")
+	if !strings.HasSuffix(address, "/") {
+		address = address + "/"
+	}
+	concurrency := int(benchconf.GetInt("cgbench", "concurrency", 5))
+	reportInterval := benchconf.GetInt("cgbench", "report_interval", 100000)
+	numObjects := benchconf.GetInt("cgbench", "num_objects", 5000000)
+	numGets := int(benchconf.GetInt("cgbench", "num_gets", 10))
+	checkMounted := benchconf.GetBool("cgbench", "check_mounted", false)
+	driveList := benchconf.GetDefault("cgbench", "drive_list", "")
+	numPartitions := int64(100)
+
+	deviceList := GetDevices(address, checkMounted)
+	if driveList != "" {
+		deviceList = strings.Split(driveList, ",")
+	}
+
+	device := strings.Trim(deviceList[0], " ")
+	part := rand.Int63() % numPartitions
+	cid := rand.Int63()
+	container := fmt.Sprintf("%s%s/%d/%s/%d", address, device, part, "a", cid)
+	req, _ := http.NewRequest("PUT", container, nil)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	resp, err := http.DefaultClient.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	if err != nil || resp.StatusCode/100 != 2 {
+		fmt.Println("Container PUT failed: ", resp.StatusCode, err)
+		os.Exit(1)
+	}
+
+	for totalObjects := int64(0); totalObjects < numObjects; totalObjects += reportInterval {
+		fmt.Println("Object count:", totalObjects)
+		objects := make([]*ContainerObject, int(reportInterval))
+		for i, _ := range objects {
+			objects[i] = &ContainerObject{
+				Url: fmt.Sprintf("%s/%d", container, rand.Int63()),
+			}
+		}
+
+		work := make([]func() bool, len(objects))
+		for i, _ := range objects {
+			work[i] = objects[i].Put
+		}
+		DoJobs("OBJECT PUT", work, concurrency)
+
+		time.Sleep(time.Second * 2)
+
+		getContainer := func() bool {
+			req, _ := http.NewRequest("GET", container+"?format=json&marker=5", nil)
+			resp, err := http.DefaultClient.Do(req)
+			if err == nil {
+				defer resp.Body.Close()
+				w, err := io.Copy(ioutil.Discard, resp.Body)
+				if err != nil || w < 2 {
+					return false
+				}
+			}
+			return err == nil && resp.StatusCode/100 == 2 && resp.Header.Get("Content-Type") == "application/json; charset=utf-8"
+		}
+		work = make([]func() bool, numGets)
+		for i := 0; i < numGets; i++ {
+			work[i] = getContainer
+		}
+		DoJobs("CONTAINER GET", work, concurrency)
+
+		time.Sleep(time.Second * 2)
+	}
+}

--- a/common/conf/policy.go
+++ b/common/conf/policy.go
@@ -32,6 +32,15 @@ type Policy struct {
 
 type PolicyList map[int]*Policy
 
+func (p PolicyList) Default() int {
+	for _, v := range p {
+		if v.Default {
+			return v.Index
+		}
+	}
+	return 0
+}
+
 // LoadPolicies loads policies, probably from /etc/swift/swift.conf
 func normalLoadPolicies() PolicyList {
 	policies := map[int]*Policy{0: {

--- a/common/conf/syncrealm.go
+++ b/common/conf/syncrealm.go
@@ -1,0 +1,75 @@
+//  Copyright (c) 2015 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package conf
+
+import "strings"
+
+type SyncRealm struct {
+	Name     string
+	Key1     string
+	Key2     string
+	Clusters map[string]string
+}
+
+type SyncRealmList map[string]SyncRealm
+
+func (l SyncRealmList) ValidateSyncTo(syncHeader string) bool {
+	if !strings.HasPrefix(syncHeader, "//") {
+		return false
+	}
+	parts := strings.Split(syncHeader[2:], "/")
+	if len(parts) < 4 {
+		return false
+	}
+	realm := parts[0]
+	cluster := parts[1]
+	account := parts[2]
+	container := parts[3]
+	if account == "" || container == "" {
+		return false
+	}
+	if l[realm].Key1 == "" {
+		return false
+	}
+	if l[realm].Clusters[cluster] == "" {
+		return false
+	}
+	return true
+}
+
+var syncRealmConfigLocations = []string{"/etc/hummingbird/container-sync-realms.conf", "/etc/swift/container-sync-realms.conf"}
+
+func GetSyncRealms() SyncRealmList {
+	resp := make(map[string]SyncRealm)
+	for _, loc := range syncRealmConfigLocations {
+		if conf, err := LoadConfig(loc); err == nil {
+			for realm, config := range conf.File {
+				realm := SyncRealm{Name: realm, Clusters: make(map[string]string)}
+				for k, v := range config {
+					if k == "key" {
+						realm.Key1 = v
+					} else if k == "key2" {
+						realm.Key2 = v
+					} else if strings.HasPrefix(k, "cluster_") {
+						realm.Clusters[k[8:]] = v
+					}
+				}
+				resp[realm.Name] = realm
+			}
+		}
+	}
+	return SyncRealmList(resp)
+}

--- a/containerserver/engine.go
+++ b/containerserver/engine.go
@@ -1,0 +1,310 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"container/list"
+	"crypto/md5"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/troubling/hummingbird/common"
+)
+
+var (
+	// ErrorNoSuchContainer is returned when a requested container doesn't exist.
+	ErrorNoSuchContainer = fmt.Errorf("No such container.")
+	// ErrorInvalidMetadata is returned for errors that violate the API metadata constraints.
+	ErrorInvalidMetadata = fmt.Errorf("Invalid metadata value")
+	// ErrorPolicyConflict is returned when an operation conflicts with the container's existing policy.
+	ErrorPolicyConflict = fmt.Errorf("Policy conflicts with existing value")
+)
+
+// ContainerInfo represents the container_info database record - basic information about the container.
+type ContainerInfo struct {
+	Account                 string              `json:"account"`
+	Container               string              `json:"container"`
+	CreatedAt               string              `json:"created_at"`
+	PutTimestamp            string              `json:"put_timestamp"`
+	DeleteTimestamp         string              `json:"delete_timestamp"`
+	StatusChangedAt         string              `json:"status_changed_at"`
+	ObjectCount             int64               `json:"count"`
+	BytesUsed               int64               `json:"bytes_used"`
+	ReportedPutTimestamp    string              `json:"-"`
+	ReportedDeleteTimestamp string              `json:"-"`
+	ReportedObjectCount     int64               `json:"-"`
+	ReportedBytesUsed       int64               `json:"-"`
+	Hash                    string              `json:"hash"`
+	ID                      string              `json:"id"`
+	XContainerSyncPoint1    string              `json:"-"`
+	XContainerSyncPoint2    string              `json:"-"`
+	StoragePolicyIndex      int                 `json:"storage_policy_index"`
+	RawMetadata             string              `json:"metadata"`
+	Metadata                map[string][]string `json:"-"`
+	MaxRow                  int64               `json:"max_row"`
+	invalid                 bool
+	updated                 time.Time
+	// This row isn't populated by GetInfo, it only exists for the times this is
+	// serialized during replication.
+	Point int64 `json:"point"`
+}
+
+// ObjectListingRecord is the struct used for serializing objects in json and xml container listings.
+type ObjectListingRecord struct {
+	XMLName      xml.Name `xml:"object" json:"-"`
+	Name         string   `xml:"name" json:"name"`
+	LastModified string   `xml:"last_modified" json:"last_modified"`
+	Size         int64    `xml:"bytes" json:"bytes"`
+	ContentType  string   `xml:"content_type" json:"content_type"`
+	ETag         string   `xml:"hash" json:"hash"`
+}
+
+// SubdirListingRecord is the struct used for serializing subdirs in json and xml container listings.
+type SubdirListingRecord struct {
+	XMLName xml.Name `xml:"subdir" json:"-"`
+	Name2   string   `xml:"name,attr" json:"-"`
+	Name    string   `xml:"name" json:"subdir"`
+}
+
+// ObjectRecord represents the object's data in-databaee, it is used by replication.
+type ObjectRecord struct {
+	Rowid              int64  `json:"ROWID"`
+	Name               string `json:"name"`
+	CreatedAt          string `json:"created_at"`
+	Size               int64  `json:"size"`
+	ContentType        string `json:"content_type"`
+	ETag               string `json:"etag"`
+	Deleted            int    `json:"deleted"`
+	StoragePolicyIndex int    `json:"storage_policy_index"`
+}
+
+// SyncRecord represents a row in the incoming_sync table.  It is used by replication.
+type SyncRecord struct {
+	SyncPoint int64  `json:"sync_point"`
+	RemoteID  string `json:"remote_id"`
+}
+
+// Container is the interface implemented by a container.
+type Container interface {
+	// GetInfo returns the ContainerInfo struct for the container.
+	GetInfo() (*ContainerInfo, error)
+	// IsDeleted returns true if the container has been deleted.
+	IsDeleted() (bool, error)
+	// Delete deletes the container.
+	Delete(timestamp string) error
+	// ListObjects lists the container's object entries.
+	ListObjects(limit int, marker string, endMarker string, prefix string, delimiter string, path *string, reverse bool, storagePolicyIndex int) ([]interface{}, error)
+	// GetMetadata returns the container's current metadata.
+	GetMetadata() (map[string]string, error)
+	// UpdateMetadata applies updates to the container's metadata.
+	UpdateMetadata(updates map[string][]string) error
+	// PutObject adds a new object to the container.
+	PutObject(name string, timestamp string, size int64, contentType string, etag string, storagePolicyIndex int) error
+	// DeleteObject deletes an object from the container.
+	DeleteObject(name string, timestamp string, storagePolicyIndex int) error
+	// ID returns a unique identifier for the container.
+	ID() string
+	// Close frees any resources associated with the container.
+	Close() error
+}
+
+// ReplicableContainer is a container that also implements the replication API.
+type ReplicableContainer interface {
+	Container
+	// MergeItems merges object records into the container, with an optional remoteId.
+	MergeItems(records []*ObjectRecord, remoteID string) error
+	// ItemsSince returns count object records with a ROWID greater than start.
+	ItemsSince(start int64, count int) ([]*ObjectRecord, error)
+	// MergeSyncTable updates the container's incoming sync tables with new data.
+	MergeSyncTable(records []*SyncRecord) error
+	// SyncTable returns the container's current sync table.
+	SyncTable() ([]*SyncRecord, error)
+	// SyncRemoteData accepts a remote container's current status information and updates local records accordingly.
+	SyncRemoteData(maxRow int64, hash, id, createdAt, putTimestamp, deleteTimestamp, metadata string) (*ContainerInfo, error)
+	// NewID gives the database a new unique identifier, which is used for incoming_sync entries.
+	NewID() error
+	// OpenDatabaseFile returns a consistent reader for the underlying database file.
+	OpenDatabaseFile() (*os.File, func(), error)
+	// CleanupTombstones removes any metadata and object tombstones older than reclaimAge seconds.
+	CleanupTombstones(reclaimAge int64) error
+	// CheckSyncLinks makes sure container sync symlinks are correct for the database.
+	CheckSyncLink() error
+	// RingHash returns the container's ring hash.
+	RingHash() string
+}
+
+// ContainerEngine is the interface of an object that creates and returns containers.
+type ContainerEngine interface {
+	// GET returns a container, given a vars mapping.
+	Get(vars map[string]string) (c Container, err error)
+	// Return returns a Container to the engine, where it can close or retain them as it sees fit.
+	Return(c Container)
+	// Create creates a new container.  Returns true if the container was created and a pointer to the container.
+	Create(vars map[string]string, putTimestamp string, metadata map[string][]string, policyIndex, defaultPolicyIndex int) (bool, Container, error)
+	// Close releases all cached containers and any other retained resources.
+	Close()
+
+	// GetByHash returns a replicable database given its hash.  This will probably move from this interface once we
+	// have replicator->replicator communication.
+	GetByHash(device, hash, partition string) (c ReplicableContainer, err error)
+	// Invalidate removes a container from the cache entirely.  This will probably also move, since it's only used by replication.
+	Invalidate(c Container)
+}
+
+// My attempts at making this lruEngine reusable have not been successful, so for now it's sqlite-specific and not exported.
+type lruEngine struct {
+	deviceRoot     string
+	hashPathPrefix string
+	hashPathSuffix string
+	maxSize        int
+	cache          map[string]*lruEntry
+	used           *list.List
+	m              sync.Mutex
+}
+
+type lruEntry struct {
+	c     Container
+	inUse int
+	elem  *list.Element
+}
+
+func (l *lruEngine) add(c Container) {
+	if len(l.cache) >= l.maxSize {
+		for elem := l.used.Front(); elem != nil; elem = elem.Next() {
+			if entry, ok := elem.Value.(*lruEntry); ok && entry.inUse == 0 {
+				l.used.Remove(elem)
+				delete(l.cache, entry.c.ID())
+				entry.c.Close()
+				break
+			}
+		}
+	}
+	holder := &lruEntry{c: c, inUse: 1}
+	holder.elem = l.used.PushBack(holder)
+	l.cache[c.ID()] = holder
+}
+
+func (l *lruEngine) containerLocation(vars map[string]string) string {
+	h := md5.New()
+	fmt.Fprintf(h, "%s/%s/%s%s", l.hashPathPrefix, vars["account"], vars["container"], l.hashPathSuffix)
+	hexHash := fmt.Sprintf("%032x", h.Sum(nil))
+	suffix := hexHash[29:32]
+	return filepath.Join(l.deviceRoot, vars["device"], "containers", vars["partition"], suffix, hexHash, hexHash+".db")
+}
+
+func (l *lruEngine) getbypath(containerFile string) (c Container, err error) {
+	if !common.Exists(containerFile) {
+		return nil, ErrorNoSuchContainer
+	}
+	ringHash := filepath.Base(filepath.Dir(containerFile))
+	l.m.Lock()
+	defer l.m.Unlock()
+	if e := l.cache[ringHash]; e != nil {
+		e.inUse++
+		l.used.MoveToBack(e.elem)
+		return e.c, nil
+	}
+	if c, err = sqliteOpenContainer(containerFile); err != nil {
+		return nil, err
+	}
+	l.add(c)
+	return c, nil
+}
+
+// Get returns a database given the incoming vars.
+func (l *lruEngine) Get(vars map[string]string) (c Container, err error) {
+	return l.getbypath(l.containerLocation(vars))
+}
+
+// Create creates a new container.
+func (l *lruEngine) Create(vars map[string]string, putTimestamp string, metadata map[string][]string, policyIndex, defaultPolicyIndex int) (bool, Container, error) {
+	containerFile := l.containerLocation(vars)
+	created := false
+	c, err := l.Get(vars)
+	if err != nil {
+		created = true
+		if policyIndex < 0 {
+			policyIndex = defaultPolicyIndex
+		}
+		err = sqliteCreateContainer(containerFile, vars["account"], vars["container"], putTimestamp, metadata, policyIndex)
+		if err == nil {
+			c, err = l.Get(vars)
+		}
+	} else {
+		created, err = sqliteCreateExistingContainer(c, putTimestamp, metadata, policyIndex, defaultPolicyIndex)
+	}
+	return created, c, err
+}
+
+// Return returns a database object to the engine.
+func (l *lruEngine) Return(c Container) {
+	l.m.Lock()
+	if e := l.cache[c.ID()]; e != nil && e.c == c {
+		e.inUse--
+	} else {
+		l.add(c)
+	}
+	l.m.Unlock()
+}
+
+// GetByHash returns a database given its device and ring hash.
+func (l *lruEngine) GetByHash(device, hash, partition string) (ReplicableContainer, error) {
+	containerFile := filepath.Join(l.deviceRoot, device, "containers", partition, hash[29:32], hash, hash+".db")
+	c, err := l.getbypath(containerFile)
+	if err != nil {
+		return nil, err
+	}
+	rc, ok := c.(ReplicableContainer)
+	if !ok {
+		return nil, fmt.Errorf("Container does not support replication.")
+	}
+	return rc, nil
+}
+
+// Invalidate removes any cached backend connections to the database.
+func (l *lruEngine) Invalidate(c Container) {
+	defer c.Close()
+	l.m.Lock()
+	if e := l.cache[c.ID()]; e != nil && e.c == c {
+		l.used.Remove(e.elem)
+		delete(l.cache, c.ID())
+	}
+	l.m.Unlock()
+}
+
+// Close shuts down any backend container database connections and clears the caches.
+func (l *lruEngine) Close() {
+	for k, v := range l.cache {
+		v.c.Close()
+		delete(l.cache, k)
+	}
+	l.used = l.used.Init()
+}
+
+func newLRUEngine(deviceRoot, hashPathPrefix, hashPathSuffix string, containerCount int) *lruEngine {
+	return &lruEngine{
+		deviceRoot:     deviceRoot,
+		hashPathPrefix: hashPathPrefix,
+		hashPathSuffix: hashPathSuffix,
+		maxSize:        containerCount,
+		cache:          make(map[string]*lruEntry),
+		used:           list.New(),
+	}
+}

--- a/containerserver/engine_test.go
+++ b/containerserver/engine_test.go
@@ -1,0 +1,82 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"container/list"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type hashDatabase struct {
+	fakeDatabase
+	hash string
+}
+
+func (h hashDatabase) ID() string {
+	return h.hash
+}
+
+func TestAddRemoves(t *testing.T) {
+	l := &lruEngine{
+		maxSize: 3,
+		cache:   make(map[string]*lruEntry),
+		used:    list.New(),
+	}
+	dbs := make([]hashDatabase, 5)
+	for i, db := range dbs {
+		db.hash = fmt.Sprintf("%d", i)
+		l.add(db)
+		l.Return(db)
+	}
+	require.Equal(t, 3, len(l.cache))
+	require.Equal(t, 3, l.used.Len())
+}
+
+func TestClose(t *testing.T) {
+	l := &lruEngine{
+		maxSize: 3,
+		cache:   make(map[string]*lruEntry),
+		used:    list.New(),
+	}
+	dbs := make([]hashDatabase, 5)
+	for i, db := range dbs {
+		db.hash = fmt.Sprintf("%d", i)
+		l.add(db)
+		l.Return(db)
+	}
+	l.Close()
+	require.Equal(t, 0, len(l.cache))
+	require.Equal(t, 0, l.used.Len())
+}
+
+func TestAddOnReturn(t *testing.T) {
+	l := &lruEngine{
+		maxSize: 3,
+		cache:   make(map[string]*lruEntry),
+		used:    list.New(),
+	}
+	dbs := make([]hashDatabase, 5)
+	for i, db := range dbs {
+		db.hash = fmt.Sprintf("%d", i)
+		l.Return(db)
+	}
+	l.Close()
+	require.Equal(t, 0, len(l.cache))
+	require.Equal(t, 0, l.used.Len())
+}

--- a/containerserver/incoming_rep.go
+++ b/containerserver/incoming_rep.go
@@ -1,0 +1,251 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/srv"
+)
+
+func isOkayFilename(s string) bool {
+	if len(s) < 5 || len(s) > 100 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+			(c == '-') || (c == '_') || (c == '.')) {
+			return false
+		}
+	}
+	return true
+}
+
+// ContainerTmpUploadHandler handles uploading container files to the tmp directory for various replication strategies.
+// This replaces the swift replicator's use of rsync.
+func (server *ContainerServer) ContainerTmpUploadHandler(writer http.ResponseWriter, request *http.Request) {
+	vars := srv.GetVars(request)
+	if !isOkayFilename(vars["filename"]) {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	filename := filepath.Join(server.driveRoot, vars["device"], "tmp", vars["filename"])
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	fp, err := os.Create(filename)
+	if err != nil {
+		srv.GetLogger(request).LogError("Unable to create file %s: %v", filename, err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	defer fp.Close()
+	if _, err := io.Copy(fp, request.Body); err != nil {
+		os.RemoveAll(filename)
+		srv.GetLogger(request).LogError("Error saving file contents %s: %v", filename, err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+	} else {
+		srv.StandardResponse(writer, http.StatusCreated)
+	}
+}
+
+// ContainerReplicateHandler handles the REPLICATE call for containers.
+func (server *ContainerServer) ContainerReplicateHandler(writer http.ResponseWriter, request *http.Request) {
+	vars := srv.GetVars(request)
+	// make sure there's a tmp dir to rsync to
+	if err := os.MkdirAll(filepath.Join(server.driveRoot, vars["device"], "tmp"), 0777); err != nil {
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	message := []json.RawMessage{}
+	decoder := json.NewDecoder(request.Body)
+	if err := decoder.Decode(&message); err != nil {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	var op string
+	if err := json.Unmarshal(message[0], &op); err != nil {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	extractArgs := func(args ...interface{}) error {
+		if len(message)-1 < len(args) {
+			return errors.New("Not enough arguments in payload.")
+		}
+		for i, arg := range args {
+			if err := json.Unmarshal(message[i+1], arg); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	switch op {
+	case "rsync_then_merge":
+		var tmpFileName string
+		if err := extractArgs(&tmpFileName); err != nil {
+			srv.StandardResponse(writer, http.StatusBadRequest)
+		} else {
+			status := server.replicateRsyncThenMerge(request, vars, tmpFileName)
+			srv.StandardResponse(writer, status)
+		}
+	case "complete_rsync":
+		var tmpFileName string
+		if err := extractArgs(&tmpFileName); err != nil {
+			srv.StandardResponse(writer, http.StatusBadRequest)
+		} else {
+			status := server.replicateCompleteRsync(request, vars, tmpFileName)
+			srv.StandardResponse(writer, status)
+		}
+	case "merge_items":
+		var records []*ObjectRecord
+		var remoteID string
+		if err := extractArgs(&records, &remoteID); err != nil {
+			srv.StandardResponse(writer, http.StatusBadRequest)
+		} else {
+			status := server.replicateMergeItems(request, vars, records, remoteID)
+			srv.StandardResponse(writer, status)
+		}
+	case "merge_syncs":
+		var records []*SyncRecord
+		if err := extractArgs(&records); err != nil {
+			srv.StandardResponse(writer, http.StatusBadRequest)
+		} else {
+			status := server.replicateMergeSyncs(request, vars, records)
+			srv.StandardResponse(writer, status)
+		}
+	case "sync":
+		var maxRow int64
+		var hash, id, createdAt, putTimestamp, deleteTimestamp, metadata string
+		if err := extractArgs(&maxRow, &hash, &id, &createdAt, &putTimestamp, &deleteTimestamp, &metadata); err != nil {
+			srv.StandardResponse(writer, http.StatusBadRequest)
+		} else if status, data := server.replicateSync(request, vars, maxRow, hash, id, createdAt, putTimestamp, deleteTimestamp, metadata); status == http.StatusOK {
+			writer.WriteHeader(http.StatusOK)
+			writer.Write(data)
+		} else {
+			srv.StandardResponse(writer, status)
+		}
+	default:
+		srv.GetLogger(request).LogError("Unknown replication op: %s", op)
+		srv.StandardResponse(writer, http.StatusBadRequest)
+	}
+}
+
+func (server *ContainerServer) replicateRsyncThenMerge(request *http.Request, vars map[string]string, tmpFileName string) int {
+	containerFile := filepath.Join(server.driveRoot, vars["device"], "containers", vars["partition"], vars["hash"][29:32], vars["hash"], vars["hash"]+".db")
+	tmpContainerFile := filepath.Join(server.driveRoot, vars["device"], "tmp", tmpFileName)
+	tmpDb, err := sqliteOpenContainer(tmpContainerFile)
+	if err != nil {
+		return http.StatusNotFound
+	}
+	defer tmpDb.Close()
+	localDb, err := server.containerEngine.GetByHash(vars["device"], vars["hash"], vars["partition"])
+	if err != nil {
+		return http.StatusNotFound
+	}
+	defer localDb.Close()
+	point := int64(-1)
+	for {
+		records, err := localDb.ItemsSince(point, 10000)
+		if err != nil {
+			srv.GetLogger(request).LogError("Error fetching items %s: %v", containerFile, err)
+			return http.StatusInternalServerError
+		}
+		if len(records) == 0 {
+			break
+		}
+		point = records[len(records)-1].Rowid
+		if err := tmpDb.MergeItems(records, ""); err != nil {
+			srv.GetLogger(request).LogError("Error merging items to %s: %v", tmpContainerFile, err)
+			return http.StatusInternalServerError
+		}
+	}
+	if tmpDb.NewID() != nil || os.MkdirAll(filepath.Dir(containerFile), 0777) != nil || os.Rename(tmpContainerFile, containerFile) != nil {
+		srv.GetLogger(request).LogError("Error blessing new container db %s", containerFile)
+		return http.StatusInternalServerError
+	}
+	server.containerEngine.Invalidate(localDb)
+	return http.StatusNoContent
+}
+
+func (server *ContainerServer) replicateCompleteRsync(request *http.Request, vars map[string]string, tmpFileName string) int {
+	containerFile := filepath.Join(server.driveRoot, vars["device"], "containers", vars["partition"], vars["hash"][29:32], vars["hash"], vars["hash"]+".db")
+	tmpContainerFile := filepath.Join(server.driveRoot, vars["device"], "tmp", tmpFileName)
+	if !common.Exists(tmpContainerFile) || common.Exists(containerFile) {
+		return http.StatusNotFound
+	}
+	tmpDb, err := sqliteOpenContainer(tmpContainerFile)
+	if err != nil {
+		return http.StatusNotFound
+	}
+	defer tmpDb.Close()
+	if tmpDb.NewID() != nil || os.MkdirAll(filepath.Dir(containerFile), 0777) != nil || os.Rename(tmpContainerFile, containerFile) != nil {
+		srv.GetLogger(request).LogError("Error blessing new container db %s", containerFile)
+		return http.StatusInternalServerError
+	}
+	return http.StatusNoContent
+}
+
+func (server *ContainerServer) replicateMergeItems(request *http.Request, vars map[string]string, records []*ObjectRecord, remoteID string) int {
+	db, err := server.containerEngine.GetByHash(vars["device"], vars["hash"], vars["partition"])
+	if err != nil {
+		return http.StatusNotFound
+	}
+	defer server.containerEngine.Return(db)
+	if err := db.MergeItems(records, remoteID); err != nil {
+		srv.GetLogger(request).LogError("Error merging records with %s: %v", db.RingHash(), err)
+		return http.StatusInternalServerError
+	}
+	return http.StatusAccepted
+}
+
+func (server *ContainerServer) replicateMergeSyncs(request *http.Request, vars map[string]string, records []*SyncRecord) int {
+	db, err := server.containerEngine.GetByHash(vars["device"], vars["hash"], vars["partition"])
+	if err != nil {
+		return http.StatusNotFound
+	}
+	defer server.containerEngine.Return(db)
+	if err := db.MergeSyncTable(records); err != nil {
+		srv.GetLogger(request).LogError("Error merging sync table with %s: %v", db.RingHash(), err)
+		return http.StatusInternalServerError
+	}
+	return http.StatusAccepted
+}
+
+func (server *ContainerServer) replicateSync(request *http.Request, vars map[string]string, maxRow int64, hash, id, createdAt, putTimestamp, deleteTimestamp, metadata string) (int, []byte) {
+	db, err := server.containerEngine.GetByHash(vars["device"], vars["hash"], vars["partition"])
+	if err != nil {
+		return http.StatusNotFound, nil
+	}
+	defer server.containerEngine.Return(db)
+	info, err := db.SyncRemoteData(maxRow, hash, id, createdAt, putTimestamp, deleteTimestamp, metadata)
+	if err != nil {
+		srv.GetLogger(request).LogError("Error syncing remote data with %s: %v", vars["hash"], err)
+		return http.StatusInternalServerError, nil
+	}
+	response, err := json.Marshal(info)
+	if err != nil {
+		srv.GetLogger(request).LogError("Error marshaling info from %s: %v", vars["hash"], err)
+		return http.StatusInternalServerError, nil
+	}
+	return http.StatusOK, response
+}

--- a/containerserver/incoming_rep_test.go
+++ b/containerserver/incoming_rep_test.go
@@ -1,0 +1,443 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/troubling/hummingbird/common"
+)
+
+func TestServerReplicateSync(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.CanonicalTimestamp(100))
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	h := md5.New()
+	fmt.Fprintf(h, "%s/%s/%s%s", "changeme", "a", "c", "changeme")
+	containerHash := fmt.Sprintf("%032x", h.Sum(nil))
+	pretendLocalID := common.UUID()
+
+	syncRequest := func(maxRow int64, hash, pretendLocalID, createdAt, putTimestamp, deleteTimestamp, metadata string) ContainerInfo {
+		replRequest := []interface{}{"sync", maxRow, hash, pretendLocalID, createdAt, putTimestamp, deleteTimestamp, metadata}
+		msg, err := json.Marshal(replRequest)
+		require.Nil(t, err)
+		rsp = makeCaptureResponse()
+		req, err = http.NewRequest("REPLICATE", "/device/1/"+containerHash, bytes.NewBuffer(msg))
+		require.Nil(t, err)
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, http.StatusOK, rsp.status)
+		var response ContainerInfo
+		require.Nil(t, json.Unmarshal(rsp.body.Bytes(), &response))
+		return response
+	}
+
+	// sync update point if hashes match
+	info := syncRequest(10, "00000000000000000000000000000000", pretendLocalID, common.CanonicalTimestamp(100), common.CanonicalTimestamp(100), "", "{}")
+	require.Equal(t, int64(10), info.Point)
+
+	// sync update metadata
+	info = syncRequest(10, "00000000000000000000000000000000", pretendLocalID, common.CanonicalTimestamp(100), common.CanonicalTimestamp(100), "", "{\"X-Container-Meta-Key\": [\"value\", \"0000000100.00000\"]}")
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, "value", rsp.header.Get("X-Container-Meta-Key"))
+
+	// sync update delete timestamp
+	info = syncRequest(10, "00000000000000000000000000000000", pretendLocalID, common.CanonicalTimestamp(100), common.CanonicalTimestamp(100), common.CanonicalTimestamp(101), "{}")
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusNotFound, rsp.status)
+}
+
+func TestServerReplicateMergeItems(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	// create a container
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.CanonicalTimestamp(100))
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusCreated, rsp.status)
+
+	h := md5.New()
+	fmt.Fprintf(h, "%s/%s/%s%s", "changeme", "a", "c", "changeme")
+	containerHash := fmt.Sprintf("%032x", h.Sum(nil))
+	pretendLocalID := common.UUID()
+
+	mergeRequest := func(records []ObjectRecord) {
+		replRequest := []interface{}{"merge_items", records, pretendLocalID}
+		msg, err := json.Marshal(replRequest)
+		require.Nil(t, err)
+		rsp = makeCaptureResponse()
+		req, err = http.NewRequest("REPLICATE", "/device/1/"+containerHash, bytes.NewBuffer(msg))
+		require.Nil(t, err)
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, http.StatusAccepted, rsp.status)
+	}
+
+	// merge a new object
+	mergeRequest([]ObjectRecord{
+		ObjectRecord{
+			Rowid:       0,
+			Name:        "an object",
+			CreatedAt:   common.CanonicalTimestamp(100),
+			Size:        100,
+			ContentType: "text/plain",
+			ETag:        "ffffffffffffffffffffffffffffffff",
+		},
+	})
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, "1", rsp.header.Get("X-Container-Object-Count"))
+	require.Equal(t, "100", rsp.header.Get("X-Container-Bytes-Used"))
+
+	// merge a delete for that object
+	mergeRequest([]ObjectRecord{
+		ObjectRecord{
+			Rowid:       0,
+			Name:        "an object",
+			CreatedAt:   common.CanonicalTimestamp(101),
+			Size:        0,
+			ContentType: "",
+			ETag:        "ffffffffffffffffffffffffffffffff",
+			Deleted:     1,
+		},
+	})
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, "0", rsp.header.Get("X-Container-Object-Count"))
+	require.Equal(t, "0", rsp.header.Get("X-Container-Bytes-Used"))
+}
+
+func TestServerReplicateMergeItemsNotFound(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	records := []ObjectRecord{}
+
+	replRequest := []interface{}{"merge_items", records, common.UUID()}
+	msg, err := json.Marshal(replRequest)
+	require.Nil(t, err)
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("REPLICATE", "/device/1/ffffffffffffffffffffffffffffffff", bytes.NewBuffer(msg))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusNotFound, rsp.status)
+}
+
+func TestServerReplicateMergeSyncsNotFound(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	records := []*SyncRecord{}
+
+	replRequest := []interface{}{"merge_syncs", records}
+	msg, err := json.Marshal(replRequest)
+	require.Nil(t, err)
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("REPLICATE", "/device/1/ffffffffffffffffffffffffffffffff", bytes.NewBuffer(msg))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusNotFound, rsp.status)
+}
+
+func TestServerReplicateCompleteRsyncNotFound(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	replRequest := []interface{}{"complete_rsync", "tmpfilename"}
+	msg, err := json.Marshal(replRequest)
+	require.Nil(t, err)
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("REPLICATE", "/device/1/ffffffffffffffffffffffffffffffff", bytes.NewBuffer(msg))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusNotFound, rsp.status)
+}
+
+func TestServerReplicateSyncNotFound(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	replRequest := []interface{}{"sync", 1, "", "", "", "", "", ""}
+	msg, err := json.Marshal(replRequest)
+	require.Nil(t, err)
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("REPLICATE", "/device/1/ffffffffffffffffffffffffffffffff", bytes.NewBuffer(msg))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusNotFound, rsp.status)
+}
+
+func TestServerReplicateMergeSyncs(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	// create a container
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.CanonicalTimestamp(100))
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	h := md5.New()
+	fmt.Fprintf(h, "%s/%s/%s%s", "changeme", "a", "c", "changeme")
+	containerHash := fmt.Sprintf("%032x", h.Sum(nil))
+	pretendLocalID := common.UUID()
+
+	syncRequest := func(maxRow int64, hash, pretendLocalID, createdAt, putTimestamp, deleteTimestamp, metadata string) ContainerInfo {
+		replRequest := []interface{}{"sync", maxRow, hash, pretendLocalID, createdAt, putTimestamp, deleteTimestamp, metadata}
+		msg, err := json.Marshal(replRequest)
+		require.Nil(t, err)
+		rsp = makeCaptureResponse()
+		req, err = http.NewRequest("REPLICATE", "/device/1/"+containerHash, bytes.NewBuffer(msg))
+		require.Nil(t, err)
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, http.StatusOK, rsp.status)
+		var response ContainerInfo
+		require.Nil(t, json.Unmarshal(rsp.body.Bytes(), &response))
+		return response
+	}
+
+	// set our sync point via matching hashes
+	info := syncRequest(10, "00000000000000000000000000000000", pretendLocalID, common.CanonicalTimestamp(100), common.CanonicalTimestamp(100), "", "{}")
+	require.Equal(t, int64(10), info.Point)
+
+	// send merge_syncs REPLICATE request with a new sync point for us
+	replRequest := []interface{}{"merge_syncs", []SyncRecord{SyncRecord{SyncPoint: 15, RemoteID: pretendLocalID}}}
+	msg, err := json.Marshal(replRequest)
+	require.Nil(t, err)
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("REPLICATE", "/device/1/"+containerHash, bytes.NewBuffer(msg))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusAccepted, rsp.status)
+
+	// use a sync request to make sure our sync point was updated
+	info = syncRequest(0, "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0", pretendLocalID, common.CanonicalTimestamp(100), common.CanonicalTimestamp(100), "", "{}")
+	require.Equal(t, int64(15), info.Point)
+}
+
+func TestServerReplicateRsyncThenMerge(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	// make a container with some objects
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.CanonicalTimestamp(100))
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	for _, name := range []string{"a", "b", "c"} {
+		req, err := http.NewRequest("PUT", "/device/1/a/c/"+name, nil)
+		require.Nil(t, err)
+		req.Header.Set("X-Timestamp", common.GetTimestamp())
+		req.Header.Set("X-Content-Type", "application/octet-stream")
+		req.Header.Set("X-Size", "2")
+		req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, 201, rsp.status)
+	}
+
+	h := md5.New()
+	fmt.Fprintf(h, "%s/%s/%s%s", "changeme", "a", "c", "changeme")
+	containerHash := fmt.Sprintf("%032x", h.Sum(nil))
+
+	// create a local database with 1 object
+	db, _, cleanup, err := createTestDatabase(common.GetTimestamp())
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"d"}))
+
+	tmpFilename := common.UUID()
+
+	// upload the local database to the server
+	fp, release, err := db.OpenDatabaseFile()
+	require.Nil(t, err)
+	defer release()
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("PUT", "/device/tmp/"+tmpFilename, fp)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	// send rsync_then_merge replicate request
+	replRequest := []interface{}{"rsync_then_merge", tmpFilename}
+	msg, err := json.Marshal(replRequest)
+	require.Nil(t, err)
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("REPLICATE", "/device/1/"+containerHash, bytes.NewBuffer(msg))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusNoContent, rsp.status)
+
+	// HEAD the container and make sure it has 3 shiny new objects and one old gross one
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, "4", rsp.header.Get("X-Container-Object-Count"))
+}
+
+func TestServerReplicateCompleteRsync(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	h := md5.New()
+	fmt.Fprintf(h, "%s/%s/%s%s", "changeme", "a", "c", "changeme")
+	containerHash := fmt.Sprintf("%032x", h.Sum(nil))
+
+	// create a local database
+	db, _, cleanup, err := createTestDatabase(common.GetTimestamp())
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c"}))
+	require.Nil(t, err)
+
+	tmpFilename := common.UUID()
+
+	// upload the local database to the server
+	fp, cleanup, err := db.OpenDatabaseFile()
+	require.Nil(t, err)
+	defer cleanup()
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/tmp/"+tmpFilename, fp)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	// send rsync_then_merge replicate request
+	replRequest := []interface{}{"complete_rsync", tmpFilename}
+	msg, err := json.Marshal(replRequest)
+	require.Nil(t, err)
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("REPLICATE", "/device/1/"+containerHash, bytes.NewBuffer(msg))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusNoContent, rsp.status)
+
+	// HEAD the container and make sure it has 3 shiny new objects
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, "3", rsp.header.Get("X-Container-Object-Count"))
+}
+
+func TestServerReplicateBadOp(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	h := md5.New()
+	fmt.Fprintf(h, "%s/%s/%s%s", "changeme", "a", "c", "changeme")
+	containerHash := fmt.Sprintf("%032x", h.Sum(nil))
+
+	replRequest := []interface{}{"made_up_op", 1, 2, 3}
+	msg, err := json.Marshal(replRequest)
+	require.Nil(t, err)
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("REPLICATE", "/device/1/"+containerHash, bytes.NewBuffer(msg))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, http.StatusBadRequest, rsp.status)
+}
+
+func TestIsOkayFilename(t *testing.T) {
+	require.True(t, isOkayFilename("d850f04cdb48312a9be171e214c0b4ee"))
+	require.True(t, isOkayFilename("2308f201-9642-48ad-bb61-cc89cc84f258"))
+	require.False(t, isOkayFilename(""))
+	require.False(t, isOkayFilename("abcdefg!"))
+	require.False(t, isOkayFilename("../../../somefile"))
+	require.False(t, isOkayFilename(strings.Repeat("F", 101)))
+}
+
+func TestServerReplicateBadFilename(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+	tmpFilename := "one!bad!filename"
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/tmp/"+tmpFilename, nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+}
+
+func TestServerReplicateBadPayload(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("REPLICATE", "/device/1/d850f04cdb48312a9be171e214c0b4ee", bytes.NewBuffer([]byte("I AM A BAD JSON")))
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+}
+
+func TestServerReplicateBadJsonOp(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+	for _, op := range []string{"rsync_then_merge", "complete_rsync", "merge_items", "merge_syncs", "sync"} {
+		msg, err := json.Marshal([]string{op})
+		require.Nil(t, err)
+		rsp := makeCaptureResponse()
+		req, err := http.NewRequest("REPLICATE", "/device/1/d850f04cdb48312a9be171e214c0b4ee", bytes.NewBuffer(msg))
+		require.Nil(t, err)
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, 400, rsp.status)
+	}
+}

--- a/containerserver/lib_test.go
+++ b/containerserver/lib_test.go
@@ -1,0 +1,279 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/ring"
+)
+
+// a place for utility functions and interface satisifiers that are used across tests
+
+func mergeItemsByName(c Container, names []string) error {
+	items := []*ObjectRecord{}
+	for _, name := range names {
+		items = append(items, &ObjectRecord{Name: name, CreatedAt: "10000000.00001"})
+	}
+	return c.(ReplicableContainer).MergeItems(items, "")
+}
+
+func createTestDatabase(timestamp string) (*sqliteContainer, string, func(), error) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return nil, "", nil, err
+	}
+	dbFile := filepath.Join(dir, "device", "containers", "1", "000", "db", "db.db")
+	if err := os.MkdirAll(filepath.Dir(dbFile), 0777); err != nil {
+		return nil, "", nil, err
+	}
+	err = sqliteCreateContainer(dbFile, "a", "c", timestamp, nil, 0)
+	if err != nil {
+		os.RemoveAll(dir)
+		return nil, "", nil, err
+	}
+	db, err := sqliteOpenContainer(dbFile)
+	cleanup := func() {
+		db.Close()
+		os.RemoveAll(dir)
+	}
+	return db.(*sqliteContainer), dbFile, cleanup, nil
+}
+
+type captureResponse struct {
+	status int
+	header http.Header
+	body   *bytes.Buffer
+}
+
+func (w *captureResponse) WriteHeader(status int) {
+	w.status = status
+}
+
+func (w *captureResponse) Header() http.Header {
+	return w.header
+}
+
+func (w *captureResponse) Write(b []byte) (int, error) {
+	return w.body.Write(b)
+}
+
+func makeCaptureResponse() *captureResponse {
+	return &captureResponse{
+		status: 0,
+		header: make(http.Header),
+		body:   new(bytes.Buffer),
+	}
+}
+
+func makeTestServer() (http.Handler, func(), error) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := os.Mkdir(filepath.Join(dir, "device"), 0777); err != nil {
+		return nil, nil, err
+	}
+	server := &ContainerServer{
+		driveRoot:        dir,
+		hashPathPrefix:   "changeme",
+		hashPathSuffix:   "changeme",
+		logLevel:         "INFO",
+		logger:           fakeLowLevelLogger{},
+		checkMounts:      false,
+		updateClient:     http.DefaultClient,
+		containerEngine:  newLRUEngine(dir, "changeme", "changeme", 32),
+		diskInUse:        common.NewKeyedLimit(2, 2),
+		autoCreatePrefix: ".",
+	}
+	cleanup := func() {
+		os.RemoveAll(dir)
+	}
+	return server.GetHandler(*new(conf.Config)), cleanup, nil
+}
+
+func makeTestServer2() (*ContainerServer, http.Handler, func(), error) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if err := os.Mkdir(filepath.Join(dir, "device"), 0777); err != nil {
+		return nil, nil, nil, err
+	}
+	server := &ContainerServer{
+		driveRoot:       dir,
+		hashPathPrefix:  "changeme",
+		hashPathSuffix:  "changeme",
+		logLevel:        "INFO",
+		logger:          fakeLowLevelLogger{},
+		checkMounts:     false,
+		updateClient:    http.DefaultClient,
+		containerEngine: newLRUEngine(dir, "changeme", "changeme", 32),
+		diskInUse:       common.NewKeyedLimit(2, 2),
+	}
+	cleanup := func() {
+		os.RemoveAll(dir)
+	}
+	return server, server.GetHandler(*new(conf.Config)), cleanup, nil
+}
+
+type fakeLowLevelLogger struct{}
+
+func (fakeLowLevelLogger) Err(s string) error {
+	return nil
+}
+
+func (fakeLowLevelLogger) Info(s string) error {
+	return nil
+}
+
+func (fakeLowLevelLogger) Debug(s string) error {
+	return nil
+}
+
+type fakeRing struct{}
+
+func (r *fakeRing) GetNodes(partition uint64) (response []*ring.Device) {
+	return nil
+}
+func (r *fakeRing) GetNodesInOrder(partition uint64) (response []*ring.Device) {
+	return nil
+}
+func (r *fakeRing) GetJobNodes(partition uint64, localDevice int) (response []*ring.Device, handoff bool) {
+	return []*ring.Device{
+		&ring.Device{Device: "sda", ReplicationIp: "127.0.0.1", ReplicationPort: 20000},
+		&ring.Device{Device: "sdb", ReplicationIp: "127.0.0.2", ReplicationPort: 2000},
+	}, false
+}
+func (r *fakeRing) GetPartition(account string, container string, object string) uint64 {
+	return 1
+}
+func (r *fakeRing) LocalDevices(localPort int) (devs []*ring.Device, err error) {
+	return nil, nil
+}
+func (r *fakeRing) AllDevices() (devs []ring.Device) {
+	return nil
+}
+func (r *fakeRing) GetMoreNodes(partition uint64) ring.MoreNodes {
+	return nil
+}
+func (r *fakeRing) PartitionCount() uint64 {
+	return 1
+}
+func (r *fakeRing) ReplicaCount() uint64 {
+	return 3
+}
+
+type fakeLogger struct{}
+
+func (s fakeLogger) LogError(format string, args ...interface{}) {}
+func (s fakeLogger) LogInfo(format string, args ...interface{})  {}
+func (s fakeLogger) LogDebug(format string, args ...interface{}) {}
+func (s fakeLogger) LogPanics(format string)                     {}
+
+type fakeDatabase struct{}
+
+func (f fakeDatabase) GetInfo() (*ContainerInfo, error) {
+	return nil, errors.New("")
+}
+func (f fakeDatabase) IsDeleted() (bool, error) {
+	return false, errors.New("")
+}
+func (f fakeDatabase) Delete(timestamp string) error {
+	return errors.New("")
+}
+func (f fakeDatabase) ListObjects(limit int, marker string, endMarker string, prefix string, delimiter string, path *string, reverse bool, storagePolicyIndex int) ([]interface{}, error) {
+	return nil, errors.New("")
+}
+func (f fakeDatabase) GetMetadata() (map[string]string, error) {
+	return nil, errors.New("")
+}
+func (f fakeDatabase) UpdateMetadata(updates map[string][]string) error {
+	return errors.New("")
+}
+func (f fakeDatabase) MergeItems(records []*ObjectRecord, remoteID string) error {
+	return errors.New("")
+}
+func (f fakeDatabase) ItemsSince(start int64, count int) ([]*ObjectRecord, error) {
+	return nil, errors.New("")
+}
+func (f fakeDatabase) MergeSyncTable(records []*SyncRecord) error {
+	return errors.New("")
+}
+func (f fakeDatabase) SyncTable() ([]*SyncRecord, error) {
+	return nil, errors.New("")
+}
+func (f fakeDatabase) SyncRemoteData(maxRow int64, hash, id, createdAt, putTimestamp, deleteTimestamp, metadata string) (*ContainerInfo, error) {
+	return nil, errors.New("")
+}
+func (f fakeDatabase) RingHash() string {
+	return ""
+}
+func (f fakeDatabase) ID() string {
+	return ""
+}
+func (f fakeDatabase) NewID() error {
+	return errors.New("")
+}
+func (f fakeDatabase) OpenDatabaseFile() (*os.File, func(), error) {
+	return nil, nil, errors.New("")
+}
+func (f fakeDatabase) Close() error {
+	return errors.New("")
+}
+func (f fakeDatabase) CleanupTombstones(reclaimAge int64) error {
+	return errors.New("")
+}
+func (f fakeDatabase) CheckSyncLink() error {
+	return errors.New("")
+}
+func (f fakeDatabase) PutObject(name string, timestamp string, size int64, contentType string, etag string, storagePolicyIndex int) error {
+	return errors.New("")
+}
+func (f fakeDatabase) DeleteObject(name string, timestamp string, storagePolicyIndex int) error {
+	return errors.New("")
+}
+
+type fakeContainerEngine struct{}
+
+func (fakeContainerEngine) Get(vars map[string]string) (c Container, err error) {
+	return nil, errors.New("")
+}
+func (fakeContainerEngine) GetByHash(device, hash, partition string) (c ReplicableContainer, err error) {
+	return nil, errors.New("")
+}
+func (fakeContainerEngine) Create(vars map[string]string, putTimestamp string, metadata map[string][]string, policyIndex, defaultPolicyIndex int) (bool, Container, error) {
+	return false, nil, errors.New("")
+}
+func (fakeContainerEngine) PutObject(vars map[string]string, timestamp string, size int64, contentType string, etag string, storagePolicyIndex int) error {
+	return errors.New("")
+}
+func (fakeContainerEngine) DeleteObject(vars map[string]string, timestamp string, storagePolicyIndex int) error {
+	return errors.New("")
+}
+func (fakeContainerEngine) Return(c Container) {
+}
+func (fakeContainerEngine) Invalidate(c Container) {
+}
+func (fakeContainerEngine) Close() {
+}

--- a/containerserver/replicator.go
+++ b/containerserver/replicator.go
@@ -1,0 +1,577 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/ring"
+	"github.com/troubling/hummingbird/common/srv"
+)
+
+var (
+	errDeviceNotMounted = errors.New("Remove drive was unmounted")
+	deviceLockupTimeout = time.Hour
+	// GetRing is a local pointer to the hummingbird function, for overriding in tests.
+	GetRing = ring.GetRing
+)
+
+// Replicator is the container replicator daemon object
+type Replicator struct {
+	checkMounts    bool
+	deviceRoot     string
+	reconCachePath string
+	logger         srv.LowLevelLogger
+	serverPort     int
+	Ring           ring.Ring
+	perUsync       int64
+	maxUsyncs      int
+	concurrencySem chan struct{}
+	sendStat       chan statUpdate
+	checkin        chan string
+	startRun       chan string
+	client         *http.Client
+	runningDevices map[string]*replicationDevice
+	reclaimAge     int64
+}
+
+type statUpdate struct {
+	device string
+	stat   string
+	value  int64
+}
+
+type replicationDevice struct {
+	i interface {
+		sendReplicationMessage(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error)
+		sync(dev *ring.Device, part uint64, ringHash string, info *ContainerInfo) (*ContainerInfo, error)
+		rsync(dev *ring.Device, c ReplicableContainer, part uint64, op string) error
+		usync(dev *ring.Device, c ReplicableContainer, part uint64, localID string, point int64) error
+		chooseReplicationStrategy(localInfo, remoteInfo *ContainerInfo, usyncThreshold int64) string
+		replicateDatabaseToDevice(dev *ring.Device, c ReplicableContainer, part uint64) error
+		replicateDatabase(dbFile string) error
+		findContainerDbs(devicePath string, results chan string)
+		incrementStat(stat string)
+	}
+	r             *Replicator
+	cancel        chan struct{}
+	dev           *ring.Device
+	stats         map[string]int64
+	lastCheckin   time.Time
+	runStarted    time.Time
+	deviceStarted time.Time
+}
+
+func (rd *replicationDevice) sendReplicationMessage(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error) {
+	body, err := json.Marshal(args)
+	if err != nil {
+		return 0, nil, err
+	}
+	req, err := http.NewRequest("REPLICATE", fmt.Sprintf("http://%s:%d/%s/%d/%s",
+		dev.ReplicationIp, dev.ReplicationPort, dev.Device, part, ringHash), bytes.NewBuffer(body))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Cancel = rd.cancel
+	resp, err := rd.r.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, err
+	}
+	return resp.StatusCode, respBody, nil
+}
+
+func (rd *replicationDevice) sync(dev *ring.Device, part uint64, ringHash string, info *ContainerInfo) (*ContainerInfo, error) {
+	var remoteInfo ContainerInfo
+	status, body, err := rd.i.sendReplicationMessage(dev, part, ringHash, "sync", info.MaxRow, info.Hash,
+		info.ID, info.CreatedAt, info.PutTimestamp, info.DeleteTimestamp, info.RawMetadata)
+	if err != nil {
+		return nil, fmt.Errorf("sending sync request to %s/%s: %v", dev.ReplicationIp, dev.Device, err)
+	} else if status == http.StatusNotFound {
+		return nil, nil
+	} else if status == http.StatusInsufficientStorage {
+		return nil, errDeviceNotMounted
+	} else if status/100 != 2 {
+		return nil, fmt.Errorf("bad status code %d", status)
+	}
+	if err := json.Unmarshal(body, &remoteInfo); err != nil {
+		return nil, fmt.Errorf("unmarshalling sync response: %v", err)
+	}
+	return &remoteInfo, nil
+}
+
+func (rd *replicationDevice) rsync(dev *ring.Device, c ReplicableContainer, part uint64, op string) error {
+	tmpFilename := common.UUID()
+	fp, release, err := c.OpenDatabaseFile()
+	if err != nil {
+		return fmt.Errorf("Error opening databae: %v", err)
+	}
+	defer release()
+	req, err := http.NewRequest("PUT", fmt.Sprintf("http://%s:%d/%s/tmp/%s", dev.ReplicationIp, dev.ReplicationPort, dev.Device, tmpFilename), fp)
+	if err != nil {
+		return fmt.Errorf("creating request: %v", err)
+	}
+	req.Cancel = rd.cancel
+	resp, err := rd.r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("putting database to %s/%s: %v", dev.ReplicationIp, dev.Device, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("bad status code %d rsyncing file with %s/%s", resp.StatusCode, dev.ReplicationIp, dev.Device)
+	}
+	status, _, err := rd.i.sendReplicationMessage(dev, part, c.RingHash(), op, tmpFilename)
+	if err != nil || status/100 != 2 {
+		return fmt.Errorf("sending %s message to %s/%s: %v", op, dev.ReplicationIp, dev.Device, err)
+	}
+	return nil
+}
+
+func (rd *replicationDevice) usync(dev *ring.Device, c ReplicableContainer, part uint64, localID string, point int64) error {
+	objects, err := c.ItemsSince(point, int(rd.r.perUsync))
+	if err != nil {
+		return fmt.Errorf("getting object records from %s: %v", c.RingHash(), err)
+	}
+	usyncs := 0
+	syncTable, err := c.SyncTable()
+	if err != nil {
+		return fmt.Errorf("Error getting sync table: %v", err)
+	}
+	for len(objects) != 0 && usyncs < rd.r.maxUsyncs {
+		status, _, err := rd.i.sendReplicationMessage(dev, part, c.RingHash(), "merge_items", objects, localID)
+		if err != nil || status/100 != 2 {
+			return fmt.Errorf("Bad response to merge_items with %s/%s: %v, %v", dev.ReplicationIp, dev.Device, status, err)
+		}
+		point = objects[len(objects)-1].Rowid
+		usyncs++
+		if objects, err = c.ItemsSince(point, int(rd.r.perUsync)); err != nil {
+			return fmt.Errorf("getting object records from database: %s, %v", c.RingHash(), err)
+		}
+	}
+	if usyncs >= rd.r.maxUsyncs {
+		rd.i.incrementStat("diff_capped")
+		return fmt.Errorf("capping usync at %d requests", usyncs)
+	}
+	status, _, err := rd.i.sendReplicationMessage(dev, part, c.RingHash(), "merge_syncs", syncTable)
+	if err != nil {
+		return err
+	}
+	if status/100 != 2 {
+		return fmt.Errorf("Invalid status code from merge_syncs: %d", status)
+	}
+	return nil
+}
+
+func (rd *replicationDevice) chooseReplicationStrategy(localInfo, remoteInfo *ContainerInfo, usyncThreshold int64) string {
+	switch {
+	case remoteInfo == nil:
+		return "complete_rsync"
+	case localInfo.MaxRow == -1:
+		return "empty"
+	case localInfo.MaxRow == remoteInfo.Point:
+		return "no_change"
+	case localInfo.Hash == remoteInfo.Hash:
+		return "hashmatch"
+	case remoteInfo.MaxRow < localInfo.MaxRow*2 && localInfo.MaxRow-remoteInfo.MaxRow > usyncThreshold:
+		return "rsync_then_merge"
+	default:
+		return "diff"
+	}
+}
+
+func (rd *replicationDevice) replicateDatabaseToDevice(dev *ring.Device, c ReplicableContainer, part uint64) error {
+	rd.i.incrementStat("attempted")
+	info, err := c.GetInfo()
+	if err != nil {
+		return fmt.Errorf("getting local info from %s: %v", c.RingHash(), err)
+	}
+	remoteInfo, err := rd.i.sync(dev, part, c.RingHash(), info)
+	if err != nil {
+		return err
+	}
+	strategy := rd.i.chooseReplicationStrategy(info, remoteInfo, rd.r.perUsync*3)
+	rd.i.incrementStat(strategy)
+	switch strategy {
+	case "empty", "hashmatch", "no_change":
+		rd.r.LogDebug("Not replicating anything (%s): %s", strategy, c.RingHash())
+	case "complete_rsync", "rsync_then_merge":
+		rd.r.LogDebug("Replicating %s to %s/%s via %s", c.RingHash(), dev.ReplicationIp, dev.Device, strategy)
+		return rd.i.rsync(dev, c, part, strategy)
+	case "diff":
+		rd.r.LogDebug("Replicating %s to %s/%s via %s", c.RingHash(), dev.ReplicationIp, dev.Device, strategy)
+		return rd.i.usync(dev, c, part, info.ID, remoteInfo.Point)
+	}
+	return nil
+}
+
+func (rd *replicationDevice) replicateDatabase(dbFile string) error {
+	rd.r.LogDebug("Replicating database: %s", filepath.Base(dbFile))
+	parts := filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(dbFile))))
+	part, err := strconv.ParseUint(parts, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Bad partition: %s", parts)
+	}
+	devices, handoff := rd.r.Ring.GetJobNodes(part, rd.dev.Id)
+	moreNodes := rd.r.Ring.GetMoreNodes(part)
+	c, err := sqliteOpenContainer(dbFile)
+	if err != nil {
+		return err
+	}
+	if err := c.CleanupTombstones(rd.r.reclaimAge); err != nil {
+		return err
+	}
+	if err := c.CheckSyncLink(); err != nil {
+		return err
+	}
+	successes := 0
+	for i := 0; i < len(devices); i++ {
+		if err := rd.i.replicateDatabaseToDevice(devices[i], c, part); err == nil {
+			rd.i.incrementStat("success")
+			rd.r.LogDebug("Succeeded replicating database %s to %s/%s", dbFile, devices[i].ReplicationIp, devices[i].Device)
+			successes++
+		} else {
+			rd.i.incrementStat("failure")
+			rd.r.LogError("Error replicating database %s to %s/%s: %v", dbFile, devices[i].ReplicationIp, devices[i].Device, err)
+			if err == errDeviceNotMounted && !handoff {
+				next := moreNodes.Next()
+				if next == nil {
+					rd.r.LogError("Ran out of handoffs to talk to: %s", dbFile)
+				} else {
+					devices = append(devices, moreNodes.Next())
+				}
+			}
+		}
+	}
+	if handoff && successes == len(devices) {
+		rd.i.incrementStat("remove")
+		return os.RemoveAll(filepath.Dir(dbFile))
+	}
+	return nil
+}
+
+func (rd *replicationDevice) findContainerDbs(devicePath string, results chan string) {
+	defer close(results)
+	containersDir := filepath.Join(devicePath, "containers")
+	partitions, err := filepath.Glob(filepath.Join(containersDir, "[0-9]*"))
+	if err != nil {
+		rd.r.LogError("Error getting partitions in %s: %v", containersDir, err)
+		return
+	}
+	for _, part := range partitions {
+		suffixes, err := filepath.Glob(filepath.Join(part, "[a-f0-9][a-f0-9][a-f0-9]"))
+		if err != nil {
+			rd.r.LogError("Error getting suffixes in %s: %v", part, err)
+			return
+		}
+		for _, suff := range suffixes {
+			hashes, err := filepath.Glob(filepath.Join(suff, "????????????????????????????????"))
+			if err != nil {
+				rd.r.LogError("Error getting hashes in %s: %v", suff, err)
+				return
+			}
+			for _, hash := range hashes {
+				dbFile := filepath.Join(hash, filepath.Base(hash)+".db")
+				if common.Exists(dbFile) {
+					select {
+					case results <- dbFile:
+					case <-rd.cancel:
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+func (rd *replicationDevice) replicate() {
+	rd.r.LogInfo("Beginning replication for device %s", rd.dev.Device)
+	rd.r.startRun <- rd.dev.Device
+	devicePath := filepath.Join(rd.r.deviceRoot, rd.dev.Device)
+	stat, err := os.Stat(devicePath)
+	if err != nil || !stat.IsDir() {
+		rd.r.LogError("Device doesn't exist: %s", devicePath)
+		return
+	}
+	if mount, err := common.IsMount(devicePath); rd.r.checkMounts && (err != nil || !mount) {
+		rd.r.LogError("Device not mounted: %s", devicePath)
+		return
+	}
+	results := make(chan string, 100)
+	go rd.i.findContainerDbs(devicePath, results)
+	for dbFile := range results {
+		select {
+		case <-rd.cancel:
+			return
+		case rd.r.concurrencySem <- struct{}{}:
+			rd.r.checkin <- rd.dev.Device
+			if err := rd.i.replicateDatabase(dbFile); err != nil {
+				rd.r.LogError("Error replicating database file %s: %v", dbFile, err)
+			}
+			<-rd.r.concurrencySem
+		}
+	}
+}
+
+func (rd *replicationDevice) replicateLoop() {
+	for {
+		select {
+		case <-rd.cancel:
+			return
+		default:
+			rd.replicate()
+		}
+		time.Sleep(time.Second * 30)
+	}
+}
+
+func (rd *replicationDevice) incrementStat(stat string) {
+	rd.r.sendStat <- statUpdate{rd.dev.Device, stat, 1}
+}
+
+func newReplicationDevice(dev *ring.Device, r *Replicator) *replicationDevice {
+	rd := &replicationDevice{
+		r:             r,
+		cancel:        make(chan struct{}),
+		lastCheckin:   time.Now(),
+		deviceStarted: time.Now(),
+		dev:           dev,
+		stats: map[string]int64{
+			"attempted":             0,
+			"success":               0,
+			"failure":               0,
+			"no_change":             0,
+			"hashmatch":             0,
+			"rsync":                 0,
+			"diff":                  0,
+			"remove":                0,
+			"empty":                 0,
+			"remote_merge":          0,
+			"diff_capped":           0,
+			"lifetime_attempted":    0,
+			"lifetime_success":      0,
+			"lifetime_failure":      0,
+			"lifetime_no_change":    0,
+			"lifetime_hashmatch":    0,
+			"lifetime_rsync":        0,
+			"lifetime_diff":         0,
+			"lifetime_remove":       0,
+			"lifetime_empty":        0,
+			"lifetime_remote_merge": 0,
+			"lifetime_diff_capped":  0,
+			"lifetime_passes":       0,
+		},
+	}
+	rd.i = rd
+	return rd
+}
+
+func (r *Replicator) verifyDevices() {
+	// kill devices that haven't checked in for a while
+	for key, rd := range r.runningDevices {
+		if time.Since(rd.lastCheckin) > deviceLockupTimeout {
+			close(rd.cancel)
+			delete(r.runningDevices, key)
+		}
+	}
+	ringDevices, err := r.Ring.LocalDevices(r.serverPort)
+	if err != nil {
+		r.LogError("Error getting local devices from ring: %v", err)
+		return
+	}
+	// look for devices that aren't running but should be
+	for _, dev := range ringDevices {
+		if _, ok := r.runningDevices[dev.Device]; !ok {
+			r.runningDevices[dev.Device] = newReplicationDevice(dev, r)
+			go r.runningDevices[dev.Device].replicateLoop()
+		}
+	}
+	// look for devices that are running but shouldn't be
+	for key, rd := range r.runningDevices {
+		found := false
+		for _, dev := range ringDevices {
+			if dev.Device == key {
+				found = true
+			}
+		}
+		if !found {
+			close(rd.cancel)
+			delete(r.runningDevices, key)
+		}
+	}
+}
+
+func (r *Replicator) reportStats() {
+	var totalTime time.Duration
+	aggStats := map[string]int64{"attempted": 0, "success": 0, "failure": 0, "remove": 0}
+	for _, device := range r.runningDevices {
+		totalTime += time.Since(device.runStarted)
+		aggStats["attempted"] += device.stats["attempted"]
+		aggStats["success"] += device.stats["success"]
+		aggStats["failure"] += device.stats["failure"]
+		aggStats["remove"] += device.stats["remove"]
+	}
+	// there's no longer the concept of a single pass, so we report the average running time.
+	if len(r.runningDevices) > 0 {
+		rate := 0.0
+		runningTime := (totalTime / time.Duration(len(r.runningDevices))).Seconds()
+		if runningTime > 0 {
+			rate = float64(aggStats["attempted"]) / runningTime
+		}
+		r.LogInfo("Attempted to replicate %d dbs in %.5f seconds (%.5f/s)", aggStats["attempted"], runningTime, rate)
+		r.LogInfo("Removed %d dbs", aggStats["remove"])
+		r.LogInfo("%d successes, %d failures", aggStats["success"], aggStats["failure"])
+	} else {
+		r.LogInfo("No devices replicating.")
+	}
+}
+
+func (r *Replicator) runLoopCheck(reportTimer <-chan time.Time) {
+	select {
+	case device := <-r.checkin:
+		if rd, ok := r.runningDevices[device]; ok {
+			rd.lastCheckin = time.Now()
+		}
+	case device := <-r.startRun:
+		if rd, ok := r.runningDevices[device]; ok {
+			rd.runStarted = time.Now()
+			rd.lastCheckin = time.Now()
+			for k, v := range rd.stats {
+				rd.stats[k] = 0
+				rd.stats["lifetime_"+k] += v
+			}
+			rd.stats["lifetime_passes"]++
+		}
+	case update := <-r.sendStat:
+		if rd, ok := r.runningDevices[update.device]; ok {
+			rd.stats[update.stat] += update.value
+		}
+	case <-reportTimer:
+		r.reportStats()
+		r.verifyDevices()
+	}
+}
+
+// RunForever runs the replicator in a forever-loop.
+func (r *Replicator) RunForever() {
+	reportTimer := time.NewTimer(time.Minute * 15)
+	r.verifyDevices()
+	for {
+		r.runLoopCheck(reportTimer.C)
+	}
+}
+
+// Run runs a pass of the replicator once.
+func (r *Replicator) Run() {
+	done := make(chan struct{})
+	devices, err := r.Ring.LocalDevices(r.serverPort)
+	if err != nil {
+		r.LogError("Error getting local devices from ring: %v", err)
+		return
+	}
+	for _, dev := range devices {
+		r.runningDevices[dev.Device] = newReplicationDevice(dev, r)
+		go func(dev *ring.Device) {
+			r.runningDevices[dev.Device].replicate()
+			done <- struct{}{}
+		}(dev)
+	}
+	waitingFor := len(devices)
+	for waitingFor > 0 {
+		select {
+		case <-r.checkin:
+		case <-r.startRun:
+		case update := <-r.sendStat:
+			if ctx, ok := r.runningDevices[update.device]; ok {
+				ctx.stats[update.stat] += update.value
+			}
+		case <-done:
+			waitingFor--
+		}
+	}
+	r.reportStats()
+}
+
+// LogDebug formats and logs debug messages to the underlying logger.
+func (r *Replicator) LogDebug(format string, args ...interface{}) {
+	r.logger.Debug(fmt.Sprintf(format, args...))
+}
+
+// LogInfo formats and  logs info messages to the underlying logger.
+func (r *Replicator) LogInfo(format string, args ...interface{}) {
+	r.logger.Info(fmt.Sprintf(format, args...))
+}
+
+// LogError formats and logs info messages to the underlying logger.
+func (r *Replicator) LogError(format string, args ...interface{}) {
+	r.logger.Err(fmt.Sprintf(format, args...))
+}
+
+// GetReplicator uses the config settings and command-line flags to configure and return a replicator daemon struct.
+func GetReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, error) {
+	if !serverconf.HasSection("container-replicator") {
+		return nil, fmt.Errorf("Unable to find container-replicator config section")
+	}
+	hashPathPrefix, hashPathSuffix, err := GetHashPrefixAndSuffix()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get hash prefix and suffix")
+	}
+	ring, err := GetRing("container", hashPathPrefix, hashPathSuffix, 0)
+	if err != nil {
+		return nil, fmt.Errorf("Error loading container ring")
+	}
+	concurrency := int(serverconf.GetInt("container-replicator", "concurrency", 4))
+	var logger srv.LowLevelLogger
+	if logger, err = srv.SetupLogger(serverconf, flags, "app:container-server", "container-server"); err != nil {
+		return nil, fmt.Errorf("Error setting up logger: %v", err)
+	}
+	return &Replicator{
+		runningDevices: make(map[string]*replicationDevice),
+		perUsync:       3000,
+		maxUsyncs:      25,
+		sendStat:       make(chan statUpdate),
+		checkin:        make(chan string),
+		startRun:       make(chan string),
+		reconCachePath: serverconf.GetDefault("container-replicator", "recon_cache_path", "/var/cache/swift"),
+		checkMounts:    serverconf.GetBool("container-replicator", "mount_check", true),
+		deviceRoot:     serverconf.GetDefault("container-replicator", "devices", "/srv/node"),
+		serverPort:     int(serverconf.GetInt("container-replicator", "bind_port", 6000)),
+		reclaimAge:     serverconf.GetInt("container-replicator", "reclaim_age", 604800),
+		logger:         logger,
+		concurrencySem: make(chan struct{}, concurrency),
+		Ring:           ring,
+		client: &http.Client{
+			Timeout:   time.Minute * 15,
+			Transport: &http.Transport{Dial: (&net.Dialer{Timeout: time.Second}).Dial},
+		},
+	}, nil
+}

--- a/containerserver/replicator_test.go
+++ b/containerserver/replicator_test.go
@@ -1,0 +1,715 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/ring"
+)
+
+type patchableReplicationDevice struct {
+	rd                         *replicationDevice
+	_sendReplicationMessage    func(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error)
+	_sync                      func(dev *ring.Device, part uint64, ringHash string, info *ContainerInfo) (*ContainerInfo, error)
+	_rsync                     func(dev *ring.Device, c ReplicableContainer, part uint64, op string) error
+	_usync                     func(dev *ring.Device, c ReplicableContainer, part uint64, localID string, point int64) error
+	_chooseReplicationStrategy func(localInfo, remoteInfo *ContainerInfo, usyncThreshold int64) string
+	_replicateDatabaseToDevice func(dev *ring.Device, c ReplicableContainer, part uint64) error
+	_replicateDatabase         func(dbFile string) error
+	_findContainerDbs          func(devicePath string, results chan string)
+	_incrementStat             func(stat string)
+}
+
+func (d *patchableReplicationDevice) sendReplicationMessage(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error) {
+	if d._sendReplicationMessage != nil {
+		return d._sendReplicationMessage(dev, part, ringHash, args...)
+	}
+	return d.rd.sendReplicationMessage(dev, part, ringHash, args...)
+}
+func (d *patchableReplicationDevice) sync(dev *ring.Device, part uint64, ringHash string, info *ContainerInfo) (*ContainerInfo, error) {
+	if d._sync != nil {
+		return d._sync(dev, part, ringHash, info)
+	}
+	return d.rd.sync(dev, part, ringHash, info)
+}
+func (d *patchableReplicationDevice) rsync(dev *ring.Device, c ReplicableContainer, part uint64, op string) error {
+	if d._rsync != nil {
+		return d._rsync(dev, c, part, op)
+	}
+	return d.rd.rsync(dev, c, part, op)
+}
+func (d *patchableReplicationDevice) usync(dev *ring.Device, c ReplicableContainer, part uint64, localID string, point int64) error {
+	if d._usync != nil {
+		return d._usync(dev, c, part, localID, point)
+	}
+	return d.rd.usync(dev, c, part, localID, point)
+}
+func (d *patchableReplicationDevice) chooseReplicationStrategy(localInfo, remoteInfo *ContainerInfo, usyncThreshold int64) string {
+	if d._chooseReplicationStrategy != nil {
+		return d._chooseReplicationStrategy(localInfo, remoteInfo, usyncThreshold)
+	}
+	return d.rd.chooseReplicationStrategy(localInfo, remoteInfo, usyncThreshold)
+}
+func (d *patchableReplicationDevice) replicateDatabaseToDevice(dev *ring.Device, c ReplicableContainer, part uint64) error {
+	if d._replicateDatabaseToDevice != nil {
+		return d._replicateDatabaseToDevice(dev, c, part)
+	}
+	return d.rd.replicateDatabaseToDevice(dev, c, part)
+}
+func (d *patchableReplicationDevice) replicateDatabase(dbFile string) error {
+	if d._replicateDatabase != nil {
+		return d._replicateDatabase(dbFile)
+	}
+	return d.rd.replicateDatabase(dbFile)
+}
+func (d *patchableReplicationDevice) findContainerDbs(devicePath string, results chan string) {
+	if d._findContainerDbs != nil {
+		d._findContainerDbs(devicePath, results)
+		return
+	}
+	d.rd.findContainerDbs(devicePath, results)
+}
+func (d *patchableReplicationDevice) incrementStat(stat string) {
+	if d._incrementStat != nil {
+		d._incrementStat(stat)
+		return
+	}
+	d.rd.incrementStat(stat)
+}
+func (d *patchableReplicationDevice) replicate() {
+	d.rd.replicate()
+}
+
+func newTestReplicationDevice(dev *ring.Device, r *Replicator) *patchableReplicationDevice {
+	if r.sendStat == nil {
+		r.sendStat = make(chan statUpdate, 100)
+	}
+	if r.logger == nil {
+		r.logger = fakeLowLevelLogger{}
+	}
+	if r.Ring == nil {
+		r.Ring = &fakeRing{}
+	}
+	if r.concurrencySem == nil {
+		r.concurrencySem = make(chan struct{}, 1)
+	}
+	if r.startRun == nil {
+		r.startRun = make(chan string, 100)
+	}
+	if r.checkin == nil {
+		r.checkin = make(chan string, 100)
+	}
+	rd := newReplicationDevice(dev, r)
+	p := &patchableReplicationDevice{rd: rd}
+	rd.i = p
+	return p
+}
+
+func testServer(t *testing.T, h http.Handler) (*ring.Device, func()) {
+	ts := httptest.NewServer(h)
+	u, err := url.Parse(ts.URL)
+	require.Nil(t, err)
+	host, portstring, err := net.SplitHostPort(u.Host)
+	require.Nil(t, err)
+	port, err := strconv.Atoi(portstring)
+	require.Nil(t, err)
+	dev := &ring.Device{
+		ReplicationIp:   host,
+		ReplicationPort: port,
+		Device:          "sdb",
+	}
+	return dev, ts.Close
+}
+
+func TestReplicatorSync(t *testing.T) {
+	info := &ContainerInfo{
+		MaxRow:          -1,
+		Hash:            "00000000000000000000000000000000",
+		ID:              "12345",
+		CreatedAt:       "1470586890.28563",
+		PutTimestamp:    "1470586890.28563",
+		DeleteTimestamp: "",
+		RawMetadata:     "{}",
+	}
+	rinfo := &ContainerInfo{
+		MaxRow:          10,
+		Hash:            "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+		ID:              "67890",
+		CreatedAt:       "1410586890.28563",
+		PutTimestamp:    "1410586890.28563",
+		DeleteTimestamp: "",
+		RawMetadata:     "{}",
+	}
+	dev, cleanup := testServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, r.Method, "REPLICATE")
+		require.Equal(t, r.URL.Path, "/sdb/1/00000000000000000000000000000000")
+		body, err := ioutil.ReadAll(r.Body)
+		require.Nil(t, err)
+		var args []interface{}
+		require.Nil(t, json.Unmarshal(body, &args))
+		require.Equal(t, args[0], "sync")
+		require.Equal(t, int64(args[1].(float64)), info.MaxRow)
+		require.Equal(t, args[2], info.Hash)
+		require.Equal(t, args[3], info.ID)
+		require.Equal(t, args[4], info.CreatedAt)
+		require.Equal(t, args[5], info.PutTimestamp)
+		require.Equal(t, args[6], info.DeleteTimestamp)
+		require.Equal(t, args[7], info.RawMetadata)
+		resp, err := json.Marshal(rinfo)
+		require.Nil(t, err)
+		w.Write(resp)
+	}))
+	defer cleanup()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{client: http.DefaultClient})
+	newrinfo, err := rd.sync(dev, 1, "00000000000000000000000000000000", info)
+	require.Nil(t, err)
+	require.Equal(t, rinfo, newrinfo)
+}
+
+func TestReplicatorSyncNotFound(t *testing.T) {
+	dev, cleanup := testServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer cleanup()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{client: http.DefaultClient})
+	rinfo, err := rd.sync(dev, 1, "00000000000000000000000000000000", &ContainerInfo{})
+	require.Nil(t, rinfo)
+	require.Nil(t, err)
+}
+
+func TestReplicatorSyncUnmounted(t *testing.T) {
+	dev, cleanup := testServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInsufficientStorage)
+	}))
+	defer cleanup()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{client: http.DefaultClient})
+	_, err := rd.sync(dev, 1, "00000000000000000000000000000000", &ContainerInfo{})
+	require.Equal(t, err, errDeviceNotMounted)
+}
+
+func TestReplicatorRsync(t *testing.T) {
+	tmpFileName := ""
+	dev, cleanup1 := testServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PUT" {
+			written, err := io.Copy(ioutil.Discard, r.Body)
+			require.Nil(t, err)
+			require.True(t, written > 0)
+			tmpFileName = filepath.Base(r.URL.Path)
+		} else if r.Method == "REPLICATE" {
+			var args []interface{}
+			body, err := ioutil.ReadAll(r.Body)
+			require.Nil(t, err)
+			require.Nil(t, json.Unmarshal(body, &args))
+			require.Equal(t, args[0], "complete_rsync")
+			require.Equal(t, args[1], tmpFileName)
+		}
+	}))
+	defer cleanup1()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{client: http.DefaultClient})
+	c, _, cleanup2, err := createTestDatabase("1410586890.28563")
+	require.Nil(t, err)
+	require.Nil(t, mergeItemsByName(c, []string{"a", "b", "c"}))
+	defer cleanup2()
+	err = rd.rsync(dev, c, 1, "complete_rsync")
+	require.Nil(t, err)
+}
+
+func TestReplicatorUsync(t *testing.T) {
+	requestNumber := 0
+	dev, cleanup1 := testServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var args []interface{}
+		body, err := ioutil.ReadAll(r.Body)
+		require.Nil(t, err)
+		require.Nil(t, json.Unmarshal(body, &args))
+		if requestNumber < 3 {
+			require.Equal(t, args[0], "merge_items")
+		} else {
+			require.Equal(t, args[0], "merge_syncs")
+		}
+		requestNumber++
+	}))
+	defer cleanup1()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{client: http.DefaultClient, perUsync: 1, maxUsyncs: 5})
+	c, _, cleanup2, err := createTestDatabase("1410586890.28563")
+	require.Nil(t, err)
+	require.Nil(t, mergeItemsByName(c, []string{"a", "b", "c"}))
+	defer cleanup2()
+	err = rd.usync(dev, c, 1, "12345", -1)
+	require.Nil(t, err)
+}
+
+func TestReplicatorChooseReplicationStrategy(t *testing.T) {
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{client: http.DefaultClient})
+	require.Equal(t, "complete_rsync", rd.chooseReplicationStrategy(&ContainerInfo{}, nil, 100))
+	require.Equal(t, "empty", rd.chooseReplicationStrategy(&ContainerInfo{MaxRow: -1}, &ContainerInfo{}, 100))
+	require.Equal(t, "no_change", rd.chooseReplicationStrategy(&ContainerInfo{MaxRow: 123}, &ContainerInfo{Point: 123}, 100))
+	require.Equal(t, "hashmatch", rd.chooseReplicationStrategy(
+		&ContainerInfo{Hash: "somehash", MaxRow: 10},
+		&ContainerInfo{Hash: "somehash", Point: 9},
+		100))
+	require.Equal(t, "rsync_then_merge", rd.chooseReplicationStrategy(
+		&ContainerInfo{Hash: "somehash1", MaxRow: 1000},
+		&ContainerInfo{Hash: "somehash2", Point: 9},
+		100))
+	require.Equal(t, "diff", rd.chooseReplicationStrategy(
+		&ContainerInfo{Hash: "somehash1", MaxRow: 10},
+		&ContainerInfo{Hash: "somehash2", Point: 9},
+		100))
+}
+
+func TestReplicatorReplicateDatabaseToDevice(t *testing.T) {
+	c, _, cleanup, err := createTestDatabase("1410586890.28563")
+	require.Nil(t, err)
+	defer cleanup()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{})
+	currentMethod := "complete_rsync"
+	rsyncCalled := false
+	usyncCalled := false
+	rd._sync = func(dev *ring.Device, part uint64, ringHash string, info *ContainerInfo) (*ContainerInfo, error) {
+		return &ContainerInfo{}, nil
+	}
+	rd._chooseReplicationStrategy = func(localInfo, remoteInfo *ContainerInfo, usyncThreshold int64) string {
+		return currentMethod
+	}
+	rd._rsync = func(dev *ring.Device, c ReplicableContainer, part uint64, op string) error {
+		rsyncCalled = true
+		return nil
+	}
+	rd._usync = func(dev *ring.Device, c ReplicableContainer, part uint64, localID string, point int64) error {
+		usyncCalled = true
+		return nil
+	}
+	require.Nil(t, rd.replicateDatabaseToDevice(&ring.Device{}, c, 1))
+	require.True(t, rsyncCalled)
+	require.False(t, usyncCalled)
+	rsyncCalled = false
+	currentMethod = "diff"
+	require.Nil(t, rd.replicateDatabaseToDevice(&ring.Device{}, c, 1))
+	require.True(t, usyncCalled)
+	require.False(t, rsyncCalled)
+	usyncCalled = false
+	currentMethod = "no_change"
+	require.Nil(t, rd.replicateDatabaseToDevice(&ring.Device{}, c, 1))
+	require.False(t, usyncCalled)
+	require.False(t, rsyncCalled)
+}
+
+func TestFindContainers(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(tempDir)
+	files := []string{
+		"containers/1/123/f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0/f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0.db",
+		"containers/2/456/49f68a5c8493ec2c0bf489821c21fc3b/49f68a5c8493ec2c0bf489821c21fc3b.db",
+		"containers/3/789/d850f04cdb48312a9be171e214c0b4ee/d850f04cdb48312a9be171e214c0b4ee.db",
+	}
+	for _, f := range files {
+		os.MkdirAll(filepath.Join(tempDir, filepath.Dir(f)), 0777)
+		ioutil.WriteFile(filepath.Join(tempDir, f), []byte(""), 0666)
+	}
+	results := make(chan string, 3)
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{client: http.DefaultClient})
+	rd.findContainerDbs(tempDir, results)
+	for _, f := range files {
+		require.Equal(t, filepath.Join(tempDir, f), <-results)
+	}
+
+	results = make(chan string, 3)
+	close(rd.rd.cancel)
+	rd.findContainerDbs(tempDir, results)
+}
+
+func TestReplicateDatabase(t *testing.T) {
+	_, dbFile, cleanup, err := createTestDatabase("1410586890.28563")
+	require.Nil(t, err)
+	defer cleanup()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{})
+	called := 0
+	rd._replicateDatabaseToDevice = func(dev *ring.Device, c ReplicableContainer, part uint64) error {
+		require.Equal(t, part, uint64(1))
+		if called == 0 {
+			require.Equal(t, "sda", dev.Device)
+		} else if called == 1 {
+			require.Equal(t, "sdb", dev.Device)
+		}
+		called++
+		return nil
+	}
+	rd.replicateDatabase(dbFile)
+	require.Equal(t, 2, called)
+}
+
+type handoffJobRing struct {
+	fakeRing
+}
+
+func (r *handoffJobRing) GetJobNodes(partition uint64, localDevice int) (response []*ring.Device, handoff bool) {
+	return []*ring.Device{
+		&ring.Device{Device: "sda", ReplicationIp: "127.0.0.1", ReplicationPort: 20000},
+		&ring.Device{Device: "sdb", ReplicationIp: "127.0.0.2", ReplicationPort: 2000},
+	}, true
+}
+
+func TestReplicateDatabaseDeletesHandoff(t *testing.T) {
+	_, dbFile, cleanup, err := createTestDatabase("1410586890.28563")
+	require.Nil(t, err)
+	defer cleanup()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{Ring: &handoffJobRing{}})
+	called := 0
+	rd._replicateDatabaseToDevice = func(dev *ring.Device, c ReplicableContainer, part uint64) error {
+		require.Equal(t, part, uint64(1))
+		if called == 0 {
+			require.Equal(t, "sda", dev.Device)
+		} else if called == 1 {
+			require.Equal(t, "sdb", dev.Device)
+		}
+		called++
+		return nil
+	}
+	rd.replicateDatabase(dbFile)
+	require.Equal(t, 2, called)
+	require.False(t, common.Exists(dbFile))
+}
+
+func TestReplicateDatabaseDeletesHandoffOnSuccess(t *testing.T) {
+	_, dbFile, cleanup, err := createTestDatabase("1410586890.28563")
+	require.Nil(t, err)
+	defer cleanup()
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{Ring: &handoffJobRing{}})
+	called := 0
+	rd._replicateDatabaseToDevice = func(dev *ring.Device, c ReplicableContainer, part uint64) error {
+		require.Equal(t, part, uint64(1))
+		if called == 0 {
+			require.Equal(t, "sda", dev.Device)
+		} else if called == 1 {
+			require.Equal(t, "sdb", dev.Device)
+		}
+		called++
+		return errors.New("I HAVE FAILED YOU")
+	}
+	rd.replicateDatabase(dbFile)
+	require.Equal(t, 2, called)
+	require.True(t, common.Exists(dbFile))
+}
+
+func TestReplicate(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(tempDir)
+	require.Nil(t, os.MkdirAll(filepath.Join(tempDir, "sdb"), 0777))
+
+	rep := &Replicator{deviceRoot: tempDir}
+	rd := newTestReplicationDevice(&ring.Device{Device: "sdb"}, rep)
+	dbFiles := []string{
+		"/path/to/a/db.db",
+		"/path/to/another/db.db",
+		"/path/to/yetanother/db.db",
+	}
+	rd._findContainerDbs = func(devicePath string, results chan string) {
+		for _, dbFile := range dbFiles {
+			results <- dbFile
+		}
+		close(results)
+	}
+	call := 0
+	rd._replicateDatabase = func(dbFile string) error {
+		require.Equal(t, dbFiles[call], dbFile)
+		call++
+		return nil
+	}
+	rd.replicate()
+	require.Equal(t, "sdb", <-rep.startRun)
+	for i := 0; i < len(dbFiles); i++ {
+		require.Equal(t, "sdb", <-rep.checkin)
+	}
+	require.Equal(t, call, len(dbFiles))
+}
+
+type localDevicesRing struct {
+	fakeRing
+	localDevs []*ring.Device
+}
+
+func (r *localDevicesRing) LocalDevices(localPort int) (devs []*ring.Device, err error) {
+	return r.localDevs, nil
+}
+
+func TestVerifyDevicesRemoveStuck(t *testing.T) {
+	r := &Replicator{
+		Ring:   &localDevicesRing{localDevs: []*ring.Device{}},
+		logger: fakeLowLevelLogger{},
+		runningDevices: map[string]*replicationDevice{
+			"sda": &replicationDevice{lastCheckin: time.Now().Add(time.Hour * -2), cancel: make(chan struct{})},
+			"sdb": &replicationDevice{lastCheckin: time.Now().Add(time.Hour * -2), cancel: make(chan struct{})},
+		},
+	}
+	r.verifyDevices()
+	require.Nil(t, r.runningDevices["sda"])
+	require.Nil(t, r.runningDevices["sdb"])
+}
+
+func TestVerifyDevicesLaunchMissing(t *testing.T) {
+	r := &Replicator{
+		Ring: &localDevicesRing{
+			localDevs: []*ring.Device{
+				&ring.Device{Device: "sda"},
+				&ring.Device{Device: "sdb"},
+			},
+		},
+		logger:         fakeLowLevelLogger{},
+		runningDevices: map[string]*replicationDevice{},
+	}
+	r.verifyDevices()
+	require.NotNil(t, r.runningDevices["sda"])
+	require.NotNil(t, r.runningDevices["sdb"])
+}
+
+func TestVerifyDevicesRemoveMissing(t *testing.T) {
+	r := &Replicator{
+		Ring: &localDevicesRing{
+			localDevs: []*ring.Device{},
+		},
+		logger: fakeLowLevelLogger{},
+		runningDevices: map[string]*replicationDevice{
+			"sda": &replicationDevice{lastCheckin: time.Now(), cancel: make(chan struct{})},
+			"sdb": &replicationDevice{lastCheckin: time.Now(), cancel: make(chan struct{})},
+		},
+	}
+	r.verifyDevices()
+	require.Equal(t, 0, len(r.runningDevices))
+}
+
+func TestGetReplicator(t *testing.T) {
+	oldGetRing := GetRing
+	oldGetHashes := GetHashPrefixAndSuffix
+	defer func() {
+		GetHashPrefixAndSuffix = oldGetHashes
+		GetRing = oldGetRing
+	}()
+	GetHashPrefixAndSuffix = func() (pfx string, sfx string, err error) {
+		return "changeme", "changeme", nil
+	}
+	GetRing = func(ringType, prefix, suffix string, policy int) (ring.Ring, error) {
+		return &fakeRing{}, nil
+	}
+	config, err := conf.StringConfig("[container-replicator]\nmount_check=false\nbind_port=1000")
+	require.Nil(t, err)
+	r, err := GetReplicator(config, &flag.FlagSet{})
+	require.Nil(t, err)
+	replicator, ok := r.(*Replicator)
+	require.True(t, ok)
+	require.Equal(t, 1000, replicator.serverPort)
+	require.Equal(t, "/srv/node", replicator.deviceRoot)
+	require.NotNil(t, replicator.client)
+	require.NotNil(t, replicator.sendStat)
+	require.NotNil(t, replicator.checkin)
+	require.NotNil(t, replicator.concurrencySem)
+	require.False(t, replicator.checkMounts)
+
+	config, err = conf.StringConfig("")
+	require.Nil(t, err)
+	r, err = GetReplicator(config, &flag.FlagSet{})
+	require.NotNil(t, err)
+
+	GetHashPrefixAndSuffix = func() (pfx string, sfx string, err error) {
+		return "", "", errors.New("I AM A BAD CONFIGURATION")
+	}
+	config, err = conf.StringConfig("[container-replicator]\nmount_check=false\nbind_port=1000")
+	require.Nil(t, err)
+	r, err = GetReplicator(config, &flag.FlagSet{})
+	require.NotNil(t, err)
+}
+
+type savingLowLevelLogger struct {
+	fakeLowLevelLogger
+	logs []string
+}
+
+func (s *savingLowLevelLogger) Info(l string) error {
+	s.logs = append(s.logs, l)
+	return nil
+}
+
+func TestReportStats(t *testing.T) {
+	logger := &savingLowLevelLogger{logs: make([]string, 0)}
+	r := &Replicator{
+		logger: logger,
+		runningDevices: map[string]*replicationDevice{
+			"sda": &replicationDevice{
+				runStarted: time.Now().Add(-5 * time.Minute),
+				cancel:     make(chan struct{}),
+				stats: map[string]int64{
+					"attempted": 10, "success": 5, "failure": 5,
+					"no_change": 5, "hashmatch": 4,
+					"rsync": 1, "diff": 0, "remove": 7,
+					"empty": 0, "remote_merge": 0, "diff_capped": 0,
+				},
+			},
+			"sdb": &replicationDevice{
+				runStarted: time.Now().Add(-15 * time.Minute),
+				stats: map[string]int64{
+					"attempted": 10, "success": 9, "failure": 1,
+					"no_change": 8, "hashmatch": 0,
+					"rsync": 0, "diff": 1, "remove": 3,
+					"empty": 0, "remote_merge": 0, "diff_capped": 0,
+				},
+			},
+		},
+	}
+	r.reportStats()
+	require.True(t, strings.HasPrefix(logger.logs[0], "Attempted to replicate 20 dbs in 600."))
+	require.Equal(t, "Removed 10 dbs", logger.logs[1])
+	require.Equal(t, "14 successes, 6 failures", logger.logs[2])
+}
+
+func TestRunLoop(t *testing.T) {
+	logger := &savingLowLevelLogger{logs: make([]string, 0)}
+	r := &Replicator{
+		logger: logger,
+		Ring: &localDevicesRing{
+			localDevs: []*ring.Device{
+				&ring.Device{Device: "sda"},
+				&ring.Device{Device: "sdb"},
+			},
+		},
+		runningDevices: map[string]*replicationDevice{
+			"sda": &replicationDevice{
+				runStarted:  time.Now().Add(-5 * time.Minute),
+				lastCheckin: time.Now().Add(-5 * time.Minute),
+				stats: map[string]int64{
+					"attempted": 0, "success": 0, "failure": 0, "no_change": 0, "hashmatch": 0,
+					"rsync": 0, "diff": 0, "remove": 0, "empty": 0, "remote_merge": 0, "diff_capped": 0,
+				},
+			},
+			"sdb": &replicationDevice{
+				runStarted:  time.Now().Add(-15 * time.Minute),
+				lastCheckin: time.Now().Add(-15 * time.Minute),
+				stats: map[string]int64{
+					"attempted": 0, "success": 0, "failure": 0, "no_change": 0, "hashmatch": 0,
+					"rsync": 0, "diff": 0, "remove": 0, "empty": 0, "remote_merge": 0, "diff_capped": 0,
+				},
+			},
+		},
+		sendStat: make(chan statUpdate, 1),
+		startRun: make(chan string, 1),
+		checkin:  make(chan string, 1),
+	}
+	rpTimer := make(chan time.Time, 1)
+	rpTimer <- time.Now()
+	r.runLoopCheck(rpTimer)
+	require.True(t, strings.HasPrefix(logger.logs[0], "Attempted to replicate "))
+
+	r.sendStat <- statUpdate{"sda", "attempted", 1}
+	r.runLoopCheck(rpTimer)
+	require.Equal(t, int64(1), r.runningDevices["sda"].stats["attempted"])
+
+	r.startRun <- "sda"
+	r.runLoopCheck(rpTimer)
+	require.Equal(t, int64(0), r.runningDevices["sda"].stats["attempted"])
+	lastCheckin := r.runningDevices["sda"].lastCheckin
+
+	r.checkin <- "sda"
+	r.runLoopCheck(rpTimer)
+	require.NotEqual(t, lastCheckin, r.runningDevices["sda"].lastCheckin)
+}
+
+func TestReplicatorRun(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+	os.MkdirAll(filepath.Join(dir, "sda"), 0777)
+	os.MkdirAll(filepath.Join(dir, "sdb"), 0777)
+	r := &Replicator{
+		Ring: &localDevicesRing{localDevs: []*ring.Device{
+			&ring.Device{Device: "sda"},
+			&ring.Device{Device: "sdb"},
+		}},
+		logger:         fakeLowLevelLogger{},
+		deviceRoot:     dir,
+		sendStat:       make(chan statUpdate, 10),
+		startRun:       make(chan string, 10),
+		checkin:        make(chan string, 10),
+		runningDevices: map[string]*replicationDevice{},
+	}
+	r.Run()
+	require.Equal(t, 2, len(r.runningDevices))
+	_, ok := r.runningDevices["sda"]
+	require.True(t, ok)
+	_, ok = r.runningDevices["sdb"]
+	require.True(t, ok)
+}
+
+func TestReplicateSyncOnMessageError(t *testing.T) {
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{Ring: &handoffJobRing{}})
+	rd._sendReplicationMessage = func(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error) {
+		return 0, nil, errors.New("SOME ERROR")
+	}
+	rinfo, err := rd.sync(&ring.Device{}, 1, "SOMEHASH", &ContainerInfo{})
+	require.Nil(t, rinfo)
+	require.NotNil(t, err)
+
+	rd._sendReplicationMessage = func(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error) {
+		return 404, []byte{}, nil
+	}
+	rinfo, err = rd.sync(&ring.Device{}, 1, "SOMEHASH", &ContainerInfo{})
+	require.Nil(t, rinfo)
+	require.Nil(t, err)
+
+	rd._sendReplicationMessage = func(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error) {
+		return 200, []byte("BAD JSON"), nil
+	}
+	rinfo, err = rd.sync(&ring.Device{}, 1, "SOMEHASH", &ContainerInfo{})
+	require.Nil(t, rinfo)
+	require.NotNil(t, err)
+
+	rd._sendReplicationMessage = func(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error) {
+		return http.StatusInsufficientStorage, []byte{}, nil
+	}
+	rinfo, err = rd.sync(&ring.Device{}, 1, "SOMEHASH", &ContainerInfo{})
+	require.Nil(t, rinfo)
+	require.Equal(t, err, errDeviceNotMounted)
+
+	rd._sendReplicationMessage = func(dev *ring.Device, part uint64, ringHash string, args ...interface{}) (int, []byte, error) {
+		return 500, []byte{}, nil
+	}
+	rinfo, err = rd.sync(&ring.Device{}, 1, "SOMEHASH", &ContainerInfo{})
+	require.Nil(t, rinfo)
+	require.NotNil(t, err)
+}
+
+func TestSomeDatabaseFailures(t *testing.T) {
+	rd := newTestReplicationDevice(&ring.Device{}, &Replicator{Ring: &handoffJobRing{}})
+	require.NotNil(t, rd.rsync(&ring.Device{}, fakeDatabase{}, 1, "complete_rsync"))
+	require.NotNil(t, rd.usync(&ring.Device{}, fakeDatabase{}, 1, "123", 3))
+}

--- a/containerserver/schema.go
+++ b/containerserver/schema.go
@@ -1,0 +1,262 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const (
+	policyStatTableScript = `
+		CREATE TABLE policy_stat (
+			storage_policy_index INTEGER PRIMARY KEY,
+			object_count INTEGER DEFAULT 0,
+			bytes_used INTEGER DEFAULT 0
+		);`
+
+	policyStatTriggerScript = `
+		CREATE TRIGGER object_insert_policy_stat AFTER INSERT ON object
+		BEGIN
+			UPDATE policy_stat
+			SET object_count = object_count + (1 - new.deleted),
+				bytes_used = bytes_used + new.size
+			WHERE storage_policy_index = new.storage_policy_index;
+			INSERT INTO policy_stat (
+				storage_policy_index, object_count, bytes_used)
+			SELECT new.storage_policy_index,
+				   (1 - new.deleted),
+				   new.size
+			WHERE NOT EXISTS(
+				SELECT changes() as change
+				FROM policy_stat
+				WHERE change <> 0
+			);
+			UPDATE container_info
+			SET hash = chexor(hash, new.name, new.created_at);
+		END;
+		CREATE TRIGGER object_delete_policy_stat AFTER DELETE ON object
+		BEGIN
+			UPDATE policy_stat
+			SET object_count = object_count - (1 - old.deleted),
+				bytes_used = bytes_used - old.size
+			WHERE storage_policy_index = old.storage_policy_index;
+			UPDATE container_info
+			SET hash = chexor(hash, old.name, old.created_at);
+		END;`
+
+	containerInfoTableScript = `
+		CREATE TABLE container_info (
+			account TEXT,
+			container TEXT,
+			created_at TEXT,
+			put_timestamp TEXT DEFAULT '0',
+			delete_timestamp TEXT DEFAULT '0',
+			reported_put_timestamp TEXT DEFAULT '0',
+			reported_delete_timestamp TEXT DEFAULT '0',
+			reported_object_count INTEGER DEFAULT 0,
+			reported_bytes_used INTEGER DEFAULT 0,
+			hash TEXT default '00000000000000000000000000000000',
+			id TEXT,
+			status TEXT DEFAULT '',
+			status_changed_at TEXT DEFAULT '0',
+			metadata TEXT DEFAULT '{}',
+			x_container_sync_point1 INTEGER DEFAULT -1,
+			x_container_sync_point2 INTEGER DEFAULT -1,
+			storage_policy_index INTEGER DEFAULT 0,
+			reconciler_sync_point INTEGER DEFAULT -1
+		);`
+
+	containerStatViewScript = `
+		CREATE VIEW container_stat
+		AS SELECT ci.account, ci.container, ci.created_at,
+			ci.put_timestamp, ci.delete_timestamp,
+			ci.reported_put_timestamp, ci.reported_delete_timestamp,
+			ci.reported_object_count, ci.reported_bytes_used, ci.hash,
+			ci.id, ci.status, ci.status_changed_at, ci.metadata,
+			ci.x_container_sync_point1, ci.x_container_sync_point2,
+			ci.reconciler_sync_point,
+			ci.storage_policy_index,
+			coalesce(ps.object_count, 0) AS object_count,
+			coalesce(ps.bytes_used, 0) AS bytes_used
+		FROM container_info ci LEFT JOIN policy_stat ps
+		ON ci.storage_policy_index = ps.storage_policy_index;
+		CREATE TRIGGER container_stat_update
+		INSTEAD OF UPDATE ON container_stat
+		BEGIN
+			UPDATE container_info
+			SET account = NEW.account,
+				container = NEW.container,
+				created_at = NEW.created_at,
+				put_timestamp = NEW.put_timestamp,
+				delete_timestamp = NEW.delete_timestamp,
+				reported_put_timestamp = NEW.reported_put_timestamp,
+				reported_delete_timestamp = NEW.reported_delete_timestamp,
+				reported_object_count = NEW.reported_object_count,
+				reported_bytes_used = NEW.reported_bytes_used,
+				hash = NEW.hash,
+				id = NEW.id,
+				status = NEW.status,
+				status_changed_at = NEW.status_changed_at,
+				metadata = NEW.metadata,
+				x_container_sync_point1 = NEW.x_container_sync_point1,
+				x_container_sync_point2 = NEW.x_container_sync_point2,
+				storage_policy_index = NEW.storage_policy_index,
+				reconciler_sync_point = NEW.reconciler_sync_point;
+		END;`
+
+	objectTableScript = `
+		CREATE TABLE object (
+				ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+				name TEXT,
+				created_at TEXT,
+				size INTEGER,
+				content_type TEXT,
+				etag TEXT,
+				deleted INTEGER DEFAULT 0,
+				storage_policy_index INTEGER DEFAULT 0
+			);
+		CREATE INDEX ix_object_deleted_name ON object (deleted, name);
+		CREATE TRIGGER object_update BEFORE UPDATE ON object
+			BEGIN
+				SELECT RAISE(FAIL, 'UPDATE not allowed; DELETE and INSERT');
+			END;`
+
+	syncTableScript = `	
+		CREATE TABLE outgoing_sync (
+				remote_id TEXT UNIQUE,
+				sync_point INTEGER,
+				updated_at TEXT DEFAULT 0
+			);
+		CREATE TABLE incoming_sync (
+				remote_id TEXT UNIQUE,
+				sync_point INTEGER,
+				updated_at TEXT DEFAULT 0
+			);
+		CREATE TRIGGER outgoing_sync_insert AFTER INSERT ON outgoing_sync
+			BEGIN
+				UPDATE outgoing_sync
+				SET updated_at = STRFTIME('%s', 'NOW')
+				WHERE ROWID = new.ROWID;
+			END;
+		CREATE TRIGGER outgoing_sync_update AFTER UPDATE ON outgoing_sync
+			BEGIN
+				UPDATE outgoing_sync
+				SET updated_at = STRFTIME('%s', 'NOW')
+				WHERE ROWID = new.ROWID;
+			END;
+		CREATE TRIGGER incoming_sync_insert AFTER INSERT ON incoming_sync
+			BEGIN
+				UPDATE incoming_sync
+				SET updated_at = STRFTIME('%s', 'NOW')
+				WHERE ROWID = new.ROWID;
+			END;
+		CREATE TRIGGER incoming_sync_update AFTER UPDATE ON incoming_sync
+			BEGIN
+				UPDATE incoming_sync
+				SET updated_at = STRFTIME('%s', 'NOW')
+				WHERE ROWID = new.ROWID;
+			END;`
+
+	policyMigrateColumns = `account, container, created_at, put_timestamp, delete_timestamp, reported_put_timestamp,
+		reported_object_count, reported_bytes_used, hash, id, status, status_changed_at, metadata,
+		x_container_sync_point1, x_container_sync_point2`
+
+	policyMigrateScript = policyStatTableScript +
+		"INSERT INTO policy_stat (storage_policy_index, object_count, bytes_used) SELECT 0, object_count, bytes_used FROM container_stat;" +
+		"ALTER TABLE object ADD COLUMN storage_policy_index INTEGER DEFAULT 0;" +
+		"DROP TRIGGER object_insert;" +
+		"DROP TRIGGER object_delete;" +
+		policyStatTriggerScript +
+		containerInfoTableScript +
+		"INSERT INTO container_info (" + policyMigrateColumns + ") SELECT " + policyMigrateColumns + " FROM container_stat;" +
+		"DROP TABLE IF EXISTS container_stat;" +
+		containerStatViewScript
+
+	syncPointMigrateScript = `
+		ALTER TABLE container_stat ADD COLUMN x_container_sync_point1 INTEGER DEFAULT -1;
+		ALTER TABLE container_stat ADD COLUMN x_container_sync_point2 INTEGER DEFAULT -1;`
+
+	metadataMigrateScript = "ALTER TABLE container_stat ADD COLUMN metadata DEFAULT '{}';"
+
+	pragmaScript = `
+		PRAGMA synchronous = NORMAL;
+		PRAGMA cache_size = -4096;
+		PRAGMA temp_store = MEMORY;
+		PRAGMA journal_mode = WAL;
+		PRAGMA busy_timeout = 25000;`
+)
+
+func schemaMigrate(db *sql.DB) (bool, error) {
+	hasDeletedNameIndex := false
+	hasSyncPoints := false
+	hasMetadata := false
+	hasPolicyStat := false
+
+	tx, err := db.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	// We just pull the schema out of sqlite_master and look at it to get the current state of the database.
+	rows, err := tx.Query("SELECT name, sql FROM sqlite_master WHERE name in ('policy_stat', 'ix_object_deleted_name', 'container_stat')")
+	if err != nil {
+		return false, err
+	}
+	for rows.Next() {
+		var name, sql string
+		if err := rows.Scan(&name, &sql); err != nil {
+			return false, err
+		}
+		if name == "policy_stat" {
+			hasPolicyStat = true
+		} else if name == "ix_object_deleted_name" {
+			hasDeletedNameIndex = true
+		} else if name == "container_stat" {
+			hasSyncPoints = strings.Contains(sql, "x_container_sync_point1")
+			hasMetadata = strings.Contains(sql, "metadata")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return hasDeletedNameIndex, err
+	}
+	if err := rows.Close(); err != nil {
+		return hasDeletedNameIndex, err
+	}
+
+	if hasSyncPoints && hasMetadata && hasPolicyStat {
+		return hasDeletedNameIndex, nil
+	}
+
+	if !hasSyncPoints {
+		if _, err := tx.Exec(syncPointMigrateScript); err != nil {
+			return hasDeletedNameIndex, fmt.Errorf("Adding sync_point columns: %v", err)
+		}
+	}
+	if !hasMetadata {
+		if _, err := tx.Exec(metadataMigrateScript); err != nil {
+			return hasDeletedNameIndex, fmt.Errorf("Adding metadata column: %v", err)
+		}
+	}
+	if !hasPolicyStat {
+		if _, err = tx.Exec(policyMigrateScript); err != nil {
+			return hasDeletedNameIndex, fmt.Errorf("Performing policy migration: %v", err)
+		}
+	}
+	return hasDeletedNameIndex, tx.Commit()
+}

--- a/containerserver/schema_test.go
+++ b/containerserver/schema_test.go
@@ -1,0 +1,174 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"database/sql"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This is the schema from when we first released swift.
+var superCruftySchema = `
+	CREATE TABLE outgoing_sync (
+			remote_id TEXT UNIQUE,
+			sync_point INTEGER,
+			updated_at TEXT DEFAULT 0
+		);
+	CREATE TABLE incoming_sync (
+			remote_id TEXT UNIQUE,
+			sync_point INTEGER,
+			updated_at TEXT DEFAULT 0
+		);
+	CREATE TRIGGER outgoing_sync_insert AFTER INSERT ON outgoing_sync
+		BEGIN
+			UPDATE outgoing_sync
+			SET updated_at = STRFTIME('%s', 'NOW')
+			WHERE ROWID = new.ROWID;
+		END;
+	CREATE TRIGGER outgoing_sync_update AFTER UPDATE ON outgoing_sync
+		BEGIN
+			UPDATE outgoing_sync
+			SET updated_at = STRFTIME('%s', 'NOW')
+			WHERE ROWID = new.ROWID;
+		END;
+	CREATE TRIGGER incoming_sync_insert AFTER INSERT ON incoming_sync
+		BEGIN
+			UPDATE incoming_sync
+			SET updated_at = STRFTIME('%s', 'NOW')
+			WHERE ROWID = new.ROWID;
+		END;
+	CREATE TRIGGER incoming_sync_update AFTER UPDATE ON incoming_sync
+		BEGIN
+			UPDATE incoming_sync
+			SET updated_at = STRFTIME('%s', 'NOW')
+			WHERE ROWID = new.ROWID;
+		END;
+	CREATE TABLE object (
+			ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT UNIQUE,
+			created_at TEXT,
+			size INTEGER,
+			content_type TEXT,
+			etag TEXT,
+			deleted INTEGER DEFAULT 0
+		);
+	CREATE INDEX ix_object_deleted ON object (deleted);
+	CREATE TRIGGER object_insert AFTER INSERT ON object
+		BEGIN
+			UPDATE container_stat
+			SET object_count = object_count + (1 - new.deleted),
+				bytes_used = bytes_used + new.size,
+				hash = chexor(hash, new.name, new.created_at);
+		END;
+	CREATE TRIGGER object_update BEFORE UPDATE ON object
+		BEGIN
+			SELECT RAISE(FAIL, 'UPDATE not allowed; DELETE and INSERT');
+		END;
+	CREATE TRIGGER object_delete AFTER DELETE ON object
+		BEGIN
+			UPDATE container_stat
+			SET object_count = object_count - (1 - old.deleted),
+				bytes_used = bytes_used - old.size,
+				hash = chexor(hash, old.name, old.created_at);
+		END;
+	CREATE TABLE container_stat (
+			account TEXT,
+			container TEXT,
+			created_at TEXT,
+			put_timestamp TEXT DEFAULT '0',
+			delete_timestamp TEXT DEFAULT '0',
+			object_count INTEGER,
+			bytes_used INTEGER,
+			reported_put_timestamp TEXT DEFAULT '0',
+			reported_delete_timestamp TEXT DEFAULT '0',
+			reported_object_count INTEGER DEFAULT 0,
+			reported_bytes_used INTEGER DEFAULT 0,
+			hash TEXT default '00000000000000000000000000000000',
+			id TEXT,
+			status TEXT DEFAULT '',
+			status_changed_at TEXT DEFAULT '0'
+		);
+	INSERT INTO container_stat (account, container, created_at, object_count, bytes_used, id) VALUES ("a", "c", '0', 0, 0, "some database");`
+
+func createCruftyDatabase() (string, func(), error) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return "", nil, err
+	}
+	dbFile := filepath.Join(dir, "db.db")
+	dbConn, err := sql.Open("sqlite3_hummingbird", dbFile)
+	if err != nil {
+		return "", nil, err
+	}
+	if _, err := dbConn.Exec(superCruftySchema); err != nil {
+		return "", nil, err
+	}
+	cleanup := func() {
+		os.RemoveAll(dir)
+	}
+	return dbFile, cleanup, nil
+}
+
+func TestMigrateCruftyDatabase(t *testing.T) {
+	dbFile, cleanup, err := createCruftyDatabase()
+	require.Nil(t, err)
+	defer cleanup()
+	c, err := sqliteOpenContainer(dbFile)
+	require.Nil(t, err)
+	db, ok := c.(*sqliteContainer)
+	require.True(t, ok)
+	require.False(t, db.hasDeletedNameIndex)
+	count := 0
+	require.Nil(t, db.connect())
+	err = db.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE name in ('policy_stat', 'object_insert_policy_stat', 'container_info', 'container_stat_update')").Scan(&count)
+	require.Nil(t, err)
+	require.Equal(t, 4, count)
+	require.Nil(t, db.QueryRow("SELECT COUNT(*) FROM container_info").Scan(&count))
+	require.Nil(t, err)
+	require.Equal(t, 1, count)
+	require.Nil(t, db.QueryRow("SELECT COUNT(*) FROM policy_stat").Scan(&count))
+	require.Nil(t, err)
+	require.Equal(t, 1, count)
+	info, err := db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, "a", info.Account)
+	require.Equal(t, "c", info.Container)
+	require.Equal(t, "some database", info.ID)
+
+	ensureColumnsExist := func(table string, columns []string) {
+		rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
+		require.Nil(t, err)
+		columnNames := map[string]bool{}
+		for rows.Next() {
+			var columnName string
+			var _x interface{}
+			require.Nil(t, rows.Scan(&_x, &columnName, &_x, &_x, &_x, &_x))
+			columnNames[columnName] = true
+		}
+		rows.Close()
+		for _, column := range columns {
+			require.True(t, columnNames[column])
+		}
+	}
+	ensureColumnsExist("object", []string{"storage_policy_index"})
+	ensureColumnsExist("container_stat", []string{"metadata", "x_container_sync_point1", "x_container_sync_point2"})
+}

--- a/containerserver/server.go
+++ b/containerserver/server.go
@@ -1,0 +1,609 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	_ "net/http/pprof" // install pprof http handlers
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/justinas/alice"
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/srv"
+	"github.com/troubling/hummingbird/middleware"
+)
+
+// GetHashPrefixAndSuffix is a pointer to hummingbird's function of the same name, for overriding in tests.
+var GetHashPrefixAndSuffix = conf.GetHashPrefixAndSuffix
+
+// GetSyncRealms is a pointer to hummingbird's function of the same name, for overriding in tests.
+var GetSyncRealms = conf.GetSyncRealms
+
+// LoadPolicies is a pointer to hummingbird's function of the same name, for overriding in tests.
+var LoadPolicies = conf.LoadPolicies
+
+// ContainerServer contains all of the information for a running container server.
+type ContainerServer struct {
+	driveRoot        string
+	hashPathPrefix   string
+	hashPathSuffix   string
+	logger           srv.LowLevelLogger
+	logLevel         string
+	diskInUse        *common.KeyedLimit
+	checkMounts      bool
+	containerEngine  ContainerEngine
+	updateClient     *http.Client
+	autoCreatePrefix string
+	syncRealms       conf.SyncRealmList
+	defaultPolicy    int
+}
+
+var saveHeaders = map[string]bool{
+	"X-Container-Read":     true,
+	"X-Container-Write":    true,
+	"X-Container-Sync-Key": true,
+	"X-Container-Sync-To":  true,
+	"X-Versions-Location":  true,
+}
+
+func formatTimestamp(ts string) string {
+	if len(ts) == 16 && ts[10] == '.' {
+		return ts
+	}
+	t, err := strconv.ParseFloat(ts, 64)
+	if err != nil {
+		return "0000000000.00000"
+	}
+	ret := strconv.FormatFloat(t, 'f', 5, 64)
+	if len(ret) < 16 {
+		return strings.Repeat("0", 16-len(ret)) + ret
+	}
+	return ret
+}
+
+// ContainerGetHandler handles GET and HEAD requests for a container.
+func (server *ContainerServer) ContainerGetHandler(writer http.ResponseWriter, request *http.Request) {
+	vars := srv.GetVars(request)
+	if err := request.ParseForm(); err != nil {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	db, err := server.containerEngine.Get(vars)
+	if err == ErrorNoSuchContainer {
+		srv.StandardResponse(writer, http.StatusNotFound)
+		return
+	} else if err != nil {
+		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	defer server.containerEngine.Return(db)
+	info, err := db.GetInfo()
+	if err != nil {
+		srv.GetLogger(request).LogError("Unable to get container info: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	headers := writer.Header()
+	if ts, err := common.GetEpochFromTimestamp(info.CreatedAt); err == nil {
+		headers.Set("X-Backend-Timestamp", ts)
+	}
+	if ts, err := common.GetEpochFromTimestamp(info.PutTimestamp); err == nil {
+		headers.Set("X-Backend-Put-Timestamp", ts)
+	}
+	if ts, err := common.GetEpochFromTimestamp(info.DeleteTimestamp); err == nil {
+		headers.Set("X-Backend-Delete-Timestamp", ts)
+	}
+	if ts, err := common.GetEpochFromTimestamp(info.StatusChangedAt); err == nil {
+		headers.Set("X-Backend-Status-Changed-At", ts)
+	}
+	headers.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(info.StoragePolicyIndex))
+	metadata, err := db.GetMetadata()
+	if err != nil {
+		srv.GetLogger(request).LogError("Unable to get metadata: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	for key, value := range metadata {
+		headers.Set(key, value)
+	}
+	if deleted, err := db.IsDeleted(); err != nil {
+		srv.GetLogger(request).LogError("Error calling IsDeleted: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	} else if deleted {
+		srv.StandardResponse(writer, http.StatusNotFound)
+		return
+	} else {
+		headers.Set("X-Container-Object-Count", strconv.FormatInt(info.ObjectCount, 10))
+		headers.Set("X-Container-Bytes-Used", strconv.FormatInt(info.BytesUsed, 10))
+		if ts, err := common.GetEpochFromTimestamp(info.CreatedAt); err == nil {
+			headers.Set("X-Timestamp", ts)
+		}
+		if ts, err := common.GetEpochFromTimestamp(info.PutTimestamp); err == nil {
+			headers.Set("X-Put-Timestamp", ts)
+		}
+	}
+	if request.Method == "HEAD" {
+		writer.WriteHeader(http.StatusNoContent)
+		writer.Write([]byte(""))
+		return
+	}
+	limit, _ := strconv.ParseInt(request.FormValue("limit"), 10, 64)
+	if limit <= 0 || limit > 10000 {
+		limit = 10000
+	}
+	marker := request.Form.Get("marker")
+	delimiter := request.Form.Get("delimiter")
+	endMarker := request.Form.Get("end_marker")
+	prefix := request.Form.Get("prefix")
+	var path *string
+	if v, ok := request.Form["path"]; ok && len(v) > 0 {
+		path = &v[0]
+	}
+	policyIndex, err := strconv.Atoi(request.Header.Get("X-Backend-Storage-Policy-Index"))
+	if err != nil {
+		policyIndex = info.StoragePolicyIndex
+	}
+	reverse := common.LooksTrue(request.Form.Get("reverse"))
+	objects, err := db.ListObjects(int(limit), marker, endMarker, prefix, delimiter, path, reverse, policyIndex)
+	if err != nil {
+		srv.GetLogger(request).LogError("Unable to list objects: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	format := request.Form.Get("format")
+	if format == "" { /* TODO: real accept parsing */
+		accept := request.Header.Get("Accept")
+		if strings.Contains(accept, "application/json") {
+			format = "json"
+		} else if strings.Contains(accept, "application/xml") || strings.Contains(accept, "text/xml") {
+			format = "xml"
+		} else {
+			format = "text"
+		}
+	}
+	if format == "text" {
+		response := ""
+		for _, obj := range objects {
+			if or, ok := obj.(*ObjectListingRecord); ok {
+				response += or.Name + "\n"
+			} else if sr, ok := obj.(*SubdirListingRecord); ok {
+				response += sr.Name + "\n"
+			}
+		}
+		if len(response) > 0 {
+			headers.Set("Content-Length", strconv.Itoa(len(response)))
+			writer.WriteHeader(200)
+			writer.Write([]byte(response))
+		} else {
+			headers.Set("Content-Length", "0")
+			writer.WriteHeader(204)
+			writer.Write([]byte(""))
+		}
+	} else if format == "json" {
+		output, err := json.Marshal(objects)
+		if err != nil {
+			srv.StandardResponse(writer, http.StatusInternalServerError)
+			return
+		}
+		headers.Set("Content-Type", "application/json; charset=utf-8")
+		headers.Set("Content-Length", strconv.Itoa(len(output)))
+		writer.WriteHeader(200)
+		writer.Write(output)
+	} else if format == "xml" {
+		type Container struct {
+			XMLName xml.Name `xml:"container"`
+			Name    string   `xml:"name,attr"`
+			Objects []interface{}
+		}
+		container := &Container{Name: vars["container"], Objects: objects}
+		writer.Header().Set("Content-Type", "application/xml; charset=utf-8")
+		output, _ := xml.MarshalIndent(container, "", "  ")
+		headers.Set("Content-Length", strconv.Itoa(len(output)+39))
+		writer.WriteHeader(200)
+		writer.Write([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"))
+		writer.Write(output)
+	}
+}
+
+// ContainerPutHandler handles PUT requests for a container.
+func (server *ContainerServer) ContainerPutHandler(writer http.ResponseWriter, request *http.Request) {
+	vars := srv.GetVars(request)
+	timestamp, err := common.StandardizeTimestamp(request.Header.Get("X-Timestamp"))
+	if err != nil {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	if syncTo := request.Header.Get("X-Container-Sync-To"); syncTo != "" {
+		if !server.syncRealms.ValidateSyncTo(syncTo) {
+			srv.StandardResponse(writer, http.StatusBadRequest)
+			return
+		}
+	}
+	policyIndex, err := strconv.Atoi(request.Header.Get("X-Backend-Storage-Policy-Index"))
+	if err != nil {
+		policyIndex = -1
+	}
+	defaultPolicyIndex, err := strconv.Atoi(request.Header.Get("X-Backend-Storage-Policy-Default"))
+	if err != nil {
+		defaultPolicyIndex = server.defaultPolicy
+	}
+	metadata := make(map[string][]string)
+	for key, values := range request.Header {
+		_, inSaveHeaders := saveHeaders[key]
+		if !(strings.HasPrefix(key, "X-Container-Meta-") || strings.HasPrefix(key, "X-Container-Sysmeta-") || inSaveHeaders) {
+			continue
+		} else if len(values) == 0 || values[0] == "" {
+			continue
+		}
+		metadata[key] = []string{request.Header.Get(key), timestamp}
+	}
+	created, db, err := server.containerEngine.Create(vars, timestamp, metadata, policyIndex, defaultPolicyIndex)
+	if err == ErrorPolicyConflict {
+		srv.StandardResponse(writer, http.StatusConflict)
+		return
+	} else if err != nil {
+		srv.GetLogger(request).LogError("Unable to create database: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	defer server.containerEngine.Return(db)
+	if info, err := db.GetInfo(); err == nil {
+		server.accountUpdate(request, vars, info, srv.GetLogger(request))
+	}
+	if created {
+		srv.StandardResponse(writer, http.StatusCreated)
+	} else {
+		srv.StandardResponse(writer, http.StatusAccepted)
+	}
+}
+
+// ContainerDeleteHandler handles DELETE requests for the container.
+func (server *ContainerServer) ContainerDeleteHandler(writer http.ResponseWriter, request *http.Request) {
+	vars := srv.GetVars(request)
+	db, err := server.containerEngine.Get(vars)
+	if err == ErrorNoSuchContainer {
+		srv.StandardResponse(writer, http.StatusNotFound)
+		return
+	} else if err != nil {
+		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	defer server.containerEngine.Return(db)
+	timestamp, err := common.StandardizeTimestamp(request.Header.Get("X-Timestamp"))
+	if err != nil {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	info, err := db.GetInfo()
+	if err != nil {
+		srv.GetLogger(request).LogError("Unable to get container info: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	if info.ObjectCount > 0 {
+		srv.StandardResponse(writer, http.StatusConflict)
+		return
+	}
+	if err = db.Delete(timestamp); err != nil {
+		srv.GetLogger(request).LogError("Unable to delete database: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	info, err = db.GetInfo()
+	if err == nil {
+		server.accountUpdate(request, vars, info, srv.GetLogger(request))
+	}
+	writer.WriteHeader(http.StatusNoContent)
+	writer.Write([]byte(""))
+}
+
+// ContainerPostHandler handles POST requests for a container.
+func (server *ContainerServer) ContainerPostHandler(writer http.ResponseWriter, request *http.Request) {
+	vars := srv.GetVars(request)
+	timestamp, err := common.StandardizeTimestamp(request.Header.Get("X-Timestamp"))
+	if err != nil {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	if syncTo := request.Header.Get("X-Container-Sync-To"); syncTo != "" {
+		if !server.syncRealms.ValidateSyncTo(syncTo) {
+			srv.StandardResponse(writer, http.StatusBadRequest)
+			return
+		}
+	}
+	updates := make(map[string][]string)
+	for key := range request.Header {
+		_, inSaveHeaders := saveHeaders[key]
+		if !(strings.HasPrefix(key, "X-Container-Meta-") || strings.HasPrefix(key, "X-Container-Sysmeta") || inSaveHeaders) {
+			continue
+		}
+		updates[key] = []string{request.Header.Get(key), timestamp}
+	}
+	db, err := server.containerEngine.Get(vars)
+	if err == ErrorNoSuchContainer {
+		srv.StandardResponse(writer, http.StatusNotFound)
+		return
+	} else if err != nil {
+		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	defer server.containerEngine.Return(db)
+	if deleted, err := db.IsDeleted(); err != nil {
+		srv.GetLogger(request).LogError("Error calling IsDeleted: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	} else if deleted {
+		srv.StandardResponse(writer, http.StatusNotFound)
+		return
+	}
+	if err := db.UpdateMetadata(updates); err == ErrorInvalidMetadata {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+	} else if err != nil {
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+	} else {
+		writer.WriteHeader(http.StatusNoContent)
+		writer.Write([]byte(""))
+	}
+}
+
+// ObjPutHandler handles the PUT of object records to a container.
+func (server *ContainerServer) ObjPutHandler(writer http.ResponseWriter, request *http.Request) {
+	vars := srv.GetVars(request)
+	timestamp, err := common.StandardizeTimestamp(request.Header.Get("X-Timestamp"))
+	if err != nil {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	contentType := request.Header.Get("X-Content-Type")
+	etag := request.Header.Get("X-Etag")
+	size, err := strconv.ParseInt(request.Header.Get("X-Size"), 10, 64)
+	if err != nil || contentType == "" || etag == "" {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	policyIndex, err := strconv.Atoi(request.Header.Get("X-Backend-Storage-Policy-Index"))
+	if err != nil {
+		policyIndex = 0
+	}
+	db, err := server.containerEngine.Get(vars)
+	if err == ErrorNoSuchContainer {
+		if strings.HasPrefix(vars["account"], server.autoCreatePrefix) {
+			if _, db, err = server.containerEngine.Create(vars, timestamp, map[string][]string{}, policyIndex, 0); err != nil {
+				srv.GetLogger(request).LogError("Unable to auto-create container: %v", err)
+				srv.StandardResponse(writer, http.StatusInternalServerError)
+				return
+			}
+		} else {
+			srv.StandardResponse(writer, http.StatusNotFound)
+			return
+		}
+	} else if err != nil {
+		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	defer server.containerEngine.Return(db)
+	if err := db.PutObject(vars["obj"], timestamp, size, contentType, etag, policyIndex); err != nil {
+		srv.GetLogger(request).LogError("Error adding object to container: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	srv.StandardResponse(writer, http.StatusCreated)
+}
+
+// ObjDeleteHandler handles the DELETE of object records in a container.
+func (server *ContainerServer) ObjDeleteHandler(writer http.ResponseWriter, request *http.Request) {
+	vars := srv.GetVars(request)
+	timestamp, err := common.StandardizeTimestamp(request.Header.Get("X-Timestamp"))
+	if err != nil {
+		srv.StandardResponse(writer, http.StatusBadRequest)
+		return
+	}
+	policyIndex, err := strconv.Atoi(request.Header.Get("X-Backend-Storage-Policy-Index"))
+	if err != nil {
+		policyIndex = 0
+	}
+	db, err := server.containerEngine.Get(vars)
+	if err == ErrorNoSuchContainer {
+		if strings.HasPrefix(vars["account"], server.autoCreatePrefix) {
+			if _, db, err = server.containerEngine.Create(vars, timestamp, map[string][]string{}, policyIndex, 0); err != nil {
+				srv.GetLogger(request).LogError("Unable to auto-create container: %v", err)
+				srv.StandardResponse(writer, http.StatusInternalServerError)
+				return
+			}
+		} else {
+			srv.StandardResponse(writer, http.StatusNotFound)
+			return
+		}
+	} else if err != nil {
+		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	defer server.containerEngine.Return(db)
+	if err := db.DeleteObject(vars["obj"], timestamp, policyIndex); err != nil {
+		srv.GetLogger(request).LogError("Error adding object to container: %v", err)
+		srv.StandardResponse(writer, http.StatusInternalServerError)
+		return
+	}
+	writer.WriteHeader(http.StatusNoContent)
+	writer.Write([]byte(""))
+}
+
+// HealthcheckHandler implements a basic health check, that just returns "OK".
+func (server *ContainerServer) HealthcheckHandler(writer http.ResponseWriter, request *http.Request) {
+	writer.Header().Set("Content-Length", "2")
+	writer.WriteHeader(http.StatusOK)
+	writer.Write([]byte("OK"))
+}
+
+// ReconHandler delegates incoming /recon calls to the common recon handler.
+func (server *ContainerServer) ReconHandler(writer http.ResponseWriter, request *http.Request) {
+	middleware.ReconHandler(server.driveRoot, writer, request)
+}
+
+// DiskUsageHandler returns information on the current outstanding HTTP requests per-disk.
+func (server *ContainerServer) DiskUsageHandler(writer http.ResponseWriter, request *http.Request) {
+	if data, err := server.diskInUse.MarshalJSON(); err == nil {
+		writer.WriteHeader(http.StatusOK)
+		writer.Write(data)
+	} else {
+		writer.WriteHeader(http.StatusInternalServerError)
+		writer.Write([]byte(err.Error()))
+	}
+}
+
+// LogRequest is a middleware that logs requests and also sets up a logger in the request context.
+func (server *ContainerServer) LogRequest(next http.Handler) http.Handler {
+	fn := func(writer http.ResponseWriter, request *http.Request) {
+		newWriter := &srv.WebWriter{ResponseWriter: writer, Status: 500, ResponseStarted: false}
+		requestLogger := &srv.RequestLogger{Request: request, Logger: server.logger, W: newWriter}
+		defer requestLogger.LogPanics("LOGGING REQUEST")
+		start := time.Now()
+		request = srv.SetLogger(request, requestLogger)
+		next.ServeHTTP(newWriter, request)
+		forceAcquire := request.Header.Get("X-Force-Acquire") == "true"
+		if (request.Method != "REPLICATE" && request.Method != "REPCONN") || server.logLevel == "DEBUG" {
+			extraInfo := "-"
+			if forceAcquire {
+				extraInfo = "FA"
+			}
+			server.logger.Info(fmt.Sprintf("%s - - [%s] \"%s %s\" %d %s \"%s\" \"%s\" \"%s\" %.4f \"%s\"",
+				request.RemoteAddr,
+				time.Now().Format("02/Jan/2006:15:04:05 -0700"),
+				request.Method,
+				common.Urlencode(request.URL.Path),
+				newWriter.Status,
+				common.GetDefault(newWriter.Header(), "Content-Length", "-"),
+				common.GetDefault(request.Header, "Referer", "-"),
+				common.GetDefault(request.Header, "X-Trans-Id", "-"),
+				common.GetDefault(request.Header, "User-Agent", "-"),
+				time.Since(start).Seconds(),
+				extraInfo))
+		}
+	}
+	return http.HandlerFunc(fn)
+}
+
+// AcquireDevice is a middleware that makes sure the device is available - mounted and not beyond its max concurrency.
+func (server *ContainerServer) AcquireDevice(next http.Handler) http.Handler {
+	fn := func(writer http.ResponseWriter, request *http.Request) {
+		vars := srv.GetVars(request)
+		if device, ok := vars["device"]; ok && device != "" {
+			devicePath := filepath.Join(server.driveRoot, device)
+			if server.checkMounts {
+				if mounted, err := common.IsMount(devicePath); err != nil || !mounted {
+					vars["Method"] = request.Method
+					srv.CustomErrorResponse(writer, 507, vars)
+					return
+				}
+			}
+
+			forceAcquire := request.Header.Get("X-Force-Acquire") == "true"
+			if concRequests := server.diskInUse.Acquire(device, forceAcquire); concRequests != 0 {
+				writer.Header().Set("X-Disk-Usage", strconv.FormatInt(concRequests, 10))
+				srv.StandardResponse(writer, 503)
+				return
+			}
+			defer server.diskInUse.Release(device)
+		}
+		next.ServeHTTP(writer, request)
+	}
+	return http.HandlerFunc(fn)
+}
+
+func (server *ContainerServer) updateDeviceLocks(seconds int64) {
+	reloadTime := time.Duration(seconds) * time.Second
+	for {
+		time.Sleep(reloadTime)
+		for _, key := range server.diskInUse.Keys() {
+			lockPath := filepath.Join(server.driveRoot, key, "lock_device")
+			if common.Exists(lockPath) {
+				server.diskInUse.Lock(key)
+			} else {
+				server.diskInUse.Unlock(key)
+			}
+		}
+	}
+}
+
+// GetHandler returns the server's http handler - it sets up routes and instantiates middleware.
+func (server *ContainerServer) GetHandler(config conf.Config) http.Handler {
+	commonHandlers := alice.New(server.LogRequest, middleware.ValidateRequest, server.AcquireDevice)
+	router := srv.NewRouter()
+	router.Get("/healthcheck", commonHandlers.ThenFunc(server.HealthcheckHandler))
+	router.Get("/diskusage", commonHandlers.ThenFunc(server.DiskUsageHandler))
+	router.Get("/recon/:method/:recon_type", commonHandlers.ThenFunc(server.ReconHandler))
+	router.Get("/recon/:method", commonHandlers.ThenFunc(server.ReconHandler))
+	router.Put("/:device/tmp/:filename", commonHandlers.ThenFunc(server.ContainerTmpUploadHandler))
+	router.Put("/:device/:partition/:account/:container/*obj", commonHandlers.ThenFunc(server.ObjPutHandler))
+	router.Delete("/:device/:partition/:account/:container/*obj", commonHandlers.ThenFunc(server.ObjDeleteHandler))
+	router.Put("/:device/:partition/:account/:container", commonHandlers.ThenFunc(server.ContainerPutHandler))
+	router.Get("/:device/:partition/:account/:container", commonHandlers.ThenFunc(server.ContainerGetHandler))
+	router.Head("/:device/:partition/:account/:container", commonHandlers.ThenFunc(server.ContainerGetHandler))
+	router.Delete("/:device/:partition/:account/:container", commonHandlers.ThenFunc(server.ContainerDeleteHandler))
+	router.Post("/:device/:partition/:account/:container", commonHandlers.ThenFunc(server.ContainerPostHandler))
+	router.Replicate("/:device/:partition/:hash", commonHandlers.ThenFunc(server.ContainerReplicateHandler))
+	router.Get("/debug/pprof/:parm", http.DefaultServeMux)
+	router.Post("/debug/pprof/:parm", http.DefaultServeMux)
+	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, fmt.Sprintf("Invalid path: %s", r.URL.Path), http.StatusBadRequest)
+	})
+	return alice.New(middleware.GrepObject).Then(router)
+}
+
+// GetServer parses configs and command-line flags, returning a configured server object and the ip and port it should bind on.
+func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bindPort int, serv srv.Server, logger srv.LowLevelLogger, err error) {
+	server := &ContainerServer{driveRoot: "/srv/node", hashPathPrefix: "", hashPathSuffix: ""}
+	server.syncRealms = GetSyncRealms()
+	server.hashPathPrefix, server.hashPathSuffix, err = GetHashPrefixAndSuffix()
+	if err != nil {
+		return "", 0, nil, nil, err
+	}
+	policies := LoadPolicies()
+	server.defaultPolicy = policies.Default()
+	server.autoCreatePrefix = serverconf.GetDefault("app:container-server", "auto_create_account_prefix", ".")
+	server.driveRoot = serverconf.GetDefault("app:container-server", "devices", "/srv/node")
+	server.checkMounts = serverconf.GetBool("app:container-server", "mount_check", true)
+	server.logLevel = serverconf.GetDefault("app:container-server", "log_level", "INFO")
+	server.diskInUse = common.NewKeyedLimit(serverconf.GetLimit("app:container-server", "disk_limit", 25, 10000))
+	bindIP = serverconf.GetDefault("app:container-server", "bind_ip", "0.0.0.0")
+	bindPort = int(serverconf.GetInt("app:container-server", "bind_port", 6000))
+	if server.logger, err = srv.SetupLogger(serverconf, flags, "app:container-server", "container-server"); err != nil {
+		return "", 0, nil, nil, fmt.Errorf("Error setting up logger: %v", err)
+	}
+	server.containerEngine = newLRUEngine(server.driveRoot, server.hashPathPrefix, server.hashPathSuffix, 32)
+	connTimeout := time.Duration(serverconf.GetFloat("app:container-server", "conn_timeout", 1.0) * float64(time.Second))
+	nodeTimeout := time.Duration(serverconf.GetFloat("app:container-server", "node_timeout", 10.0) * float64(time.Second))
+	server.updateClient = &http.Client{
+		Timeout:   nodeTimeout,
+		Transport: &http.Transport{Dial: (&net.Dialer{Timeout: connTimeout}).Dial},
+	}
+	return bindIP, bindPort, server, server.logger, nil
+}

--- a/containerserver/server_test.go
+++ b/containerserver/server_test.go
@@ -1,0 +1,725 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"encoding/json"
+	"flag"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+)
+
+func TestFormatTimestamp(t *testing.T) {
+	require.Equal(t, "0000000000.00000", formatTimestamp("something"))
+	require.Equal(t, "0000000001.00000", formatTimestamp("1"))
+	require.Equal(t, "1000000000.00000", formatTimestamp("1000000000"))
+	require.Equal(t, "1000000000.00000", formatTimestamp("1000000000.00000"))
+}
+
+func TestContainerGetNotFound(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("GET", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 404, rsp.status)
+}
+
+func TestContainerDeleteNotFound(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("DELETE", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 404, rsp.status)
+}
+
+func TestContainerPostDeleted(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "2")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("DELETE", "/device/1/a/c", nil)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("POST", "/device/1/a/c", nil)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 404, rsp.status)
+}
+
+func TestContainerPostNotFound(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("POST", "/device/1/a/c", nil)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 404, rsp.status)
+}
+
+func TestContainerPostBadTimestamp(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("POST", "/device/1/a/c", nil)
+	req.Header.Set("X-Timestamp", "invalid")
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+}
+
+func TestContainerPutBadTimestamp(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "invalid")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "2")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+}
+
+func TestContainerDeleteBadTimestamp(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "2")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("DELETE", "/device/1/a/c", nil)
+	req.Header.Set("X-Timestamp", "invalid")
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+}
+
+func TestContainerPutExisting(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "2")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "2000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "2")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 202, rsp.status)
+}
+
+func TestContainerPutPolicyConflict(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "2")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "2000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 409, rsp.status)
+}
+
+func TestContainerPutHead(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "2")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+	require.Equal(t, "0", rsp.header.Get("X-Container-Object-Count"))
+	require.Equal(t, "0", rsp.header.Get("X-Container-Bytes-Used"))
+	require.Equal(t, "2", rsp.header.Get("X-Backend-Storage-Policy-Index"))
+	require.Equal(t, "1000000000.00001", rsp.header.Get("X-Put-Timestamp"))
+}
+
+func TestContainerPutNoPolicy(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+	require.Equal(t, "0", rsp.header.Get("X-Backend-Storage-Policy-Index"))
+}
+
+func TestContainerDeleteNotEmpty(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "100000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	for _, object := range []string{"1", "2", "3"} {
+		rsp := makeCaptureResponse()
+		req, err := http.NewRequest("PUT", "/device/1/a/c/"+object, nil)
+		require.Nil(t, err)
+		req.Header.Set("X-Timestamp", common.GetTimestamp())
+		req.Header.Set("X-Content-Type", "application/octet-stream")
+		req.Header.Set("X-Size", "2")
+		req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, 201, rsp.status)
+	}
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("DELETE", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 409, rsp.status)
+}
+
+func TestContainerPutObjectsGet(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "100000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	for _, object := range []string{"1", "2", "3"} {
+		rsp := makeCaptureResponse()
+		req, err := http.NewRequest("PUT", "/device/1/a/c/"+object, nil)
+		require.Nil(t, err)
+		req.Header.Set("X-Timestamp", common.GetTimestamp())
+		req.Header.Set("X-Content-Type", "application/octet-stream")
+		req.Header.Set("X-Size", "2")
+		req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, 201, rsp.status)
+	}
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("GET", "/device/1/a/c?format=json", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 200, rsp.status)
+	require.Equal(t, "application/json; charset=utf-8", rsp.header.Get("Content-Type"))
+	require.Equal(t, "3", rsp.header.Get("X-Container-Object-Count"))
+	require.Equal(t, "6", rsp.header.Get("X-Container-Bytes-Used"))
+	var data []ObjectListingRecord
+	require.Nil(t, json.Unmarshal(rsp.body.Bytes(), &data))
+	require.Equal(t, 3, len(data))
+	require.Equal(t, "1", data[0].Name)
+	require.Equal(t, "2", data[1].Name)
+	require.Equal(t, "3", data[2].Name)
+	require.Equal(t, int64(2), data[2].Size)
+	require.Equal(t, "d41d8cd98f00b204e9800998ecf8427e", data[2].ETag)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("GET", "/device/1/a/c", nil)
+	req.Header.Set("Accept", "application/json")
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 200, rsp.status)
+	require.Equal(t, "application/json; charset=utf-8", rsp.header.Get("Content-Type"))
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("GET", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 200, rsp.status)
+	require.Equal(t, "1\n2\n3\n", rsp.body.String())
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("GET", "/device/1/a/c?format=xml", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 200, rsp.status)
+	require.Equal(t, "application/xml; charset=utf-8", rsp.header.Get("Content-Type"))
+	// TODO parse and validate xml.  or maybe we won't do that.
+}
+
+func TestContainerPutObjectsFails(t *testing.T) {
+	server, handler, cleanup, err := makeTestServer2()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "100000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	server.containerEngine = fakeContainerEngine{}
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("PUT", "/device/1/a/c/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Content-Type", "application/octet-stream")
+	req.Header.Set("X-Size", "2")
+	req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 500, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("DELETE", "/device/1/a/c/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 500, rsp.status)
+}
+
+func TestContainerGetTextEmpty(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "100000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("GET", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+}
+
+func TestContainerPutObjectBadRequests(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("PUT", "/device/1/a/c/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "invalid")
+	req.Header.Set("X-Content-Type", "application/octet-stream")
+	req.Header.Set("X-Size", "2")
+	req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("PUT", "/device/1/a/c/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Content-Type", "application/octet-stream")
+	req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("DELETE", "/device/1/a/c/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "invalid")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+}
+
+func TestContainerPutDeleteObjectsGet(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	for _, object := range []string{"1", "2", "3"} {
+		rsp := makeCaptureResponse()
+		req, err := http.NewRequest("PUT", "/device/1/a/c/"+object, nil)
+		require.Nil(t, err)
+		req.Header.Set("X-Timestamp", common.GetTimestamp())
+		req.Header.Set("X-Content-Type", "application/octet-stream")
+		req.Header.Set("X-Size", "2")
+		req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, 201, rsp.status)
+	}
+
+	for _, object := range []string{"1", "2", "3"} {
+		rsp := makeCaptureResponse()
+		req, err := http.NewRequest("DELETE", "/device/1/a/c/"+object, nil)
+		require.Nil(t, err)
+		req.Header.Set("X-Timestamp", common.GetTimestamp())
+		handler.ServeHTTP(rsp, req)
+		require.Equal(t, 204, rsp.status)
+	}
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+	require.Equal(t, "0", rsp.header.Get("X-Container-Object-Count"))
+	require.Equal(t, "0", rsp.header.Get("X-Container-Bytes-Used"))
+}
+
+func TestContainerMetadata(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	req.Header.Set("X-Container-Meta-First", "1")
+	req.Header.Set("X-Container-Meta-Second", "2")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("POST", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Container-Meta-First", "!")
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("POST", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Container-Meta-Second", "@")
+	req.Header.Set("X-Timestamp", common.CanonicalTimestamp(1))
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+	require.Equal(t, "!", rsp.header.Get("X-Container-Meta-First"))
+	require.Equal(t, "2", rsp.header.Get("X-Container-Meta-Second"))
+}
+
+func TestContainerDelete(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("DELETE", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.CanonicalTimestamp(1))
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("DELETE", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 404, rsp.status)
+}
+
+func TestHealthcheck(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("GET", "/healthcheck", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 200, rsp.status)
+	require.Equal(t, "OK", rsp.body.String())
+}
+
+func TestDiskUsage(t *testing.T) {
+	server, handler, cleanup, err := makeTestServer2()
+	require.Nil(t, err)
+	defer cleanup()
+
+	server.diskInUse = common.NewKeyedLimit(2, 8)
+	server.diskInUse.Acquire("sda", false)
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("GET", "/diskusage", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 200, rsp.status)
+	expected, err := server.diskInUse.MarshalJSON()
+	require.Nil(t, err)
+	require.Equal(t, string(expected), string(rsp.body.Bytes()))
+}
+
+func TestGetServer(t *testing.T) {
+	oldgethash := GetHashPrefixAndSuffix
+	oldgetsync := GetSyncRealms
+	defer func() {
+		GetHashPrefixAndSuffix = oldgethash
+		GetSyncRealms = oldgetsync
+	}()
+	GetHashPrefixAndSuffix = func() (string, string, error) {
+		return "changeme", "changeme", nil
+	}
+	GetSyncRealms = func() conf.SyncRealmList {
+		return conf.SyncRealmList(map[string]conf.SyncRealm{})
+	}
+
+	configString := "[app:container-server]\ndevices=whatever\nmount_check=false\nbind_ip=127.0.0.2\nbind_port=1000\nlog_level=INFO\n"
+	conf, err := conf.StringConfig(configString)
+	require.Nil(t, err)
+	bindIP, bindPort, s, logger, err := GetServer(conf, &flag.FlagSet{})
+	require.Nil(t, err)
+	server, ok := s.(*ContainerServer)
+	require.True(t, ok)
+	require.Equal(t, "127.0.0.2", bindIP)
+	require.Equal(t, 1000, bindPort)
+	require.NotNil(t, logger)
+	require.Equal(t, "whatever", server.driveRoot)
+	require.Equal(t, "INFO", server.logLevel)
+	require.False(t, server.checkMounts)
+	require.NotNil(t, server.updateClient)
+	require.NotNil(t, server.containerEngine)
+}
+
+func TestContainerAutoCreateOnPut(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/.a/c/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Content-Type", "application/octet-stream")
+	req.Header.Set("X-Size", "2")
+	req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/.a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+}
+
+func TestContainerAutoCreateOnDelete(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("DELETE", "/device/1/.a/c/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("HEAD", "/device/1/.a/c", nil)
+	require.Nil(t, err)
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+}
+
+func TestContainerNotFoundOnPut(t *testing.T) {
+	handler, cleanup, err := makeTestServer()
+	require.Nil(t, err)
+	defer cleanup()
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/cX/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	req.Header.Set("X-Content-Type", "application/octet-stream")
+	req.Header.Set("X-Size", "2")
+	req.Header.Set("X-Etag", "d41d8cd98f00b204e9800998ecf8427e")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 404, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("DELETE", "/device/1/a/cY/o", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", common.GetTimestamp())
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 404, rsp.status)
+}
+
+func TestContainerVerifySync(t *testing.T) {
+	server, handler, cleanup, err := makeTestServer2()
+	require.Nil(t, err)
+	defer cleanup()
+	server.syncRealms = conf.SyncRealmList(map[string]conf.SyncRealm{
+		"realm1": conf.SyncRealm{
+			Name:     "realm1",
+			Key1:     "somekey",
+			Key2:     "someotherkey",
+			Clusters: map[string]string{"cluster1": "http://some/cluster/url"},
+		},
+	})
+
+	rsp := makeCaptureResponse()
+	req, err := http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	req.Header.Set("X-Container-Sync-To", "//realm2/cluster1/account/container")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("PUT", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	req.Header.Set("X-Container-Sync-To", "//realm1/cluster1/account/container")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 201, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("POST", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	req.Header.Set("X-Container-Sync-To", "//realm2/cluster1/account/container")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 400, rsp.status)
+
+	rsp = makeCaptureResponse()
+	req, err = http.NewRequest("POST", "/device/1/a/c", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Timestamp", "1000000000.00001")
+	req.Header.Set("X-Backend-Storage-Policy-Index", "0")
+	req.Header.Set("X-Container-Sync-To", "//realm1/cluster1/account/container")
+	handler.ServeHTTP(rsp, req)
+	require.Equal(t, 204, rsp.status)
+}

--- a/containerserver/sqlite_backend.go
+++ b/containerserver/sqlite_backend.go
@@ -1,0 +1,1038 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"crypto/md5"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"mime"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mattn/go-sqlite3"
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/pickle"
+)
+
+const (
+	maxQueryArgs       = 990
+	maxOpenConns       = 2
+	maxIdleConns       = 2
+	pendingCap         = 131072
+	maxMetaCount       = 90
+	maxMetaOverallSize = 4096
+)
+
+var infoCacheTimeout = time.Second * 10
+
+func chexor(old, name, timestamp string) string {
+	oldDigest, err := hex.DecodeString(old)
+	if err != nil {
+		panic(fmt.Sprintf("Error decoding hex: %v", err))
+	}
+	h := md5.New()
+	if _, err := io.WriteString(h, name+"-"+timestamp); err != nil {
+		panic("THIS SHOULD NEVER HAPPEN")
+	}
+	digest := h.Sum(nil)
+	for i := range digest {
+		digest[i] ^= oldDigest[i]
+	}
+	return hex.EncodeToString(digest)
+}
+
+func init() {
+	// register our sql driver with user-defined chexor function
+	sql.Register("sqlite3_hummingbird",
+		&sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				if err := conn.RegisterFunc("chexor", chexor, true); err != nil {
+					return err
+				}
+				if _, err := conn.Exec(pragmaScript, nil); err != nil {
+					return err
+				}
+				if _, err := conn.Exec(`CREATE TEMPORARY VIEW IF NOT EXISTS maxrowid (max) AS
+				  						SELECT IFNULL(MAX(seq), -1) FROM sqlite_sequence WHERE name='object'`, nil); err != nil {
+					return err
+				}
+				return nil
+			},
+		},
+	)
+}
+
+// SqliteContainer wraps a connection to the underlying database and provides all of the operations on that database.
+type sqliteContainer struct {
+	connectLock sync.Mutex
+	*sql.DB
+	containerFile       string
+	hasDeletedNameIndex bool
+	infoCache           atomic.Value
+	ringhash            string
+}
+
+var _ Container = &sqliteContainer{}
+
+func (db *sqliteContainer) connect() error {
+	db.connectLock.Lock()
+	defer db.connectLock.Unlock()
+	if db.DB != nil {
+		return nil
+	}
+	dbConn, err := sql.Open("sqlite3_hummingbird", "file:"+db.containerFile+"?psow=1&_txlock=immediate&mode=rw")
+	if err != nil {
+		return fmt.Errorf("Failed to open: %v", err)
+	}
+	dbConn.SetMaxOpenConns(maxOpenConns)
+	dbConn.SetMaxIdleConns(maxIdleConns)
+	hasDeletedNameIndex, err := schemaMigrate(dbConn)
+	if err != nil {
+		db.Close()
+		return fmt.Errorf("Error migrating database: %v", err)
+	}
+	db.hasDeletedNameIndex = hasDeletedNameIndex
+	db.DB = dbConn
+	return nil
+}
+
+// GetInfo returns the container's information as a ContainerInfo struct.
+func (db *sqliteContainer) GetInfo() (*ContainerInfo, error) {
+	if err := db.connect(); err != nil {
+		return nil, err
+	}
+	if err := db.flush(); err != nil {
+		return nil, err
+	}
+	if info, ok := db.infoCache.Load().(*ContainerInfo); ok && !info.invalid && time.Since(info.updated) < infoCacheTimeout {
+		return info, nil
+	}
+	info := &ContainerInfo{updated: time.Now()}
+	row := db.QueryRow(`SELECT cs.account, cs.container, cs.created_at, cs.put_timestamp,
+							cs.delete_timestamp, cs.status_changed_at,
+							cs.object_count, cs.bytes_used,
+							cs.reported_put_timestamp, cs.reported_delete_timestamp,
+							cs.reported_object_count, cs.reported_bytes_used, cs.hash,
+							cs.id, cs.x_container_sync_point1, cs.x_container_sync_point2,
+							cs.storage_policy_index, cs.metadata, maxrowid.max
+						FROM container_stat cs, maxrowid`)
+	if err := row.Scan(&info.Account, &info.Container, &info.CreatedAt, &info.PutTimestamp,
+		&info.DeleteTimestamp, &info.StatusChangedAt, &info.ObjectCount,
+		&info.BytesUsed, &info.ReportedPutTimestamp, &info.ReportedDeleteTimestamp,
+		&info.ReportedObjectCount, &info.ReportedBytesUsed, &info.Hash,
+		&info.ID, &info.XContainerSyncPoint1, &info.XContainerSyncPoint2,
+		&info.StoragePolicyIndex, &info.RawMetadata, &info.MaxRow); err != nil {
+		return nil, err
+	}
+	if info.RawMetadata == "" {
+		info.Metadata = make(map[string][]string)
+	} else if err := json.Unmarshal([]byte(info.RawMetadata), &info.Metadata); err != nil {
+		return nil, err
+	}
+	db.infoCache.Store(info)
+	return info, nil
+}
+
+func (db *sqliteContainer) invalidateCache() {
+	db.infoCache.Store(&ContainerInfo{invalid: true})
+}
+
+// IsDeleted returns true if the container is deleted - if its delete timestamp is later than its put timestamp.
+func (db *sqliteContainer) IsDeleted() (bool, error) {
+	info, err := db.GetInfo()
+	if err != nil {
+		return false, err
+	}
+	return info.DeleteTimestamp > info.PutTimestamp, nil
+}
+
+// Delete sets the container's deleted timestamp and tombstones any metadata older than that timestamp.
+// This may or may not make the container "deleted".
+func (db *sqliteContainer) Delete(timestamp string) error {
+	if err := db.connect(); err != nil {
+		return err
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var metastr string
+	var metadata map[string][]string
+	if err := tx.QueryRow("SELECT metadata FROM container_info").Scan(&metastr); err != nil {
+		return err
+	}
+	if err := json.Unmarshal([]byte(metastr), &metadata); err != nil {
+		return err
+	}
+	for key, value := range metadata {
+		if value[1] < timestamp {
+			metadata[key] = []string{"", timestamp}
+		}
+	}
+	serializedMetadata, err := json.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+	if _, err = tx.Exec("UPDATE container_info SET delete_timestamp = ?, metadata = ?", timestamp, string(serializedMetadata)); err != nil {
+		return err
+	}
+	defer db.invalidateCache()
+	return tx.Commit()
+}
+
+// MergeItems merges ObjectRecords into the container.  If a remote id is provided (incoming replication), the incoming_sync table is updated.
+func (db *sqliteContainer) MergeItems(records []*ObjectRecord, remoteID string) error {
+	if err := db.connect(); err != nil {
+		return err
+	}
+	type recordID struct {
+		policy int
+		name   string
+	}
+	names := make([]interface{}, len(records))
+	existing := make(map[recordID]*ObjectRecord)
+	toAdd := make(map[recordID]*ObjectRecord)
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for i, record := range records {
+		names[i] = record.Name
+	}
+	for i := 0; i < len(records); i += maxQueryArgs {
+		j := i + maxQueryArgs
+		if j > len(records) {
+			j = len(records)
+		}
+		batch := names[i:j]
+		query := ""
+		if db.hasDeletedNameIndex {
+			query = fmt.Sprintf("SELECT name, storage_policy_index, created_at, ROWID FROM object WHERE deleted IN (0, 1) AND name IN (%s)",
+				strings.TrimRight(strings.Repeat("?,", len(batch)), ","))
+		} else {
+			query = fmt.Sprintf("SELECT name, storage_policy_index, created_at, ROWID FROM object WHERE name IN (%s)",
+				strings.TrimRight(strings.Repeat("?,", len(batch)), ","))
+		}
+		rows, err := tx.Query(query, batch...)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			var name, timestamp string
+			var rowid int64
+			var policy int
+			if err := rows.Scan(&name, &policy, &timestamp, &rowid); err != nil {
+				return err
+			}
+			existing[recordID{policy, name}] = &ObjectRecord{CreatedAt: timestamp, Rowid: rowid}
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+	}
+
+	dst, err := tx.Prepare("DELETE FROM object WHERE ROWID=?")
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	ast, err := tx.Prepare("INSERT INTO object (name, created_at, size, content_type, etag, deleted, storage_policy_index) VALUES (?, ?, ?, ?, ?, ?, ?)")
+	if err != nil {
+		return err
+	}
+	defer ast.Close()
+
+	var maxRowid int64 = -1
+	for _, record := range records {
+		if record.Rowid > maxRowid {
+			maxRowid = record.Rowid
+		}
+		rid := recordID{record.StoragePolicyIndex, record.Name}
+		if alreadyIn, ok := toAdd[rid]; !ok || record.CreatedAt > alreadyIn.CreatedAt {
+			current, inExisting := existing[rid]
+			if inExisting && current.CreatedAt < record.CreatedAt {
+				if _, err := dst.Exec(current.Rowid); err != nil {
+					return err
+				}
+				delete(existing, rid)
+				toAdd[rid] = record
+			} else if !inExisting {
+				toAdd[rid] = record
+			}
+		}
+	}
+
+	for _, record := range toAdd {
+		if _, err := ast.Exec(record.Name, record.CreatedAt, record.Size, record.ContentType, record.ETag, record.Deleted, record.StoragePolicyIndex); err != nil {
+			return err
+		}
+	}
+
+	if remoteID != "" && maxRowid > -1 {
+		if _, err := tx.Exec(`UPDATE incoming_sync SET sync_point = ? WHERE remote_id = ?;
+							  INSERT INTO incoming_sync (remote_id, sync_point) SELECT ?, ? WHERE changes() == 0;`,
+			maxRowid, remoteID, remoteID, maxRowid); err != nil {
+			return err
+		}
+	}
+
+	defer db.invalidateCache()
+	return tx.Commit()
+}
+
+func indexAfter(s, sep string, after int) int {
+	index := strings.Index(s[after:], sep)
+	if index == -1 {
+		return -1
+	}
+	return index + after
+}
+
+func updateRecord(rec *ObjectListingRecord) error {
+	f, err := strconv.ParseFloat(rec.LastModified, 64)
+	if err != nil {
+		return err
+	}
+	whole, nans := math.Modf(f)
+	rec.LastModified = time.Unix(int64(whole), int64(nans*1.0e9)).Format("2006-01-02T15:04:05.000000")
+
+	// somewhat dirty check to see if we need to parse the content-type
+	if strings.Contains(rec.ContentType, ";") && strings.Contains(rec.ContentType, "swift_bytes") {
+		contentType, params, err := mime.ParseMediaType(rec.ContentType)
+		if err != nil {
+			return err
+		}
+		for k, v := range params {
+			if k == "swift_bytes" {
+				if rec.Size, err = strconv.ParseInt(v, 0, 64); err != nil {
+					return err
+				}
+				delete(params, k)
+			}
+		}
+		rec.ContentType = mime.FormatMediaType(contentType, params)
+	}
+
+	return nil
+}
+
+// ListObjects implements object listings.  Path is a string pointer because behavior is different for empty and missing path query parameters.
+func (db *sqliteContainer) ListObjects(limit int, marker string, endMarker string, prefix string, delimiter string,
+	path *string, reverse bool, storagePolicyIndex int) ([]interface{}, error) {
+	if err := db.connect(); err != nil {
+		return nil, err
+	}
+	var point, pointDirection, queryTail, queryStart string
+
+	if path != nil {
+		if *path != "" {
+			p := strings.TrimRight(*path, "/") + "/"
+			path = &p
+		}
+		delimiter = "/"
+		prefix = *path
+	}
+	if db.hasDeletedNameIndex {
+		queryStart = "SELECT name, created_at, size, content_type, etag FROM object WHERE deleted = 0 AND"
+	} else {
+		queryStart = "SELECT name, created_at, size, content_type, etag FROM object WHERE +deleted = 0 AND"
+	}
+	if reverse {
+		marker, endMarker = endMarker, marker
+		queryTail = "ORDER BY name DESC LIMIT ?"
+		pointDirection = "name < ?"
+	} else {
+		queryTail = "ORDER BY name LIMIT ?"
+		pointDirection = "name > ?"
+	}
+
+	results := []interface{}{}
+	queryArgs := make([]interface{}, 8)
+	wheres := make([]string, 8)
+	gotResults := true
+
+	for len(results) < limit && gotResults {
+		wheres := append(wheres[:0], "storage_policy_index == ?")
+		queryArgs := append(queryArgs[:0], storagePolicyIndex)
+		if prefix != "" {
+			wheres = append(wheres, "name BETWEEN ? AND ?")
+			queryArgs = append(queryArgs, prefix, prefix+"\xFF")
+		}
+		if marker != "" {
+			wheres = append(wheres, "name > ?")
+			queryArgs = append(queryArgs, marker)
+		}
+		if endMarker != "" {
+			wheres = append(wheres, "name < ?")
+			queryArgs = append(queryArgs, endMarker)
+		}
+		if point != "" {
+			wheres = append(wheres, pointDirection)
+			queryArgs = append(queryArgs, point)
+		}
+		rows, err := db.Query(queryStart+" "+strings.Join(wheres, " AND ")+" "+queryTail,
+			append(queryArgs, limit-len(results))...)
+		if err != nil {
+			return nil, err
+		}
+		gotResults = false
+		for rows.Next() && len(results) < limit {
+			gotResults = true
+			record := &ObjectListingRecord{}
+			if err := rows.Scan(&record.Name, &record.LastModified, &record.Size, &record.ContentType, &record.ETag); err != nil {
+				return nil, err
+			}
+			point = record.Name
+			if delimiter != "" {
+				if path != nil && record.Name == *path {
+					continue
+				}
+				end := indexAfter(record.Name, delimiter, len(prefix))
+				if end >= 0 && (path == nil || len(record.Name) > end+1) {
+					dirName := record.Name[:end] + delimiter
+					if reverse {
+						point = record.Name[:end+len(delimiter)]
+					} else {
+						point = dirName + "\xFF"
+					}
+					if path == nil && dirName != marker {
+						results = append(results, &SubdirListingRecord{Name2: dirName, Name: dirName})
+					}
+					break
+				}
+			}
+			if err := updateRecord(record); err != nil {
+				return nil, err
+			}
+			results = append(results, record)
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		rows.Close()
+		if delimiter == "" && path == nil {
+			break
+		}
+	}
+	return results, nil
+}
+
+// NewID sets the container's ID to a new, random string.
+func (db *sqliteContainer) NewID() error {
+	if err := db.connect(); err != nil {
+		return err
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	_, err = tx.Exec(`INSERT OR REPLACE INTO incoming_sync (remote_id, sync_point)
+					  SELECT container_info.id, maxrowid.max FROM container_info, maxrowid`)
+	if err != nil {
+		return err
+	}
+	if _, err = tx.Exec("UPDATE container_info SET id = ?", common.UUID()); err != nil {
+		return err
+	}
+	defer db.invalidateCache()
+	return tx.Commit()
+}
+
+// ItemsSince returns (count) object records with a rowid greater than (start).
+func (db *sqliteContainer) ItemsSince(start int64, count int) ([]*ObjectRecord, error) {
+	db.flush()
+	records := []*ObjectRecord{}
+	rows, err := db.Query(`SELECT ROWID, name, created_at, size, content_type, etag, deleted, storage_policy_index
+						   FROM object WHERE ROWID > ? ORDER BY ROWID ASC LIMIT ?`, start, count)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		r := &ObjectRecord{}
+		if err := rows.Scan(&r.Rowid, &r.Name, &r.CreatedAt, &r.Size, &r.ContentType, &r.ETag, &r.Deleted, &r.StoragePolicyIndex); err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	rows.Close()
+	return records, nil
+}
+
+// GetMetadata returns the current container metadata as a simple map[string]string, i.e. it leaves out tombstones and timestamps.
+func (db *sqliteContainer) GetMetadata() (map[string]string, error) {
+	info, err := db.GetInfo()
+	if err != nil {
+		return nil, err
+	}
+	metadata := make(map[string]string)
+	for key, value := range info.Metadata {
+		if value[0] != "" {
+			metadata[key] = value[0]
+		}
+	}
+	return metadata, nil
+}
+
+func (db *sqliteContainer) mergeMetas(a map[string][]string, b map[string][]string, deleteTimestamp string) (string, error) {
+	newMeta := map[string][]string{}
+	for k, v := range a {
+		newMeta[k] = v
+	}
+	for k, v := range b {
+		if existing, ok := a[k]; ok {
+			if existing[1] < v[1] {
+				newMeta[k] = v
+			}
+		} else {
+			newMeta[k] = v
+		}
+	}
+	metaSize := 0
+	metaCount := 0
+	for k, v := range newMeta {
+		if deleteTimestamp != "" && v[1] < deleteTimestamp {
+			newMeta[k] = []string{"", deleteTimestamp}
+		} else if v[0] != "" && strings.HasPrefix(strings.ToLower(k), "x-container-meta-") {
+			metaSize += len(k) - 17
+			metaSize += len(v[0])
+			metaCount++
+		}
+	}
+	if metaCount > maxMetaCount || metaSize > maxMetaOverallSize {
+		return "", ErrorInvalidMetadata
+	}
+	serMeta, err := json.Marshal(newMeta)
+	if err != nil {
+		return "", err
+	}
+	return string(serMeta), nil
+}
+
+// UpdateMetadata merges the current container metadata with new incoming metadata.
+func (db *sqliteContainer) UpdateMetadata(newMetadata map[string][]string) error {
+	if err := db.connect(); err != nil {
+		return err
+	}
+	if len(newMetadata) == 0 {
+		return nil
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var metadataValue, deleteTimestamp string
+	if err := tx.QueryRow("SELECT metadata, delete_timestamp FROM container_info").Scan(&metadataValue, &deleteTimestamp); err != nil {
+		return err
+	}
+	var existingMetadata map[string][]string
+	if metadataValue == "" {
+		existingMetadata = map[string][]string{}
+	} else if err := json.Unmarshal([]byte(metadataValue), &existingMetadata); err != nil {
+		return err
+	}
+	metastr, err := db.mergeMetas(existingMetadata, newMetadata, deleteTimestamp)
+	if err != nil {
+		return err
+	}
+	if _, err = tx.Exec("UPDATE container_info SET metadata=?", metastr); err != nil {
+		return err
+	}
+	defer db.invalidateCache()
+	return tx.Commit()
+}
+
+// MergeSyncTable updates the container's current incoming_sync table records.
+func (db *sqliteContainer) MergeSyncTable(records []*SyncRecord) error {
+	if err := db.connect(); err != nil {
+		return err
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	for _, record := range records {
+		if _, err := tx.Exec(`UPDATE incoming_sync SET sync_point = ? WHERE remote_id = ?;
+							  INSERT INTO incoming_sync (remote_id, sync_point) SELECT ?, ? WHERE changes() == 0;`,
+			record.SyncPoint, record.RemoteID, record.RemoteID, record.SyncPoint); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// CleanupTombstones removes any expired tombstoned objects or metadata.
+func (db *sqliteContainer) CleanupTombstones(reclaimAge int64) error {
+	if err := db.connect(); err != nil {
+		return err
+	}
+	now := float64(time.Now().UnixNano()) / 1000000000.0
+	reclaimTimestamp := common.CanonicalTimestamp(now - float64(reclaimAge))
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err = tx.Exec("DELETE FROM object WHERE deleted=1 AND created_at < ?", reclaimTimestamp); err != nil {
+		return err
+	}
+	var metastr string
+	if err := tx.QueryRow("SELECT metadata FROM container_info").Scan(&metastr); err != nil {
+		return err
+	}
+	var metadata map[string][]string
+	updated := false
+	if metastr == "" {
+		metadata = map[string][]string{}
+		updated = true
+	} else {
+		if err := json.Unmarshal([]byte(metastr), &metadata); err != nil {
+			return err
+		}
+		for k, v := range metadata {
+			if v[0] == "" {
+				if ts, err := common.GetEpochFromTimestamp(v[1]); err != nil || ts < reclaimTimestamp {
+					delete(metadata, k)
+					updated = true
+				}
+			}
+		}
+	}
+	if updated {
+		if mb, err := json.Marshal(metadata); err != nil {
+			return err
+		} else if _, err = tx.Exec("UPDATE container_info SET metadata = ?", string(mb)); err != nil {
+			return err
+		}
+	}
+	defer db.invalidateCache()
+	return tx.Commit()
+}
+
+// SyncTable returns the container's current incoming_sync table, and also includes the current container's id and max row as an entry.
+func (db *sqliteContainer) SyncTable() ([]*SyncRecord, error) {
+	if err := db.connect(); err != nil {
+		return nil, err
+	}
+	records := []*SyncRecord{}
+	rows, err := db.Query(`SELECT sync_point, remote_id FROM incoming_sync
+						   WHERE remote_id NOT IN (SELECT id FROM container_info)
+						   UNION
+						   SELECT maxrowid.max AS sync_point, container_info.id AS remote_id
+						   FROM container_info, maxrowid`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		rec := &SyncRecord{}
+		if err := rows.Scan(&rec.SyncPoint, &rec.RemoteID); err != nil {
+			return nil, err
+		}
+		records = append(records, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	rows.Close()
+	return records, nil
+}
+
+// SyncRemoteData compares a remote container's info to the local info and updates any necessary replication bookkeeping, returning the current container's info.
+func (db *sqliteContainer) SyncRemoteData(maxRow int64, hash, id, createdAt, putTimestamp, deleteTimestamp, metadata string) (*ContainerInfo, error) {
+	if err := db.connect(); err != nil {
+		return nil, err
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	var localMeta, localHash, localDeleteTimestamp string
+	var localPoint int64
+	if err := tx.QueryRow("SELECT hash, metadata, delete_timestamp FROM container_info").Scan(&localHash, &localMeta, &localDeleteTimestamp); err != nil {
+		return nil, err
+	}
+	var lm, rm map[string][]string
+	if err := json.Unmarshal([]byte(metadata), &rm); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal([]byte(localMeta), &lm); err != nil {
+		return nil, err
+	}
+	if deleteTimestamp > localDeleteTimestamp {
+		localDeleteTimestamp = deleteTimestamp
+	}
+	metastr, err := db.mergeMetas(lm, rm, localDeleteTimestamp)
+	if _, err = tx.Exec(`UPDATE container_info SET created_at=MIN(?, created_at), put_timestamp=MAX(?, put_timestamp),
+	  					 delete_timestamp=MAX(?, delete_timestamp), metadata=?`,
+		createdAt, putTimestamp, deleteTimestamp, metastr); err != nil {
+		return nil, err
+	}
+	if err := tx.QueryRow("SELECT IFNULL(MAX(sync_point), -1) FROM incoming_sync WHERE remote_id = ?", id).Scan(&localPoint); err != nil {
+		return nil, err
+	}
+	if localHash == hash && maxRow > localPoint {
+		localPoint = maxRow
+		if _, err = tx.Exec("INSERT OR REPLACE INTO incoming_sync (remote_id, sync_point) VALUES (?, ?)", id, localPoint); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	db.invalidateCache()
+	info, err := db.GetInfo()
+	if err != nil {
+		return nil, err
+	}
+	info.Point = localPoint
+	return info, nil
+}
+
+// CheckSyncLink makes sure the database's container sync symlink exists or doesn't exist, as in accordance with the existence of the X-Container-Sync-To header.
+func (db *sqliteContainer) CheckSyncLink() error {
+	metadata, err := db.GetMetadata()
+	if err != nil {
+		return err
+	}
+	containersDir := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(db.containerFile))))
+	deviceDir := filepath.Dir(containersDir)
+	pathFromDataDir, err := filepath.Rel(containersDir, db.containerFile)
+	if err != nil {
+		return err
+	}
+	symLoc := filepath.Join(deviceDir, "sync_containers", pathFromDataDir)
+	if metadata["X-Container-Sync-To"] != "" {
+		if common.Exists(symLoc) {
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(symLoc), 0755); err != nil {
+			return err
+		}
+		return os.Symlink(db.containerFile, symLoc)
+	} else if common.Exists(symLoc) {
+		for err := error(nil); err == nil; symLoc = filepath.Dir(symLoc) {
+			err = os.Remove(symLoc)
+		}
+	}
+	return nil
+}
+
+// OpenDatabaseFile blocks updates and opens the underlying database file for reading, so it can be uploaded to a remote server.
+func (db *sqliteContainer) OpenDatabaseFile() (*os.File, func(), error) {
+	if err := db.connect(); err != nil {
+		return nil, nil, err
+	}
+	var fp *os.File
+	if _, err := db.Exec(`
+		PRAGMA locking_mode = EXCLUSIVE;      -- grab and hold a shared lock
+		SELECT 1 FROM container_info LIMIT 1; -- it doesn't actually lock until you hit the database
+		PRAGMA wal_checkpoint(TRUNCATE);      -- truncate the wal file, if it exists`,
+	); err != nil {
+		return nil, nil, fmt.Errorf("Error locking database%s: %v", db.containerFile, err)
+	}
+	cleanup := func() {
+		db.Exec(`
+			PRAGMA locking_mode = NORMAL;         -- release shared lock
+			SELECT 1 FROM container_info LIMIT 1; -- actually release shared lock
+		`)
+		if fp != nil {
+			fp.Close()
+		}
+	}
+	// make sure there aren't any journals lying around
+	if stat, err := os.Stat(db.containerFile + "-wal"); err == nil && stat.Size() != 0 {
+		cleanup()
+		return nil, nil, fmt.Errorf("Stubborn wal file still exists: %s", db.containerFile)
+	}
+	if stat, err := os.Stat(db.containerFile + "-journal"); err == nil && stat.Size() != 0 {
+		cleanup()
+		return nil, nil, fmt.Errorf("Stubborn journal file still exists: %s", db.containerFile)
+	}
+	fp, err := os.Open(db.containerFile)
+	if err != nil {
+		fp = nil
+		cleanup()
+		return nil, nil, fmt.Errorf("Error opening %s: %v", db.containerFile, err)
+	}
+	return fp, cleanup, nil
+}
+
+// ID returns the container's ring hash as a unique identifier for it.
+func (db *sqliteContainer) ID() string {
+	return db.ringhash
+}
+
+// RingHash returns the container's ring hash as a string.
+func (db *sqliteContainer) RingHash() string {
+	return db.ringhash
+}
+
+func (db *sqliteContainer) flushAlreadyLocked() error {
+	if err := db.connect(); err != nil {
+		return err
+	}
+	if stat, err := os.Stat(db.containerFile + ".pending"); err != nil || stat.Size() == 0 {
+		return nil
+	}
+	contents, err := ioutil.ReadFile(db.containerFile + ".pending")
+	if err != nil || len(contents) == 0 {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var records []*ObjectRecord
+	for _, base64ed := range strings.Split(string(contents), ":") {
+		if len(base64ed) < 1 {
+			continue
+		}
+		pickled, err := base64.StdEncoding.DecodeString(base64ed)
+		if err != nil {
+			continue
+		}
+		r, err := pickle.PickleLoads(pickled)
+		if err != nil {
+			continue
+		}
+		record, ok := r.([]interface{})
+		if !ok || len(record) < 7 {
+			return fmt.Errorf("Invalid commit pending record")
+		}
+		casts := make([]bool, 7)
+		var deleted, policy int64
+		rec := &ObjectRecord{}
+		rec.Name, casts[0] = record[0].(string)
+		rec.CreatedAt, casts[1] = record[1].(string)
+		rec.Size, casts[2] = record[2].(int64)
+		rec.ContentType, casts[3] = record[3].(string)
+		rec.ETag, casts[4] = record[4].(string)
+		deleted, casts[5] = record[5].(int64)
+		policy, casts[6] = record[6].(int64)
+		rec.Deleted = int(deleted)
+		rec.StoragePolicyIndex = int(policy)
+		for i := 0; i < 7; i++ {
+			if !casts[i] {
+				return fmt.Errorf("Invalid commit pending record")
+			}
+		}
+		records = append(records, rec)
+	}
+	err = db.MergeItems(records, "")
+	if err == nil {
+		err = os.Truncate(db.containerFile+".pending", 0)
+	}
+	return err
+}
+
+func (db *sqliteContainer) flush() error {
+	lock, err := common.LockPath(filepath.Dir(db.containerFile), 10*time.Second)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	return db.flushAlreadyLocked()
+}
+
+func (db *sqliteContainer) addObject(name string, timestamp string, size int64, contentType string, etag string, deleted int, storagePolicyIndex int) error {
+	lock, err := common.LockPath(filepath.Dir(db.containerFile), 10*time.Second)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	tuple := []interface{}{name, timestamp, size, contentType, etag, deleted, storagePolicyIndex}
+	file, err := os.OpenFile(db.containerFile+".pending", os.O_RDWR|os.O_APPEND|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if _, err := file.WriteString(":" + base64.StdEncoding.EncodeToString(pickle.PickleDumps(tuple))); err != nil {
+		return err
+	}
+	if info, err := file.Stat(); err == nil && info.Size() > pendingCap {
+		db.flushAlreadyLocked()
+	}
+	return nil
+}
+
+// PutObject adds an object to the container, by way of pending file.
+func (db *sqliteContainer) PutObject(name string, timestamp string, size int64, contentType string, etag string, storagePolicyIndex int) error {
+	return db.addObject(name, timestamp, size, contentType, etag, 0, storagePolicyIndex)
+}
+
+// DeleteObject removes an object from the container, by way of pending file.
+func (db *sqliteContainer) DeleteObject(name string, timestamp string, storagePolicyIndex int) error {
+	return db.addObject(name, timestamp, 0, "", "", 1, storagePolicyIndex)
+}
+
+// Close closes the underlying sqlite database connection.
+func (db *sqliteContainer) Close() error {
+	db.connectLock.Lock()
+	defer func() {
+		db.DB = nil
+		db.connectLock.Unlock()
+	}()
+	if db.DB != nil {
+		return db.DB.Close()
+	}
+	return nil
+}
+
+func sqliteCreateExistingContainer(db Container, putTimestamp string, newMetadata map[string][]string, policyIndex, defaultPolicyIndex int) (bool, error) {
+	cdb, ok := db.(*sqliteContainer)
+	if !ok {
+		return false, errors.New("Unable to work with non-sqliteContainer")
+	}
+	if err := cdb.connect(); err != nil {
+		return false, err
+	}
+	tx, err := cdb.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+	var cDeleteTimestamp, cPutTimestamp, cMetadata string
+	var cPolicyIndex int
+	row := tx.QueryRow("SELECT put_timestamp, delete_timestamp, storage_policy_index, metadata FROM container_info")
+	if err := row.Scan(&cPutTimestamp, &cDeleteTimestamp, &cPolicyIndex, &cMetadata); err != nil {
+		return false, err
+	}
+	if cDeleteTimestamp <= cPutTimestamp { // not deleted
+		if policyIndex < 0 {
+			policyIndex = cPolicyIndex
+		} else if cPolicyIndex != policyIndex {
+			return false, ErrorPolicyConflict
+		}
+	} else { // deleted
+		if policyIndex < 0 {
+			policyIndex = defaultPolicyIndex
+		}
+	}
+	var existingMetadata map[string][]string
+	if cMetadata == "" {
+		existingMetadata = make(map[string][]string)
+	} else if err := json.Unmarshal([]byte(cMetadata), &existingMetadata); err != nil {
+		return false, err
+	}
+	metastr, err := cdb.mergeMetas(existingMetadata, newMetadata, cDeleteTimestamp)
+	if err != nil {
+		return false, err
+	}
+	if _, err := tx.Exec("UPDATE container_info SET put_timestamp = ?, storage_policy_index = ?, metadata = ?",
+		putTimestamp, policyIndex, metastr); err != nil {
+		return false, err
+	}
+	defer cdb.invalidateCache()
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return (cDeleteTimestamp > cPutTimestamp && putTimestamp > cDeleteTimestamp), nil
+}
+
+func sqliteCreateContainer(containerFile string, account string, container string, putTimestamp string,
+	metadata map[string][]string, policyIndex int) error {
+	var serializedMetadata []byte
+	var err error
+
+	if common.Exists(containerFile) {
+		return errors.New("Container exists!")
+	}
+	if metadata == nil {
+		serializedMetadata = []byte("{}")
+	} else if serializedMetadata, err = json.Marshal(metadata); err != nil {
+		return err
+	}
+	hashDir := filepath.Dir(containerFile)
+	if err := os.MkdirAll(hashDir, 0755); err != nil {
+		return err
+	}
+	tfp, err := ioutil.TempFile(hashDir, ".newdb")
+	if err != nil {
+		return err
+	}
+	if err := tfp.Chmod(0644); err != nil {
+		return err
+	}
+	defer tfp.Close()
+	tempFile := tfp.Name()
+	dbConn, err := sql.Open("sqlite3_hummingbird", "file:"+tempFile+"?psow=1&_txlock=immediate&mode=rwc")
+	if err != nil {
+		return err
+	}
+	defer dbConn.Close()
+	tx, err := dbConn.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(objectTableScript + policyStatTableScript + policyStatTriggerScript +
+		containerInfoTableScript + containerStatViewScript + syncTableScript); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`INSERT INTO container_info (account, container, created_at, id, put_timestamp,
+						  status_changed_at, storage_policy_index, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		account, container, common.GetTimestamp(), common.UUID(), putTimestamp,
+		putTimestamp, policyIndex, string(serializedMetadata)); err != nil {
+		return err
+	}
+	if _, err := tx.Exec("INSERT INTO policy_stat (storage_policy_index) VALUES (?)", policyIndex); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempFile, containerFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+func sqliteOpenContainer(containerFile string) (ReplicableContainer, error) {
+	if !common.Exists(containerFile) {
+		return nil, ErrorNoSuchContainer
+	}
+	db := &sqliteContainer{
+		containerFile:       containerFile,
+		hasDeletedNameIndex: false,
+		ringhash:            filepath.Base(filepath.Dir(containerFile)),
+	}
+	return db, nil
+}

--- a/containerserver/sqlite_backend_test.go
+++ b/containerserver/sqlite_backend_test.go
@@ -1,0 +1,682 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/troubling/hummingbird/common"
+)
+
+func BenchmarkMergeItems(b *testing.B) {
+	db, _, cleanup, _ := createTestDatabase("200000000.00000")
+	recs := make([]*ObjectRecord, 10000)
+	for i := 0; i < b.N; i++ {
+		for i := 0; i < 10000; i++ {
+			recs[i] = &ObjectRecord{Name: common.UUID(), CreatedAt: "20000000.00001", Deleted: 1}
+		}
+		db.MergeItems(recs, "")
+		db.MergeItems(recs, "")
+	}
+	cleanup()
+}
+
+func BenchmarkContainerListings(b *testing.B) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	if err != nil {
+		panic("NON-NIL ERROR")
+	}
+	defer cleanup()
+	names := make([]string, 8192)
+	for i := range names {
+		names[i] = common.UUID()
+	}
+	if err := mergeItemsByName(db, names); err != nil {
+		panic("NON-NIL ERROR")
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		records, err := db.ListObjects(10000, "", "", "", "", nil, false, 0)
+		if err != nil {
+			panic("NON-NIL ERROR")
+		}
+		if records == nil {
+			panic("NIL RECORDS")
+		}
+	}
+}
+
+func TestContainerListings(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c"}))
+	records, err := db.ListObjects(10000, "", "", "", "", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(records))
+	require.Equal(t, "a", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "b", records[1].(*ObjectListingRecord).Name)
+	require.Equal(t, "c", records[2].(*ObjectListingRecord).Name)
+}
+
+func TestContainerUpdateRecord(t *testing.T) {
+	rec := &ObjectListingRecord{Name: "a", ContentType: "text/plain; swift_bytes=100", LastModified: "1.0"}
+	require.Nil(t, updateRecord(rec))
+	require.Equal(t, int64(100), rec.Size)
+
+	rec = &ObjectListingRecord{Name: "a", ContentType: "text/plain; swift_bytes=100", LastModified: "X"}
+	require.NotNil(t, updateRecord(rec))
+
+	rec = &ObjectListingRecord{Name: "a", ContentType: "text/plain; swift_bytes=X", LastModified: "1.0"}
+	require.NotNil(t, updateRecord(rec))
+}
+
+func TestContainerListingsLimit(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c"}))
+	records, err := db.ListObjects(2, "", "", "", "", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "a", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "b", records[1].(*ObjectListingRecord).Name)
+}
+
+func TestContainerListingsPrefixChange(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"b10\u2603"}))
+	records, err := db.ListObjects(10000, "", "", "b10", "", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(records))
+}
+
+func TestContainerListingsPrefix(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"a1", "a2", "A3", "b1", "B2", "a10", "b10", "zz"}))
+	records, err := db.ListObjects(10000, "", "", "a", "", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(records))
+	require.Equal(t, "a1", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "a10", records[1].(*ObjectListingRecord).Name)
+	require.Equal(t, "a2", records[2].(*ObjectListingRecord).Name)
+
+	records, err = db.ListObjects(10000, "", "", "b10", "", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(records))
+	require.Equal(t, "b10", records[0].(*ObjectListingRecord).Name)
+}
+
+func TestContainerListingsPrefixLimit(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"a1", "b1", "a2", "b2", "a3", "b3"}))
+	records, err := db.ListObjects(2, "", "", "a", "", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "a1", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "a2", records[1].(*ObjectListingRecord).Name)
+}
+
+func TestContainerListingsPrefixDelim(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"US-TX-A", "US-TX-B", "US-OK-A", "US-OK-B", "US-UT-A"}))
+	records, err := db.ListObjects(10000, "", "", "US-", "-", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(records))
+	require.Equal(t, "US-OK-", records[0].(*SubdirListingRecord).Name)
+	require.Equal(t, "US-TX-", records[1].(*SubdirListingRecord).Name)
+	require.Equal(t, "US-UT-", records[2].(*SubdirListingRecord).Name)
+}
+
+func TestContainerLeadingDelimiter(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"US-TX-A", "US-TX-B", "-UK", "-CH"}))
+	records, err := db.ListObjects(10000, "", "", "", "-", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "-", records[0].(*SubdirListingRecord).Name)
+	require.Equal(t, "US-", records[1].(*SubdirListingRecord).Name)
+}
+
+func TestContainerMarkers(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c", "d", "e", "f"}))
+	records, err := db.ListObjects(10000, "b", "e", "", "", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "c", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "d", records[1].(*ObjectListingRecord).Name)
+}
+
+func TestContainerReverse(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c"}))
+	records, err := db.ListObjects(10000, "", "", "", "", nil, true, 0)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(records))
+	require.Equal(t, "c", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "b", records[1].(*ObjectListingRecord).Name)
+	require.Equal(t, "a", records[2].(*ObjectListingRecord).Name)
+}
+
+func TestContainerReverseMarkers(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c", "d", "e", "f"}))
+	records, err := db.ListObjects(10000, "e", "b", "", "", nil, true, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "d", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "c", records[1].(*ObjectListingRecord).Name)
+}
+
+func TestContainerListingsReversePrefixDelim(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"US-TX-A", "US-TX-B", "US-OK-A", "US-OK-B", "US-UT-A"}))
+	records, err := db.ListObjects(10000, "", "", "US-", "-", nil, true, 0)
+	require.Nil(t, err)
+	require.Equal(t, 3, len(records))
+	require.Equal(t, "US-UT-", records[0].(*SubdirListingRecord).Name)
+	require.Equal(t, "US-TX-", records[1].(*SubdirListingRecord).Name)
+	require.Equal(t, "US-OK-", records[2].(*SubdirListingRecord).Name)
+}
+
+func TestContainerListingsDelimiterAndPrefix(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"bar", "bazar"}))
+	records, err := db.ListObjects(10000, "", "", "ba", "a", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "bar", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "baza", records[1].(*SubdirListingRecord).Name)
+
+	records, err = db.ListObjects(10000, "", "", "ba", "a", nil, true, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "baza", records[0].(*SubdirListingRecord).Name)
+	require.Equal(t, "bar", records[1].(*ObjectListingRecord).Name)
+}
+
+func TestContainerListingsDelimiter(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, []string{"test", "test-bar", "test-foo"}))
+	records, err := db.ListObjects(10000, "", "", "", "-", nil, false, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "test", records[0].(*ObjectListingRecord).Name)
+	require.Equal(t, "test-", records[1].(*SubdirListingRecord).Name)
+
+	records, err = db.ListObjects(10000, "", "", "", "-", nil, true, 0)
+	require.Nil(t, err)
+	require.Equal(t, 2, len(records))
+	require.Equal(t, "test-", records[0].(*SubdirListingRecord).Name)
+	require.Equal(t, "test", records[1].(*ObjectListingRecord).Name)
+}
+
+func TestContainerListingsPaths(t *testing.T) {
+	files := []string{
+		"/file1",
+		"/file A",
+		"/dir1/",
+		"/dir2/",
+		"/dir1/file2",
+		"/dir1/subdir1/",
+		"/dir1/subdir2/",
+		"/dir1/subdir1/file2",
+		"/dir1/subdir1/file3",
+		"/dir1/subdir1/file4",
+		"/dir1/subdir1/subsubdir1/",
+		"/dir1/subdir1/subsubdir1/file5",
+		"/dir1/subdir1/subsubdir1/file6",
+		"/dir1/subdir1/subsubdir1/file7",
+		"/dir1/subdir1/subsubdir1/file8",
+		"/dir1/subdir1/subsubdir2/",
+		"/dir1/subdir1/subsubdir2/file9",
+		"/dir1/subdir1/subsubdir2/file0",
+		"file1",
+		"dir1/",
+		"dir2/",
+		"dir1/file2",
+		"dir1/subdir1/",
+		"dir1/subdir2/",
+		"dir1/subdir1/file2",
+		"dir1/subdir1/file3",
+		"dir1/subdir1/file4",
+		"dir1/subdir1/subsubdir1/",
+		"dir1/subdir1/subsubdir1/file5",
+		"dir1/subdir1/subsubdir1/file6",
+		"dir1/subdir1/subsubdir1/file7",
+		"dir1/subdir1/subsubdir1/file8",
+		"dir1/subdir1/subsubdir2/",
+		"dir1/subdir1/subsubdir2/file9",
+		"dir1/subdir1/subsubdir2/file0",
+		"dir1/subdir with spaces/",
+		"dir1/subdir with spaces/file B",
+		"dir1/subdir+with{whatever/",
+		"dir1/subdir+with{whatever/file D",
+	}
+
+	db, _, cleanup, err := createTestDatabase("100000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	require.Nil(t, mergeItemsByName(db, files))
+	assertListing := func(path string, expected []string) {
+		sort.Strings(expected)
+		records, err := db.ListObjects(10000, "", "", "", "-", &path, false, 0)
+		require.Nil(t, err)
+		require.Equal(t, len(expected), len(records))
+		for i, rec := range records {
+			require.Equal(t, expected[i], rec.(*ObjectListingRecord).Name)
+		}
+	}
+
+	assertListing("/", []string{"/dir1/", "/dir2/", "/file1", "/file A"})
+	assertListing("/dir1",
+		[]string{"/dir1/file2", "/dir1/subdir1/", "/dir1/subdir2/"})
+	assertListing("/dir1/",
+		[]string{"/dir1/file2", "/dir1/subdir1/", "/dir1/subdir2/"})
+	assertListing("/dir1/subdir1",
+		[]string{"/dir1/subdir1/subsubdir2/", "/dir1/subdir1/file2",
+			"/dir1/subdir1/file3", "/dir1/subdir1/file4",
+			"/dir1/subdir1/subsubdir1/"})
+	assertListing("/dir1/subdir2", []string{})
+	assertListing("", []string{"file1", "dir1/", "dir2/"})
+
+	assertListing("dir1", []string{"dir1/file2", "dir1/subdir1/",
+		"dir1/subdir2/", "dir1/subdir with spaces/",
+		"dir1/subdir+with{whatever/"})
+	assertListing("dir1/subdir1",
+		[]string{"dir1/subdir1/file4", "dir1/subdir1/subsubdir2/",
+			"dir1/subdir1/file2", "dir1/subdir1/file3",
+			"dir1/subdir1/subsubdir1/"})
+	assertListing("dir1/subdir1/subsubdir1",
+		[]string{"dir1/subdir1/subsubdir1/file7",
+			"dir1/subdir1/subsubdir1/file5",
+			"dir1/subdir1/subsubdir1/file8",
+			"dir1/subdir1/subsubdir1/file6"})
+	assertListing("dir1/subdir1/subsubdir1/",
+		[]string{"dir1/subdir1/subsubdir1/file7",
+			"dir1/subdir1/subsubdir1/file5",
+			"dir1/subdir1/subsubdir1/file8",
+			"dir1/subdir1/subsubdir1/file6"})
+	assertListing("dir1/subdir with spaces/",
+		[]string{"dir1/subdir with spaces/file B"})
+
+}
+
+func TestCreateAndGetInfo(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+	dbFile := filepath.Join(dir, "db.db")
+	metadata := map[string][]string{
+		"X-Container-Meta-Hi": []string{"There", "100000000.00001"},
+	}
+	err = sqliteCreateContainer(dbFile, "a", "c", "100000000.00000", metadata, 2)
+	require.Nil(t, err)
+	db, err := sqliteOpenContainer(dbFile)
+	require.Nil(t, err)
+	defer db.Close()
+	info, err := db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, "a", info.Account)
+	require.Equal(t, "c", info.Container)
+	require.Equal(t, "100000000.00000", info.PutTimestamp)
+	require.Equal(t, int64(0), info.ObjectCount)
+	require.Equal(t, int64(0), info.BytesUsed)
+	require.Equal(t, metadata, info.Metadata)
+	require.Equal(t, 2, info.StoragePolicyIndex)
+}
+
+func TestDeleteIsDeleted(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+
+	require.Nil(t, db.Delete("100000001.00000"))
+	deleted, err := db.IsDeleted()
+	require.Nil(t, err)
+	require.False(t, deleted)
+
+	require.Nil(t, db.Delete("200000001.00000"))
+	deleted, err = db.IsDeleted()
+	require.Nil(t, err)
+	require.True(t, deleted)
+}
+
+func TestMergeItems(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c"}))
+	info, err := db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, int64(3), info.ObjectCount)
+
+	require.Nil(t, mergeItemsByName(db, []string{"c", "d", "e"}))
+	info, err = db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, int64(5), info.ObjectCount)
+
+	require.Nil(t, db.MergeItems([]*ObjectRecord{&ObjectRecord{Name: "a", CreatedAt: "20000000.00001", Deleted: 1}}, ""))
+	info, err = db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, int64(4), info.ObjectCount)
+}
+
+func TestIndexAfter(t *testing.T) {
+	require.Equal(t, 5, indexAfter(",    ,", ",", 3))
+	require.Equal(t, 4, indexAfter("    ,,", ",", 3))
+	require.Equal(t, -1, indexAfter(",,,   ", ",", 3))
+}
+
+func TestNewID(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	info, err := db.GetInfo()
+	require.Nil(t, err)
+	oldID := info.ID
+	require.Nil(t, db.NewID())
+	info, err = db.GetInfo()
+	require.NotEqual(t, oldID, info.ID)
+}
+
+func TestGetUpdateMetadata(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+	dbFile := filepath.Join(dir, "db.db")
+	metadata := map[string][]string{
+		"X-Container-Meta-Hi": []string{"There", "200000000.00001"},
+	}
+	metadataValues := map[string]string{
+		"X-Container-Meta-Hi": "There",
+	}
+	err = sqliteCreateContainer(dbFile, "a", "c", "200000000.00000", metadata, 0)
+	require.Nil(t, err)
+	db, err := sqliteOpenContainer(dbFile)
+	require.Nil(t, err)
+	defer db.Close()
+	info, err := db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, metadata, info.Metadata)
+	m, err := db.GetMetadata()
+	require.Nil(t, err)
+	require.Equal(t, metadataValues, m)
+
+	require.Nil(t, db.UpdateMetadata(map[string][]string{
+		"X-Container-Meta-Hi": []string{"", "100000000.00001"},
+	}))
+	m, err = db.GetMetadata()
+	require.Nil(t, err)
+	require.Equal(t, metadataValues, m)
+
+	require.Nil(t, db.UpdateMetadata(map[string][]string{
+		"X-Container-Meta-Hi":         []string{"", "200000001.00001"},
+		"X-Container-Meta-Some-Other": []string{"value", "200000001.00001"},
+	}))
+	require.Nil(t, db.UpdateMetadata(map[string][]string{}))
+	m, err = db.GetMetadata()
+	require.Nil(t, err)
+	require.Equal(t, map[string]string{"X-Container-Meta-Some-Other": "value"}, m)
+}
+
+func TestItemsSince(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c", "d", "e", "f", "g", "h"}))
+
+	objs, err := db.ItemsSince(-1, 1)
+	require.Nil(t, err)
+	require.Equal(t, 1, len(objs))
+
+	objs, err = db.ItemsSince(objs[0].Rowid, 1000)
+	require.Nil(t, err)
+	require.Equal(t, 7, len(objs))
+}
+
+func TestMergeSyncTable(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	info, err := db.GetInfo()
+	require.Nil(t, err)
+	someSyncs := []*SyncRecord{
+		&SyncRecord{SyncPoint: 5, RemoteID: "some guy I guess"},
+		&SyncRecord{SyncPoint: 1, RemoteID: "some other guy"},
+	}
+	require.Nil(t, db.MergeSyncTable(someSyncs))
+	points, err := db.SyncTable()
+	expectedSyncs := map[string]int64{
+		"some guy I guess": 5,
+		"some other guy":   1,
+		info.ID:            info.MaxRow,
+	}
+	actualSyncs := map[string]int64{}
+	for i := range points {
+		actualSyncs[points[i].RemoteID] = points[i].SyncPoint
+	}
+	require.Equal(t, expectedSyncs, actualSyncs)
+	newSyncs := []*SyncRecord{
+		&SyncRecord{SyncPoint: 1000000, RemoteID: "some other guy"},
+		&SyncRecord{SyncPoint: 10, RemoteID: "new guy"},
+	}
+	require.Nil(t, db.MergeSyncTable(newSyncs))
+	expectedSyncs = map[string]int64{
+		"some guy I guess": 5,
+		"some other guy":   1000000,
+		"new guy":          10,
+		info.ID:            info.MaxRow,
+	}
+	points, err = db.SyncTable()
+	actualSyncs = map[string]int64{}
+	for i := range points {
+		actualSyncs[points[i].RemoteID] = points[i].SyncPoint
+	}
+	require.Equal(t, expectedSyncs, actualSyncs)
+}
+
+func TestSyncRemoteData(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("1000.0001")
+	require.Nil(t, err)
+	defer cleanup()
+
+	info, err := db.SyncRemoteData(1, "00000000000000000000000000000000", "your friend", "1000.0001", "1000.0001", "", "{}")
+	require.Nil(t, err)
+	require.Equal(t, int64(-1), info.MaxRow)
+	require.Equal(t, int64(1), info.Point)
+
+	require.Nil(t, mergeItemsByName(db, []string{"a", "b", "c", "d", "e", "f", "g", "h"}))
+	info, err = db.SyncRemoteData(1, "00000000000000000000000000000000", "your friend", "1000.0001", "1000.0001", "", "{}")
+	require.Nil(t, err)
+	require.Equal(t, int64(8), info.MaxRow)
+	require.Equal(t, int64(1), info.Point)
+
+	info, err = db.SyncRemoteData(10, "11111111111111111111111111111111", "your friend", "1000.0001", "1000.0001", "", "{}")
+	require.Nil(t, err)
+	require.Equal(t, int64(8), info.MaxRow)
+	require.Equal(t, int64(1), info.Point)
+
+	info, err = db.SyncRemoteData(10, "ae856a680962e8afedde3f2d657ed5b4", "your friend", "1000.0001", "1000.0001", "", "{}")
+	require.Nil(t, err)
+	require.Equal(t, int64(8), info.MaxRow)
+	require.Equal(t, int64(10), info.Point)
+
+	info, err = db.SyncRemoteData(10, "ae856a680962e8afedde3f2d657ed5b4", "your friend", "1000.0001", "1000.0001", "2000.0002", "{}")
+	require.Nil(t, err)
+	deleted, err := db.IsDeleted()
+	require.Nil(t, err)
+	require.True(t, deleted)
+
+	info, err = db.SyncRemoteData(10, "ae856a680962e8afedde3f2d657ed5b4", "your friend", "1000.0001", "3000.0003", "2000.0002", "{}")
+	require.Nil(t, err)
+	deleted, err = db.IsDeleted()
+	require.Nil(t, err)
+	require.False(t, deleted)
+
+	meta, err := db.GetMetadata()
+	require.Nil(t, err)
+	require.Equal(t, 0, len(meta))
+
+	info, err = db.SyncRemoteData(10, "ae856a680962e8afedde3f2d657ed5b4", "your friend", "1000.0001", "3000.0003", "2000.0002",
+		"{\"X-Container-Meta-Hi\": [\"I'm your friend\", \"2000.0001\"]}")
+	require.Nil(t, err)
+	meta, err = db.GetMetadata()
+	require.Nil(t, err)
+	require.Equal(t, 0, len(meta))
+
+	info, err = db.SyncRemoteData(10, "ae856a680962e8afedde3f2d657ed5b4", "your friend", "1000.0001", "3000.0003", "2000.0002",
+		"{\"X-Container-Meta-Hi\": [\"I'm your friend\", \"2001.0000\"]}")
+	require.Nil(t, err)
+	meta, err = db.GetMetadata()
+	require.Nil(t, err)
+	require.Equal(t, map[string]string{"X-Container-Meta-Hi": "I'm your friend"}, meta)
+
+	info, err = db.SyncRemoteData(10, "ae856a680962e8afedde3f2d657ed5b4", "your friend", "1000.0001", "3000.0003", "2000.0002",
+		"{\"X-Container-Meta-Hi\": [\"\", \"2001.0001\"]}")
+	require.Nil(t, err)
+	meta, err = db.GetMetadata()
+	require.Nil(t, err)
+	require.Equal(t, 0, len(meta))
+}
+
+func TestCreateExistingNoPolicy(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+
+	c, err := sqliteCreateExistingContainer(db, "200000001.00000", map[string][]string{}, -1, 0)
+	require.Nil(t, err)
+	require.False(t, c)
+	info, err := db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, info.StoragePolicyIndex, 0)
+
+	c, err = sqliteCreateExistingContainer(db, "200000001.00000", map[string][]string{}, 7, 0)
+	require.NotNil(t, err)
+
+	newMetadata := map[string][]string{
+		"X-Container-Meta-Whatever": []string{"something", "200000002.00000"},
+	}
+	c, err = sqliteCreateExistingContainer(db, "200000002.00000", newMetadata, -1, 0)
+	require.Nil(t, err)
+	require.False(t, c)
+	info, err = db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, info.Metadata, newMetadata)
+
+	newMetadata = map[string][]string{
+		"X-Container-Meta-Another": []string{"whatevs", "200000003.00000"},
+	}
+	c, err = sqliteCreateExistingContainer(db, "200000003.00000", newMetadata, -1, 0)
+	require.Nil(t, err)
+	require.False(t, c)
+	info, err = db.GetInfo()
+	require.Nil(t, err)
+	require.Equal(t, info.Metadata, map[string][]string{
+		"X-Container-Meta-Another":  []string{"whatevs", "200000003.00000"},
+		"X-Container-Meta-Whatever": []string{"something", "200000002.00000"},
+	})
+}
+
+func TestCleanupTombstones(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+
+	require.Nil(t, db.MergeItems([]*ObjectRecord{&ObjectRecord{Name: "a", CreatedAt: "10000000.00000", Deleted: 0}}, ""))
+	db.UpdateMetadata(map[string][]string{
+		"X-Container-Meta-Old-Value": []string{"", "10000000.00000"},
+	})
+	info, err := db.GetInfo()
+	require.Nil(t, err)
+	_, ok := info.Metadata["X-Container-Meta-Old-Value"]
+	require.True(t, ok)
+	require.Nil(t, db.MergeItems([]*ObjectRecord{&ObjectRecord{Name: "a", CreatedAt: "10000001.00000", Deleted: 1}}, ""))
+	require.Nil(t, db.CleanupTombstones(0))
+	info, err = db.GetInfo()
+	require.Nil(t, err)
+	_, ok = info.Metadata["X-Container-Meta-Old-Value"]
+	require.False(t, ok)
+	var count int
+	require.Nil(t, db.QueryRow("SELECT COUNT(*) FROM object").Scan(&count))
+	require.Equal(t, 0, count)
+}
+
+func TestDeleteRemovesMetadata(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+
+	db.UpdateMetadata(map[string][]string{
+		"X-Container-Meta-Key": []string{"Value", "200000000.00001"},
+	})
+	require.Nil(t, db.Delete("200000001.00000"))
+	deleted, err := db.IsDeleted()
+	require.Nil(t, err)
+	require.True(t, deleted)
+	metadata, err := db.GetMetadata()
+	require.Nil(t, err)
+	require.Equal(t, 0, len(metadata))
+}
+
+func TestCheckSyncLink(t *testing.T) {
+	db, _, cleanup, err := createTestDatabase("200000000.00000")
+	require.Nil(t, err)
+	defer cleanup()
+	link := strings.Replace(db.containerFile, "containers", "sync_containers", -1)
+	db.UpdateMetadata(map[string][]string{
+		"X-Container-Sync-To": []string{"//realm/cluster/a/c", "200000000.00001"},
+	})
+	db.CheckSyncLink()
+	require.True(t, common.Exists(link))
+	db.UpdateMetadata(map[string][]string{
+		"X-Container-Sync-To": []string{"", "200000001.00001"},
+	})
+	db.CheckSyncLink()
+	require.False(t, common.Exists(link))
+}

--- a/containerserver/update.go
+++ b/containerserver/update.go
@@ -1,0 +1,79 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/srv"
+)
+
+var waitForAccountUpdate = time.Second * 5
+
+func (server *ContainerServer) accountUpdate(request *http.Request, vars map[string]string, info *ContainerInfo, logger srv.LoggingContext) {
+	firstDone := make(chan struct{}, 1)
+	go func() {
+		defer func() { firstDone <- struct{}{} }()
+		defer logger.LogPanics("PANIC WHILE UPDATING ACCOUNT")
+		accpartition := request.Header.Get("X-Account-Partition")
+		if accpartition == "" {
+			logger.LogError("Account update failed: bad partition")
+			return
+		}
+		hosts := strings.Split(request.Header.Get("X-Account-Host"), ",")
+		devices := strings.Split(request.Header.Get("X-Account-Device"), ",")
+		if len(hosts) != len(devices) {
+			logger.LogError("Account update failed: different numbers of hosts and devices in request")
+			return
+		}
+		for index, host := range hosts {
+			url := fmt.Sprintf("http://%s/%s/%s/%s/%s", host, devices[index], accpartition,
+				common.Urlencode(vars["account"]), common.Urlencode(vars["container"]))
+			req, err := http.NewRequest("PUT", url, nil)
+			if err != nil {
+				logger.LogError("Account update failed: error creating request object")
+				continue
+			}
+			req.Header.Add("X-Put-Timestamp", info.PutTimestamp)
+			req.Header.Add("X-Delete-Timestamp", info.DeleteTimestamp)
+			req.Header.Add("X-Object-Count", strconv.FormatInt(info.ObjectCount, 10))
+			req.Header.Add("X-Bytes-Used", strconv.FormatInt(info.BytesUsed, 10))
+			req.Header.Add("X-Trans-Id", request.Header.Get("X-Trans-Id"))
+			req.Header.Add("X-Backend-Storage-Policy-Index", strconv.Itoa(info.StoragePolicyIndex))
+			if request.Header.Get("X-Account-Override-Deleted") == "yes" {
+				req.Header.Add("X-Account-Override-Deleted", "yes")
+			}
+			resp, err := server.updateClient.Do(req)
+			if err != nil {
+				logger.LogError("Account update failed: bad response from %s/%s", hosts[index], devices[index])
+				continue
+			}
+			defer resp.Body.Close()
+			if (resp.StatusCode / 100) != 2 {
+				logger.LogError("Account update failed: bad response from %s/%s", hosts[index], devices[index])
+			}
+		}
+	}()
+	select {
+	case <-time.After(waitForAccountUpdate):
+	case <-firstDone:
+	}
+}

--- a/containerserver/update_test.go
+++ b/containerserver/update_test.go
@@ -1,0 +1,116 @@
+//  Copyright (c) 2016 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package containerserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountUpdate(t *testing.T) {
+	info := &ContainerInfo{
+		PutTimestamp:       "puttimestamp",
+		DeleteTimestamp:    "deletetimestamp",
+		ObjectCount:        1,
+		BytesUsed:          1024,
+		StoragePolicyIndex: 2,
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/adevice/3/a/c", r.URL.Path)
+		require.Equal(t, "puttimestamp", r.Header.Get("X-Put-Timestamp"))
+		require.Equal(t, "deletetimestamp", r.Header.Get("X-Delete-Timestamp"))
+		require.Equal(t, "1", r.Header.Get("X-Object-Count"))
+		require.Equal(t, "1024", r.Header.Get("X-Bytes-Used"))
+		require.Equal(t, "atxid", r.Header.Get("X-Trans-Id"))
+		require.Equal(t, "2", r.Header.Get("X-Backend-Storage-Policy-Index"))
+	}))
+	defer ts.Close()
+	url, err := url.Parse(ts.URL)
+	require.Nil(t, err)
+	server := &ContainerServer{updateClient: http.DefaultClient}
+	request, err := http.NewRequest("PUT", "http://127.0.0.1/device/partition/account/container", nil)
+	require.Nil(t, err)
+	request.Header.Set("X-Account-Partition", "3")
+	request.Header.Set("X-Account-Host", url.Host)
+	request.Header.Set("X-Account-Device", "adevice")
+	request.Header.Set("X-Trans-Id", "atxid")
+	request.Header.Set("X-Account-Override-Deleted", "no")
+	vars := map[string]string{"account": "a", "container": "c"}
+	server.accountUpdate(request, vars, info, fakeLogger{})
+}
+
+func TestAccountUpdateBadHeaders(t *testing.T) {
+	info := &ContainerInfo{
+		PutTimestamp:       "puttimestamp",
+		DeleteTimestamp:    "deletetimestamp",
+		ObjectCount:        1,
+		BytesUsed:          1024,
+		StoragePolicyIndex: 2,
+	}
+	called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer ts.Close()
+	url, err := url.Parse(ts.URL)
+	require.Nil(t, err)
+	server := &ContainerServer{updateClient: http.DefaultClient}
+	request, err := http.NewRequest("PUT", "http://127.0.0.1/device/partition/account/container", nil)
+	require.Nil(t, err)
+	request.Header.Set("X-Account-Partition", "3")
+	request.Header.Set("X-Account-Host", url.Host)
+	request.Header.Set("X-Account-Device", "adevice,anotherdevice")
+	request.Header.Set("X-Trans-Id", "atxid")
+	vars := map[string]string{"account": "a", "container": "c"}
+	server.accountUpdate(request, vars, info, fakeLogger{})
+	require.False(t, called)
+}
+
+func TestAccountUpdateTimeout(t *testing.T) {
+	info := &ContainerInfo{
+		PutTimestamp:       "puttimestamp",
+		DeleteTimestamp:    "deletetimestamp",
+		ObjectCount:        1,
+		BytesUsed:          1024,
+		StoragePolicyIndex: 2,
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(time.Second)
+	}))
+	defer ts.Close()
+	url, err := url.Parse(ts.URL)
+	require.Nil(t, err)
+	server := &ContainerServer{updateClient: http.DefaultClient}
+	request, err := http.NewRequest("PUT", "http://127.0.0.1/device/partition/account/container", nil)
+	require.Nil(t, err)
+	request.Header.Set("X-Account-Partition", "3")
+	request.Header.Set("X-Account-Host", url.Host)
+	request.Header.Set("X-Account-Device", "adevice")
+	request.Header.Set("X-Trans-Id", "atxid")
+	vars := map[string]string{"account": "a", "container": "c"}
+	defer func(old time.Duration) {
+		waitForAccountUpdate = old
+	}(waitForAccountUpdate)
+	waitForAccountUpdate = time.Millisecond
+	start := time.Now()
+	server.accountUpdate(request, vars, info, fakeLogger{})
+	require.True(t, time.Since(start) < time.Second)
+}


### PR DESCRIPTION
Sorry, this is a huge massive patch.  I'm not sure what to do about that.



cbench on my SAIO with 10 concurrency, 5 containers, 50k objects:

SWIFT                               HUMMINGBIRD

OBJECT PUTs: 50000 @ 640.09/s       OBJECT PUTs: 50000 @ 2011.63/s
  Failures: 0                         Failures: 0
  Mean: 0.01562s (1403.0% RSD)        Mean: 0.00495s (867.7% RSD)
  Median: 0.00561s                    Median: 0.00038s
  85%: 0.00676s                       85%: 0.00045s
  90%: 0.00710s                       90%: 0.00047s
  95%: 0.00773s                       95%: 0.00067s
  99%: 0.01071s                       99%: 0.16002s
CONTAINER GETs: 500 @ 2.49/s        CONTAINER GETs: 500 @ 6.26/s
  Failures: 0                         Failures: 0
  Mean: 3.99264s (538.9% RSD)         Mean: 1.59099s (31.3% RSD)
  Median: 1.59760s                    Median: 1.49269s
  85%: 1.67616s                       85%: 2.11407s
  90%: 1.70633s                       90%: 2.26410s
  95%: 1.76960s                       95%: 2.60918s
  99%: 199.83902s                     99%: 3.09941s
OBJECT DELETEs: 50000 @ 632.68/s    OBJECT DELETEs: 50000 @ 1879.34/s
  Failures: 0                         Failures: 0
  Mean: 0.01580s (1440.8% RSD)        Mean: 0.00530s (815.9% RSD)
  Median: 0.00520s                    Median: 0.00037s
  85%: 0.00633s                       85%: 0.00045s
  90%: 0.00672s                       90%: 0.00048s
  95%: 0.00734s                       95%: 0.00467s
  99%: 0.00960s                       99%: 0.15108s

Median and mean object PUT/DELETE performance is way better.

The median GET times are only slightly better.  And the distribution
is kind of weird, with a lot more variation in hummingbird request
times.  I am going to dig into this more later.

Swift's GET mean is dragged down by a few crazy outlier requests that
don't complete until the rest of the benchmark finishes.  There may be
a locking bug in swift there.

There's one functional test that fails because it violates the http
spec somewhere that go's http server enforces it.  But that test also
fails if you have swift fronted by haproxy, so I'm not overly
concerned about it.

The replicator works the same as swift's.  Except it doesn't use the
outgoing_sync table anymore.  outgoing_sync is for chumps.