### PR TITLE
pickle support for builder files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ HUMMINGBIRD_VERSION?=$(shell git describe --tags)
 
 all: bin/hummingbird
 
-bin/hummingbird: */*.go
+bin/hummingbird: */*.go */*/*.go
 	mkdir -p bin
 	go build -o bin/hummingbird -ldflags "-X main.Version=$(HUMMINGBIRD_VERSION)" cmd/hummingbird/main.go
 


### PR DESCRIPTION
If a tuple is used as a dict key, promote it to a PickleTuple struct
so it can act as a map key in go.

Support loading "array.array" objects to PickleArrays.  The way this
works is kind of messy because pickles are gross.

Also, fix for BINFLOAT endianness, since it was wrong.  Why are
integers stored little-endian and floats big-endian?  ¯\_(ツ)_/¯

fixes #8