### PR TITLE
remove UseMaxProcs

### DIFF
--- a/cmd/hummingbird/main.go
+++ b/cmd/hummingbird/main.go
@@ -214,7 +214,6 @@ func ProcessControlCommand(serverCommand func(name string, args ...string)) {
 }
 
 func main() {
-	common.UseMaxProcs()
 	common.SetRlimits()
 	rand.Seed(time.Now().Unix())
 

--- a/common/utils.go
+++ b/common/utils.go
@@ -283,10 +283,6 @@ func ParseRange(rangeHeader string, fileSize int64) (reqRanges []httpRange, err 
 	return reqRanges, nil
 }
 
-func UseMaxProcs() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-}
-
 func SetRlimits() {
 	syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Max: 65536, Cur: 65536})
 }


### PR DESCRIPTION
This hasn't been needed since like 3 versions of go ago.