### PR TITLE
organize filesystem stuff

### DIFF
--- a/cmd/hummingbird/main.go
+++ b/cmd/hummingbird/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/troubling/hummingbird/bench"
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/containerserver"
 	"github.com/troubling/hummingbird/objectserver"
@@ -83,7 +84,7 @@ func findConfig(name string) string {
 		fmt.Sprintf("/etc/swift/%s-server", configName),
 	}
 	for _, config := range configSearch {
-		if common.Exists(config) {
+		if fs.Exists(config) {
 			return config
 		}
 	}
@@ -188,7 +189,7 @@ func GracefulShutdownServer(name string, args ...string) {
 }
 
 func ProcessControlCommand(serverCommand func(name string, args ...string)) {
-	if !common.Exists("/var/run/hummingbird") {
+	if !fs.Exists("/var/run/hummingbird") {
 		err := os.MkdirAll("/var/run/hummingbird", 0600)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Unable to create /var/run/hummingbird\n")

--- a/common/fs/atomic_generic.go
+++ b/common/fs/atomic_generic.go
@@ -15,7 +15,7 @@
 
 // +build !linux
 
-package objectserver
+package fs
 
 import (
 	"io/ioutil"

--- a/common/fs/atomic_linux.go
+++ b/common/fs/atomic_linux.go
@@ -15,7 +15,7 @@
 
 // +build linux
 
-package objectserver
+package fs
 
 import (
 	"errors"

--- a/common/fs/main.go
+++ b/common/fs/main.go
@@ -1,0 +1,121 @@
+//  Copyright (c) 2015 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"syscall"
+	"time"
+)
+
+// AtomicFileWriter saves a new file atomically.
+type AtomicFileWriter interface {
+	// Write writes the data to the underlying file.
+	Write([]byte) (int, error)
+	// Fd returns the file's underlying file descriptor.
+	Fd() uintptr
+	// Save atomically writes the file to its destination.
+	Save(string) error
+	// Abandon removes any resources associated with this file.
+	Abandon() error
+	// Preallocate pre-allocates space on disk, given the expected file size and disk reserve size.
+	Preallocate(int64, int64) error
+}
+
+// LockPath locks a directory with a timeout.
+func LockPath(directory string, timeout time.Duration) (*os.File, error) {
+	lockfile := filepath.Join(directory, ".lock")
+	file, err := os.OpenFile(lockfile, os.O_RDWR|os.O_CREATE, 0660)
+	if err != nil {
+		if os.IsNotExist(err) && os.MkdirAll(directory, 0755) == nil {
+			file, err = os.OpenFile(lockfile, os.O_RDWR|os.O_CREATE, 0660)
+		}
+		if err != nil {
+			return nil, errors.New(fmt.Sprintf("Unable to open lock file (%v)", err))
+		}
+	}
+	success := make(chan error)
+	cancel := make(chan struct{})
+	defer close(cancel)
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	go func(fd int) {
+		select {
+		case success <- syscall.Flock(fd, syscall.LOCK_EX):
+		case <-cancel:
+		}
+	}(int(file.Fd()))
+	select {
+	case err = <-success:
+		if err == nil {
+			return file, nil
+		}
+	case <-timer.C:
+		err = errors.New("Flock timed out")
+	}
+	file.Close()
+	return nil, err
+}
+
+func IsMount(dir string) (bool, error) {
+	dir = filepath.Clean(dir)
+	if fileinfo, err := os.Stat(dir); err == nil {
+		if parentinfo, err := os.Stat(filepath.Dir(dir)); err == nil {
+			return fileinfo.Sys().(*syscall.Stat_t).Dev != parentinfo.Sys().(*syscall.Stat_t).Dev, nil
+		} else {
+			return false, errors.New("Unable to stat parent")
+		}
+	} else {
+		return false, errors.New("Unable to stat directory")
+	}
+}
+
+func IsNotDir(err error) bool {
+	if se, ok := err.(*os.SyscallError); ok {
+		return se.Err == syscall.ENOTDIR || se.Err == syscall.EINVAL
+	}
+	if se, ok := err.(*os.PathError); ok {
+		return os.IsNotExist(se)
+	}
+	return false
+}
+
+func ReadDirNames(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	list, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+	if len(list) > 1 {
+		sort.Strings(list)
+	}
+	return list, nil
+}
+
+func Exists(file string) bool {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}

--- a/common/fs/main_test.go
+++ b/common/fs/main_test.go
@@ -1,0 +1,81 @@
+//  Copyright (c) 2015 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package fs
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMount(t *testing.T) {
+	isMount, err := IsMount("/dev")
+	assert.Nil(t, err)
+	assert.True(t, isMount)
+	isMount, err = IsMount(".")
+	assert.Nil(t, err)
+	assert.False(t, isMount)
+	isMount, err = IsMount("/slartibartfast")
+	assert.NotNil(t, err)
+}
+
+func TestIsNotDir(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "INI")
+	defer os.RemoveAll(tempFile.Name())
+	_, err := ioutil.ReadDir(tempFile.Name())
+	assert.True(t, IsNotDir(err))
+	_, err = ioutil.ReadDir("/aseagullstolemysailorhat")
+	assert.True(t, IsNotDir(err))
+}
+
+func TestReadDirNames(t *testing.T) {
+	tempDir, _ := ioutil.TempDir("", "RDN")
+	defer os.RemoveAll(tempDir)
+	ioutil.WriteFile(tempDir+"/Z", []byte{}, 0666)
+	ioutil.WriteFile(tempDir+"/X", []byte{}, 0666)
+	ioutil.WriteFile(tempDir+"/Y", []byte{}, 0666)
+	fileNames, err := ReadDirNames(tempDir)
+	assert.Nil(t, err)
+	assert.Equal(t, fileNames, []string{"X", "Y", "Z"})
+}
+
+func TestLockPath(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "")
+	defer os.RemoveAll(tempDir)
+	require.Nil(t, err)
+	c := make(chan bool)
+	ended := make(chan struct{})
+	defer close(ended)
+	go func() {
+		f, err := LockPath(tempDir, time.Millisecond)
+		c <- true
+		require.Nil(t, err)
+		require.NotNil(t, f)
+		defer f.Close()
+		select {
+		case <-time.After(time.Second):
+		case <-ended:
+		}
+	}()
+	<-c
+	f, err := LockPath(tempDir, time.Millisecond)
+	require.Nil(t, f)
+	require.NotNil(t, err)
+}

--- a/common/fs/tempfile_test.go
+++ b/common/fs/tempfile_test.go
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package objectserver
+package fs
 
 import (
 	"io/ioutil"
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/troubling/hummingbird/common"
 )
 
 func TestTempFile(t *testing.T) {
@@ -33,7 +32,7 @@ func TestTempFile(t *testing.T) {
 	require.Nil(t, err)
 	f.Write([]byte("some crap"))
 	require.Nil(t, f.Save(filepath.Join(dir, "somefile")))
-	require.True(t, common.Exists(filepath.Join(dir, "somefile")))
+	require.True(t, Exists(filepath.Join(dir, "somefile")))
 }
 
 func TestTempFileDirRemoved(t *testing.T) {
@@ -48,7 +47,7 @@ func TestTempFileDirRemoved(t *testing.T) {
 	f.Write([]byte("some crap"))
 	os.RemoveAll(dir)
 	require.Nil(t, f.Save(filepath.Join(dir, "somefile")))
-	require.True(t, common.Exists(filepath.Join(dir, "somefile")))
+	require.True(t, Exists(filepath.Join(dir, "somefile")))
 }
 
 func TestTempFileReplace(t *testing.T) {
@@ -60,7 +59,7 @@ func TestTempFileReplace(t *testing.T) {
 	require.Nil(t, err)
 	f.Write([]byte("some crap"))
 	require.Nil(t, f.Save(filepath.Join(dir, "somefile")))
-	require.True(t, common.Exists(filepath.Join(dir, "somefile")))
+	require.True(t, Exists(filepath.Join(dir, "somefile")))
 	data, err := ioutil.ReadFile(filepath.Join(dir, "somefile"))
 	require.Nil(t, err)
 	require.Equal(t, []byte("some crap"), data)

--- a/common/fs/xattr.go
+++ b/common/fs/xattr.go
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package xattr
+package fs
 
 import "errors"
 

--- a/common/fs/xattr_bsd.go
+++ b/common/fs/xattr_bsd.go
@@ -15,7 +15,7 @@
 
 // +build freebsd openbsd netbsd dragonfly
 
-package xattr
+package fs
 
 import (
 	"syscall"

--- a/common/fs/xattr_darwinlinux.go
+++ b/common/fs/xattr_darwinlinux.go
@@ -15,7 +15,7 @@
 
 // +build linux darwin
 
-package xattr
+package fs
 
 import (
 	"syscall"

--- a/common/fs/xattr_test.go
+++ b/common/fs/xattr_test.go
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package xattr
+package fs
 
 import (
 	"io/ioutil"

--- a/containerserver/engine.go
+++ b/containerserver/engine.go
@@ -25,7 +25,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 )
 
 var (
@@ -210,7 +210,7 @@ func (l *lruEngine) containerLocation(vars map[string]string) string {
 }
 
 func (l *lruEngine) getbypath(containerFile string) (c Container, err error) {
-	if !common.Exists(containerFile) {
+	if !fs.Exists(containerFile) {
 		return nil, ErrorNoSuchContainer
 	}
 	ringHash := filepath.Base(filepath.Dir(containerFile))

--- a/containerserver/incoming_rep.go
+++ b/containerserver/incoming_rep.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/srv"
 )
 
@@ -190,7 +190,7 @@ func (server *ContainerServer) replicateRsyncThenMerge(request *http.Request, va
 func (server *ContainerServer) replicateCompleteRsync(request *http.Request, vars map[string]string, tmpFileName string) int {
 	containerFile := filepath.Join(server.driveRoot, vars["device"], "containers", vars["partition"], vars["hash"][29:32], vars["hash"], vars["hash"]+".db")
 	tmpContainerFile := filepath.Join(server.driveRoot, vars["device"], "tmp", tmpFileName)
-	if !common.Exists(tmpContainerFile) || common.Exists(containerFile) {
+	if !fs.Exists(tmpContainerFile) || fs.Exists(containerFile) {
 		return http.StatusNotFound
 	}
 	tmpDb, err := sqliteOpenContainer(tmpContainerFile)

--- a/containerserver/replicator.go
+++ b/containerserver/replicator.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/srv"
 )
@@ -301,7 +302,7 @@ func (rd *replicationDevice) findContainerDbs(devicePath string, results chan st
 			}
 			for _, hash := range hashes {
 				dbFile := filepath.Join(hash, filepath.Base(hash)+".db")
-				if common.Exists(dbFile) {
+				if fs.Exists(dbFile) {
 					select {
 					case results <- dbFile:
 					case <-rd.cancel:
@@ -322,7 +323,7 @@ func (rd *replicationDevice) replicate() {
 		rd.r.LogError("Device doesn't exist: %s", devicePath)
 		return
 	}
-	if mount, err := common.IsMount(devicePath); rd.r.checkMounts && (err != nil || !mount) {
+	if mount, err := fs.IsMount(devicePath); rd.r.checkMounts && (err != nil || !mount) {
 		rd.r.LogError("Device not mounted: %s", devicePath)
 		return
 	}

--- a/containerserver/replicator_test.go
+++ b/containerserver/replicator_test.go
@@ -33,8 +33,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/ring"
 )
 
@@ -399,7 +399,7 @@ func TestReplicateDatabaseDeletesHandoff(t *testing.T) {
 	}
 	rd.replicateDatabase(dbFile)
 	require.Equal(t, 2, called)
-	require.False(t, common.Exists(dbFile))
+	require.False(t, fs.Exists(dbFile))
 }
 
 func TestReplicateDatabaseDeletesHandoffOnSuccess(t *testing.T) {
@@ -420,7 +420,7 @@ func TestReplicateDatabaseDeletesHandoffOnSuccess(t *testing.T) {
 	}
 	rd.replicateDatabase(dbFile)
 	require.Equal(t, 2, called)
-	require.True(t, common.Exists(dbFile))
+	require.True(t, fs.Exists(dbFile))
 }
 
 func TestReplicate(t *testing.T) {

--- a/containerserver/server.go
+++ b/containerserver/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/justinas/alice"
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/middleware"
 )
@@ -518,7 +519,7 @@ func (server *ContainerServer) AcquireDevice(next http.Handler) http.Handler {
 		if device, ok := vars["device"]; ok && device != "" {
 			devicePath := filepath.Join(server.driveRoot, device)
 			if server.checkMounts {
-				if mounted, err := common.IsMount(devicePath); err != nil || !mounted {
+				if mounted, err := fs.IsMount(devicePath); err != nil || !mounted {
 					vars["Method"] = request.Method
 					srv.CustomErrorResponse(writer, 507, vars)
 					return
@@ -544,7 +545,7 @@ func (server *ContainerServer) updateDeviceLocks(seconds int64) {
 		time.Sleep(reloadTime)
 		for _, key := range server.diskInUse.Keys() {
 			lockPath := filepath.Join(server.driveRoot, key, "lock_device")
-			if common.Exists(lockPath) {
+			if fs.Exists(lockPath) {
 				server.diskInUse.Lock(key)
 			} else {
 				server.diskInUse.Unlock(key)

--- a/containerserver/sqlite_backend.go
+++ b/containerserver/sqlite_backend.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/mattn/go-sqlite3"
 	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/pickle"
 )
 
@@ -741,14 +742,14 @@ func (db *sqliteContainer) CheckSyncLink() error {
 	}
 	symLoc := filepath.Join(deviceDir, "sync_containers", pathFromDataDir)
 	if metadata["X-Container-Sync-To"] != "" {
-		if common.Exists(symLoc) {
+		if fs.Exists(symLoc) {
 			return nil
 		}
 		if err := os.MkdirAll(filepath.Dir(symLoc), 0755); err != nil {
 			return err
 		}
 		return os.Symlink(db.containerFile, symLoc)
-	} else if common.Exists(symLoc) {
+	} else if fs.Exists(symLoc) {
 		for err := error(nil); err == nil; symLoc = filepath.Dir(symLoc) {
 			err = os.Remove(symLoc)
 		}
@@ -864,7 +865,7 @@ func (db *sqliteContainer) flushAlreadyLocked() error {
 }
 
 func (db *sqliteContainer) flush() error {
-	lock, err := common.LockPath(filepath.Dir(db.containerFile), 10*time.Second)
+	lock, err := fs.LockPath(filepath.Dir(db.containerFile), 10*time.Second)
 	if err != nil {
 		return err
 	}
@@ -873,7 +874,7 @@ func (db *sqliteContainer) flush() error {
 }
 
 func (db *sqliteContainer) addObject(name string, timestamp string, size int64, contentType string, etag string, deleted int, storagePolicyIndex int) error {
-	lock, err := common.LockPath(filepath.Dir(db.containerFile), 10*time.Second)
+	lock, err := fs.LockPath(filepath.Dir(db.containerFile), 10*time.Second)
 	if err != nil {
 		return err
 	}
@@ -972,7 +973,7 @@ func sqliteCreateContainer(containerFile string, account string, container strin
 	var serializedMetadata []byte
 	var err error
 
-	if common.Exists(containerFile) {
+	if fs.Exists(containerFile) {
 		return errors.New("Container exists!")
 	}
 	if metadata == nil {
@@ -1026,7 +1027,7 @@ func sqliteCreateContainer(containerFile string, account string, container strin
 }
 
 func sqliteOpenContainer(containerFile string) (ReplicableContainer, error) {
-	if !common.Exists(containerFile) {
+	if !fs.Exists(containerFile) {
 		return nil, ErrorNoSuchContainer
 	}
 	db := &sqliteContainer{

--- a/containerserver/sqlite_backend_test.go
+++ b/containerserver/sqlite_backend_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 )
 
 func BenchmarkMergeItems(b *testing.B) {
@@ -673,10 +674,10 @@ func TestCheckSyncLink(t *testing.T) {
 		"X-Container-Sync-To": []string{"//realm/cluster/a/c", "200000000.00001"},
 	})
 	db.CheckSyncLink()
-	require.True(t, common.Exists(link))
+	require.True(t, fs.Exists(link))
 	db.UpdateMetadata(map[string][]string{
 		"X-Container-Sync-To": []string{"", "200000001.00001"},
 	})
 	db.CheckSyncLink()
-	require.False(t, common.Exists(link))
+	require.False(t, fs.Exists(link))
 }

--- a/objectserver/auditor.go
+++ b/objectserver/auditor.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/middleware"
 )
@@ -80,7 +81,7 @@ func rateLimitSleep(startTime time.Time, done int64, rate int64) {
 
 // auditHash of object hash dir.
 func auditHash(hashPath string, skipMd5 bool) (bytesProcessed int64, err error) {
-	objFiles, err := common.ReadDirNames(hashPath)
+	objFiles, err := fs.ReadDirNames(hashPath)
 	if err != nil {
 		return 0, fmt.Errorf("Error reading hash dir")
 	}
@@ -143,7 +144,7 @@ func auditHash(hashPath string, skipMd5 bool) (bytesProcessed int64, err error) 
 
 // auditSuffix directory.  Lists hash dirs, calls auditHash() for each, and quarantines any with errors.
 func (a *Auditor) auditSuffix(suffixDir string) {
-	hashes, err := common.ReadDirNames(suffixDir)
+	hashes, err := fs.ReadDirNames(suffixDir)
 	if err != nil {
 		a.errors++
 		a.totalErrors++
@@ -176,7 +177,7 @@ func (a *Auditor) auditSuffix(suffixDir string) {
 
 // auditPartition directory.  Lists suffixes in the partition and calls auditSuffix() for each.
 func (a *Auditor) auditPartition(partitionDir string) {
-	suffixes, err := common.ReadDirNames(partitionDir)
+	suffixes, err := fs.ReadDirNames(partitionDir)
 	if err != nil {
 		a.errors++
 		a.totalErrors++
@@ -204,7 +205,7 @@ func (a *Auditor) auditPartition(partitionDir string) {
 func (a *Auditor) auditDevice(devPath string) {
 	defer a.LogPanics("PANIC WHILE AUDITING DEVICE")
 
-	if mounted, err := common.IsMount(devPath); a.checkMounts && (err != nil || mounted != true) {
+	if mounted, err := fs.IsMount(devPath); a.checkMounts && (err != nil || mounted != true) {
 		a.LogError("Skipping unmounted device: %s", devPath)
 		return
 	}
@@ -214,7 +215,7 @@ func (a *Auditor) auditDevice(devPath string) {
 			continue
 		}
 		objPath := filepath.Join(devPath, PolicyDir(policy.Index))
-		partitions, err := common.ReadDirNames(objPath)
+		partitions, err := fs.ReadDirNames(objPath)
 		if err != nil {
 			a.errors++
 			a.totalErrors++
@@ -287,7 +288,7 @@ func (a *Auditor) run(c <-chan time.Time) {
 		a.totalQuarantines = 0
 		a.totalErrors = 0
 		a.LogInfo("Begin object audit \"%s\" mode (%s%s)", a.mode, a.auditorType, a.driveRoot)
-		devices, err := common.ReadDirNames(a.driveRoot)
+		devices, err := fs.ReadDirNames(a.driveRoot)
 		if err != nil {
 			a.LogError("Unable to list devices: %s", a.driveRoot)
 			continue

--- a/objectserver/backend_test.go
+++ b/objectserver/backend_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -133,12 +134,12 @@ func TestQuarantineHash(t *testing.T) {
 	hashDir := filepath.Join(driveRoot, "sda", "objects", "1", "abc", "fffffffffffffffffffffffffffffabc")
 	os.MkdirAll(hashDir, 0777)
 	QuarantineHash(hashDir)
-	require.True(t, common.Exists(filepath.Join(driveRoot, "sda", "quarantined", "objects")))
-	require.False(t, common.Exists(hashDir))
+	require.True(t, fs.Exists(filepath.Join(driveRoot, "sda", "quarantined", "objects")))
+	require.False(t, fs.Exists(hashDir))
 
 	hashDir = filepath.Join(driveRoot, "sdb", "objects-1", "1", "abc", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	os.MkdirAll(hashDir, 0777)
 	QuarantineHash(hashDir)
-	require.True(t, common.Exists(filepath.Join(driveRoot, "sdb", "quarantined", "objects-1")))
-	require.False(t, common.Exists(hashDir))
+	require.True(t, fs.Exists(filepath.Join(driveRoot, "sdb", "quarantined", "objects-1")))
+	require.False(t, fs.Exists(hashDir))
 }

--- a/objectserver/main.go
+++ b/objectserver/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/justinas/alice"
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/middleware"
 )
@@ -433,7 +434,7 @@ func (server *ObjectServer) AcquireDevice(next http.Handler) http.Handler {
 		if device, ok := vars["device"]; ok && device != "" {
 			devicePath := filepath.Join(server.driveRoot, device)
 			if server.checkMounts {
-				if mounted, err := common.IsMount(devicePath); err != nil || mounted != true {
+				if mounted, err := fs.IsMount(devicePath); err != nil || mounted != true {
 					vars["Method"] = request.Method
 					srv.CustomErrorResponse(writer, 507, vars)
 					return
@@ -468,7 +469,7 @@ func (server *ObjectServer) updateDeviceLocks(seconds int64) {
 		time.Sleep(reloadTime)
 		for _, key := range server.diskInUse.Keys() {
 			lockPath := filepath.Join(server.driveRoot, key, "lock_device")
-			if common.Exists(lockPath) {
+			if fs.Exists(lockPath) {
 				server.diskInUse.Lock(key)
 			} else {
 				server.diskInUse.Unlock(key)

--- a/objectserver/replicator.go
+++ b/objectserver/replicator.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/pickle"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/srv"
@@ -540,11 +541,11 @@ func (rd *replicationDevice) listPartitions() ([]string, error) {
 func (rd *replicationDevice) Replicate() {
 	defer rd.r.LogPanics(fmt.Sprintf("PANIC REPLICATING DEVICE: %s", rd.dev.Device))
 	rd.updateStat("startRun", 1)
-	if mounted, err := common.IsMount(filepath.Join(rd.r.deviceRoot, rd.dev.Device)); rd.r.checkMounts && (err != nil || mounted != true) {
+	if mounted, err := fs.IsMount(filepath.Join(rd.r.deviceRoot, rd.dev.Device)); rd.r.checkMounts && (err != nil || mounted != true) {
 		rd.r.LogError("[replicateDevice] Drive not mounted: %s", rd.dev.Device)
 		return
 	}
-	if common.Exists(filepath.Join(rd.r.deviceRoot, rd.dev.Device, "lock_device")) {
+	if fs.Exists(filepath.Join(rd.r.deviceRoot, rd.dev.Device, "lock_device")) {
 		return
 	}
 

--- a/objectserver/replicator_test.go
+++ b/objectserver/replicator_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/ring"
 )
 
@@ -416,8 +417,8 @@ func TestListObjFiles(t *testing.T) {
 	for obj := range objChan {
 		files = append(files, obj)
 	}
-	require.False(t, common.Exists(filepath.Join(dir, "objects", "1", "abc", "d41d8cd98f00b204e9800998ecf8427e")))
-	require.True(t, common.Exists(filepath.Join(dir, "objects", "1", "abc")))
+	require.False(t, fs.Exists(filepath.Join(dir, "objects", "1", "abc", "d41d8cd98f00b204e9800998ecf8427e")))
+	require.True(t, fs.Exists(filepath.Join(dir, "objects", "1", "abc")))
 
 	objChan = make(chan string)
 	files = nil
@@ -425,8 +426,8 @@ func TestListObjFiles(t *testing.T) {
 	for obj := range objChan {
 		files = append(files, obj)
 	}
-	require.False(t, common.Exists(filepath.Join(dir, "objects", "1", "abc")))
-	require.True(t, common.Exists(filepath.Join(dir, "objects", "1")))
+	require.False(t, fs.Exists(filepath.Join(dir, "objects", "1", "abc")))
+	require.True(t, fs.Exists(filepath.Join(dir, "objects", "1")))
 
 	objChan = make(chan string)
 	files = nil
@@ -434,8 +435,8 @@ func TestListObjFiles(t *testing.T) {
 	for obj := range objChan {
 		files = append(files, obj)
 	}
-	require.False(t, common.Exists(filepath.Join(dir, "objects", "1")))
-	require.True(t, common.Exists(filepath.Join(dir, "objects")))
+	require.False(t, fs.Exists(filepath.Join(dir, "objects", "1")))
+	require.True(t, fs.Exists(filepath.Join(dir, "objects")))
 }
 
 func TestCancelListObjFiles(t *testing.T) {
@@ -598,7 +599,7 @@ func TestSyncFileNewerExists(t *testing.T) {
 	}
 	syncs, insync, err := rd.syncFile(file.Name(), dsts)
 	require.Nil(t, err)
-	require.False(t, common.Exists(filename))
+	require.False(t, fs.Exists(filename))
 	require.Equal(t, 0, syncs)
 	require.Equal(t, 1, insync)
 }
@@ -663,7 +664,7 @@ func TestReplicateHandoff(t *testing.T) {
 	nodes := []*ring.Device{remoteDev}
 	rd.replicateHandoff(partition, nodes)
 	require.True(t, syncFileCalled)
-	require.False(t, common.Exists(filename))
+	require.False(t, fs.Exists(filename))
 }
 
 func TestCleanTemp(t *testing.T) {
@@ -685,8 +686,8 @@ func TestCleanTemp(t *testing.T) {
 	oldTime := time.Now().Add(-(time.Hour * 24 * 14))
 	require.Nil(t, os.Chtimes(filepath.Join(tmpDir, "testfile2"), oldTime, oldTime))
 	rd.cleanTemp()
-	require.False(t, common.Exists(filepath.Join(tmpDir, "testfile2")))
-	require.True(t, common.Exists(filepath.Join(tmpDir, "testfile1")))
+	require.False(t, fs.Exists(filepath.Join(tmpDir, "testfile2")))
+	require.True(t, fs.Exists(filepath.Join(tmpDir, "testfile1")))
 }
 
 func TestReplicate(t *testing.T) {

--- a/objectserver/swiftobjeng.go
+++ b/objectserver/swiftobjeng.go
@@ -27,12 +27,13 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/fs"
 )
 
 // SwiftObject implements an Object that is compatible with Swift's object server.
 type SwiftObject struct {
 	file         *os.File
-	afw          AtomicFileWriter
+	afw          fs.AtomicFileWriter
 	hashDir      string
 	tempDir      string
 	dataFile     string
@@ -101,7 +102,7 @@ func (o *SwiftObject) Repr() string {
 func (o *SwiftObject) newFile(class string, size int64) (io.Writer, error) {
 	var err error
 	o.Close()
-	if o.afw, err = NewAtomicFileWriter(o.tempDir, o.hashDir); err != nil {
+	if o.afw, err = fs.NewAtomicFileWriter(o.tempDir, o.hashDir); err != nil {
 		return nil, fmt.Errorf("Error creating temp file: %v", err)
 	}
 	if err := o.afw.Preallocate(size, o.reserve); err != nil {

--- a/objectserver/swiftobjeng_test.go
+++ b/objectserver/swiftobjeng_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 )
 
 func TestSwiftObjectRoundtrip(t *testing.T) {
@@ -91,7 +91,7 @@ func TestSwiftObjectQuarantine(t *testing.T) {
 	w.Write([]byte("!"))
 	swo.Commit(map[string]string{"Content-Length": "1", "Content-Type": "text/plain", "X-Timestamp": "1234567890.123456"})
 	swo.Quarantine()
-	require.True(t, common.Exists(filepath.Join(driveRoot, "sda", "quarantined")))
+	require.True(t, fs.Exists(filepath.Join(driveRoot, "sda", "quarantined")))
 }
 
 func TestSwiftObjectMultiCopy(t *testing.T) {

--- a/objectserver/update.go
+++ b/objectserver/update.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/pickle"
 	"github.com/troubling/hummingbird/common/srv"
 )
@@ -100,7 +101,7 @@ func (server *ObjectServer) saveAsync(method, account, container, obj, localDevi
 		"headers":   headerToMap(headers),
 	}
 	if os.MkdirAll(filepath.Dir(asyncFile), 0755) == nil {
-		writer, err := NewAtomicFileWriter(tempDir, filepath.Dir(asyncFile))
+		writer, err := fs.NewAtomicFileWriter(tempDir, filepath.Dir(asyncFile))
 		if err == nil {
 			defer writer.Abandon()
 			writer.Write(pickle.PickleDumps(data))

--- a/objectserver/update_test.go
+++ b/objectserver/update_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/pickle"
 	"github.com/troubling/hummingbird/common/srv"
 )
@@ -99,7 +99,7 @@ func TestUpdateDeleteAt(t *testing.T) {
 	cs.Close()
 	server.updateDeleteAt(req, deleteAtStr, vars, &dl)
 	expectedFile := filepath.Join(ts.root, "sda", "async_pending", "8fc", "02cc012fe572f27e455edbea32da78fc-12345.6789")
-	require.True(t, common.Exists(expectedFile))
+	require.True(t, fs.Exists(expectedFile))
 	data, err := ioutil.ReadFile(expectedFile)
 	require.Nil(t, err)
 	a, err := pickle.PickleLoads(data)
@@ -127,7 +127,7 @@ func TestUpdateDeleteAtNoHeaders(t *testing.T) {
 	deleteAtStr := "1434707411"
 	server.updateDeleteAt(req, deleteAtStr, vars, &DummyLogger{})
 	expectedFile := filepath.Join(ts.root, "sda", "async_pending", "8fc", "02cc012fe572f27e455edbea32da78fc-12345.6789")
-	require.True(t, common.Exists(expectedFile))
+	require.True(t, fs.Exists(expectedFile))
 	data, err := ioutil.ReadFile(expectedFile)
 	require.Nil(t, err)
 	a, err := pickle.PickleLoads(data)
@@ -181,7 +181,7 @@ func TestUpdateContainer(t *testing.T) {
 	cs.Close()
 	server.updateContainer(metadata, req, vars, &dl)
 	expectedFile := filepath.Join(ts.root, "sda", "async_pending", "099", "2f714cd91b0e5d803cde2012b01d7099-12345.6789")
-	require.True(t, common.Exists(expectedFile))
+	require.True(t, fs.Exists(expectedFile))
 	data, err := ioutil.ReadFile(expectedFile)
 	require.Nil(t, err)
 	a, err := pickle.PickleLoads(data)
@@ -225,5 +225,5 @@ func TestUpdateContainerNoHeaders(t *testing.T) {
 	cs.Close()
 	server.updateContainer(metadata, req, vars, &dl)
 	expectedFile := filepath.Join(ts.root, "sda", "async_pending", "099", "2f714cd91b0e5d803cde2012b01d7099-12345.6789")
-	require.False(t, common.Exists(expectedFile))
+	require.False(t, fs.Exists(expectedFile))
 }

--- a/probe/auditor_test.go
+++ b/probe/auditor_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
 )
 
 func TestAuditorMd5(t *testing.T) {
@@ -37,7 +38,7 @@ func TestAuditorMd5(t *testing.T) {
 
 	// make sure the file is still there after an audit pass
 	e.auditors[0].Run()
-	assert.True(t, common.Exists(path))
+	assert.True(t, fs.Exists(path))
 
 	// simulate bit-rot of the file contents
 	f, _ := os.OpenFile(path, os.O_RDWR, 0777)
@@ -46,7 +47,7 @@ func TestAuditorMd5(t *testing.T) {
 
 	// make sure the file is gone after an audit pass
 	e.auditors[0].Run()
-	assert.False(t, common.Exists(path))
+	assert.False(t, fs.Exists(path))
 }
 
 func TestAuditorContentLength(t *testing.T) {
@@ -62,7 +63,7 @@ func TestAuditorContentLength(t *testing.T) {
 
 	// make sure the file is still there after an audit pass
 	e.auditors[0].Run()
-	assert.True(t, common.Exists(path))
+	assert.True(t, fs.Exists(path))
 
 	// simulate bit-rot of the file contents
 	f, _ := os.OpenFile(path, os.O_APPEND|os.O_RDWR, 0777)
@@ -71,5 +72,5 @@ func TestAuditorContentLength(t *testing.T) {
 
 	// make sure the file is gone after an audit pass
 	e.auditors[0].Run()
-	assert.False(t, common.Exists(path))
+	assert.False(t, fs.Exists(path))
 }


### PR DESCRIPTION
Move all of our filesystem utility functions and filesystem/operating
system abstraction code under common/fs.

Get rid of WriteFileAtomic while I'm there, since it was only used
in one place, and AtomicFileWriter is better anyway.

fixes #3