### PR TITLE
make current swift functional tests pass

### DIFF
--- a/containerserver/engine.go
+++ b/containerserver/engine.go
@@ -114,7 +114,7 @@ type Container interface {
 	// GetMetadata returns the container's current metadata.
 	GetMetadata() (map[string]string, error)
 	// UpdateMetadata applies updates to the container's metadata.
-	UpdateMetadata(updates map[string][]string) error
+	UpdateMetadata(updates map[string][]string, timestamp string) error
 	// PutObject adds a new object to the container.
 	PutObject(name string, timestamp string, size int64, contentType string, etag string, storagePolicyIndex int) error
 	// DeleteObject deletes an object from the container.

--- a/containerserver/lib_test.go
+++ b/containerserver/lib_test.go
@@ -208,7 +208,7 @@ func (f fakeDatabase) ListObjects(limit int, marker string, endMarker string, pr
 func (f fakeDatabase) GetMetadata() (map[string]string, error) {
 	return nil, errors.New("")
 }
-func (f fakeDatabase) UpdateMetadata(updates map[string][]string) error {
+func (f fakeDatabase) UpdateMetadata(updates map[string][]string, timestamp string) error {
 	return errors.New("")
 }
 func (f fakeDatabase) MergeItems(records []*ObjectRecord, remoteID string) error {

--- a/containerserver/server.go
+++ b/containerserver/server.go
@@ -107,6 +107,12 @@ func (server *ContainerServer) ContainerGetHandler(writer http.ResponseWriter, r
 		return
 	}
 	headers := writer.Header()
+	if lastModified, err := common.ParseDate(info.PutTimestamp); err == nil {
+		if lastModified.Nanosecond() > 0 { // for some reason, Last-Modified is ceil(X-Timestamp)
+			lastModified = lastModified.Truncate(time.Second).Add(time.Second)
+		}
+		headers.Set("Last-Modified", lastModified.Format(time.RFC1123))
+	}
 	if ts, err := common.GetEpochFromTimestamp(info.CreatedAt); err == nil {
 		headers.Set("X-Backend-Timestamp", ts)
 	}
@@ -221,7 +227,7 @@ func (server *ContainerServer) ContainerGetHandler(writer http.ResponseWriter, r
 		}
 		container := &Container{Name: vars["container"], Objects: objects}
 		writer.Header().Set("Content-Type", "application/xml; charset=utf-8")
-		output, _ := xml.MarshalIndent(container, "", "  ")
+		output, _ := xml.Marshal(container)
 		headers.Set("Content-Length", strconv.Itoa(len(output)+39))
 		writer.WriteHeader(200)
 		writer.Write([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"))
@@ -362,7 +368,7 @@ func (server *ContainerServer) ContainerPostHandler(writer http.ResponseWriter, 
 		srv.StandardResponse(writer, http.StatusNotFound)
 		return
 	}
-	if err := db.UpdateMetadata(updates); err == ErrorInvalidMetadata {
+	if err := db.UpdateMetadata(updates, timestamp); err == ErrorInvalidMetadata {
 		srv.StandardResponse(writer, http.StatusBadRequest)
 	} else if err != nil {
 		srv.StandardResponse(writer, http.StatusInternalServerError)

--- a/containerserver/sqlite_backend.go
+++ b/containerserver/sqlite_backend.go
@@ -545,7 +545,7 @@ func (db *sqliteContainer) mergeMetas(a map[string][]string, b map[string][]stri
 }
 
 // UpdateMetadata merges the current container metadata with new incoming metadata.
-func (db *sqliteContainer) UpdateMetadata(newMetadata map[string][]string) error {
+func (db *sqliteContainer) UpdateMetadata(newMetadata map[string][]string, timestamp string) error {
 	if err := db.connect(); err != nil {
 		return err
 	}
@@ -571,7 +571,7 @@ func (db *sqliteContainer) UpdateMetadata(newMetadata map[string][]string) error
 	if err != nil {
 		return err
 	}
-	if _, err = tx.Exec("UPDATE container_info SET metadata=?", metastr); err != nil {
+	if _, err = tx.Exec("UPDATE container_info SET metadata=?, put_timestamp=MAX(put_timestamp, ?)", metastr, timestamp); err != nil {
 		return err
 	}
 	defer db.invalidateCache()

--- a/containerserver/sqlite_backend_test.go
+++ b/containerserver/sqlite_backend_test.go
@@ -448,7 +448,7 @@ func TestGetUpdateMetadata(t *testing.T) {
 
 	require.Nil(t, db.UpdateMetadata(map[string][]string{
 		"X-Container-Meta-Hi": []string{"", "100000000.00001"},
-	}))
+	}, "100000000.00001"))
 	m, err = db.GetMetadata()
 	require.Nil(t, err)
 	require.Equal(t, metadataValues, m)
@@ -456,8 +456,8 @@ func TestGetUpdateMetadata(t *testing.T) {
 	require.Nil(t, db.UpdateMetadata(map[string][]string{
 		"X-Container-Meta-Hi":         []string{"", "200000001.00001"},
 		"X-Container-Meta-Some-Other": []string{"value", "200000001.00001"},
-	}))
-	require.Nil(t, db.UpdateMetadata(map[string][]string{}))
+	}, "200000001.00001"))
+	require.Nil(t, db.UpdateMetadata(map[string][]string{}, "200000001.00001"))
 	m, err = db.GetMetadata()
 	require.Nil(t, err)
 	require.Equal(t, map[string]string{"X-Container-Meta-Some-Other": "value"}, m)
@@ -631,7 +631,7 @@ func TestCleanupTombstones(t *testing.T) {
 	require.Nil(t, db.MergeItems([]*ObjectRecord{&ObjectRecord{Name: "a", CreatedAt: "10000000.00000", Deleted: 0}}, ""))
 	db.UpdateMetadata(map[string][]string{
 		"X-Container-Meta-Old-Value": []string{"", "10000000.00000"},
-	})
+	}, "10000000.00000")
 	info, err := db.GetInfo()
 	require.Nil(t, err)
 	_, ok := info.Metadata["X-Container-Meta-Old-Value"]
@@ -654,7 +654,7 @@ func TestDeleteRemovesMetadata(t *testing.T) {
 
 	db.UpdateMetadata(map[string][]string{
 		"X-Container-Meta-Key": []string{"Value", "200000000.00001"},
-	})
+	}, "10000000.00001")
 	require.Nil(t, db.Delete("200000001.00000"))
 	deleted, err := db.IsDeleted()
 	require.Nil(t, err)
@@ -671,12 +671,12 @@ func TestCheckSyncLink(t *testing.T) {
 	link := strings.Replace(db.containerFile, "containers", "sync_containers", -1)
 	db.UpdateMetadata(map[string][]string{
 		"X-Container-Sync-To": []string{"//realm/cluster/a/c", "200000000.00001"},
-	})
+	}, "20000000.00001")
 	db.CheckSyncLink()
 	require.True(t, common.Exists(link))
 	db.UpdateMetadata(map[string][]string{
 		"X-Container-Sync-To": []string{"", "200000001.00001"},
-	})
+	}, "20000001.00001")
 	db.CheckSyncLink()
 	require.False(t, common.Exists(link))
 }

--- a/objectserver/main.go
+++ b/objectserver/main.go
@@ -66,6 +66,33 @@ func (server *ObjectServer) newObject(req *http.Request, vars map[string]string,
 	return engine.New(vars, needData)
 }
 
+func parseIfMatch(s string) map[string]bool {
+	r := make(map[string]bool)
+	if len(strings.Trim(s, " ")) > 0 {
+		for _, ss := range strings.Split(s, ",") {
+			if sst := strings.Trim(ss, " "); sst != "" {
+				if sst[0] == '"' && sst[len(sst)-1] == '"' {
+					r[sst[1:len(sst)-1]] = true
+				} else {
+					r[sst] = true
+				}
+			}
+		}
+	}
+	return r
+}
+
+func resolveEtag(req *http.Request, metadata map[string]string) string {
+	etag := metadata["ETag"]
+	for _, ph := range strings.Split(req.Header.Get("X-Backend-Etag-Is-At"), ",") {
+		ph = strings.Trim(ph, " ")
+		if altEtag, exists := metadata[http.CanonicalHeaderKey(ph)]; exists && ph != "" {
+			etag = altEtag
+		}
+	}
+	return etag
+}
+
 func (server *ObjectServer) ObjGetHandler(writer http.ResponseWriter, request *http.Request) {
 	vars := srv.GetVars(request)
 	headers := writer.Header()
@@ -77,17 +104,20 @@ func (server *ObjectServer) ObjGetHandler(writer http.ResponseWriter, request *h
 	}
 	defer obj.Close()
 
+	ifMatches := parseIfMatch(request.Header.Get("If-Match"))
+	ifNoneMatches := parseIfMatch(request.Header.Get("If-None-Match"))
+
 	if !obj.Exists() {
-		if im := request.Header.Get("If-Match"); im != "" && strings.Contains(im, "*") {
+		if ifMatches["*"] {
 			srv.StandardResponse(writer, http.StatusPreconditionFailed)
-			return
 		} else {
 			srv.StandardResponse(writer, http.StatusNotFound)
-			return
 		}
+		return
 	}
 
 	metadata := obj.Metadata()
+	etag := resolveEtag(request, metadata)
 
 	headers.Set("X-Backend-Timestamp", metadata["X-Timestamp"])
 	if deleteAt, ok := metadata["X-Delete-At"]; ok {
@@ -108,7 +138,7 @@ func (server *ObjectServer) ObjGetHandler(writer http.ResponseWriter, request *h
 		lastModifiedHeader = lastModified.Truncate(time.Second).Add(time.Second)
 	}
 	headers.Set("Last-Modified", lastModifiedHeader.Format(time.RFC1123))
-	headers.Set("ETag", "\""+metadata["ETag"]+"\"")
+	headers.Set("ETag", "\""+etag+"\"")
 	xTimestamp, err := common.GetEpochFromTimestamp(metadata["X-Timestamp"])
 	if err != nil {
 		srv.GetLogger(request).LogError("Error getting the epoch time from x-timestamp: %s", err.Error())
@@ -124,12 +154,12 @@ func (server *ObjectServer) ObjGetHandler(writer http.ResponseWriter, request *h
 		}
 	}
 
-	if im := request.Header.Get("If-Match"); im != "" && !strings.Contains(im, metadata["ETag"]) && !strings.Contains(im, "*") {
+	if len(ifMatches) > 0 && !ifMatches[etag] && !ifMatches["*"] {
 		srv.StandardResponse(writer, http.StatusPreconditionFailed)
 		return
 	}
 
-	if inm := request.Header.Get("If-None-Match"); inm != "" && (strings.Contains(inm, metadata["ETag"]) || strings.Contains(inm, "*")) {
+	if len(ifNoneMatches) > 0 && (ifNoneMatches[etag] || ifNoneMatches["*"]) {
 		writer.WriteHeader(http.StatusNotModified)
 		return
 	}
@@ -152,6 +182,7 @@ func (server *ObjectServer) ObjGetHandler(writer http.ResponseWriter, request *h
 		ranges, err := common.ParseRange(rangeHeader, obj.ContentLength())
 		if err != nil {
 			headers.Set("Content-Length", "0")
+			headers.Set("Content-Range", fmt.Sprintf("bytes */%d", obj.ContentLength()))
 			writer.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
 			return
 		} else if ranges != nil && len(ranges) == 1 {
@@ -498,7 +529,8 @@ func (server *ObjectServer) GetHandler(config conf.Config) http.Handler {
 
 func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bindPort int, serv srv.Server, logger srv.LowLevelLogger, err error) {
 	server := &ObjectServer{driveRoot: "/srv/node", hashPathPrefix: "", hashPathSuffix: "",
-		allowedHeaders: map[string]bool{"Content-Disposition": true,
+		allowedHeaders: map[string]bool{
+			"Content-Disposition":   true,
 			"Content-Encoding":      true,
 			"X-Delete-At":           true,
 			"X-Object-Manifest":     true,


### PR DESCRIPTION
Fix some new tests/functionality from swift from the last few months.

If-Match and If-None-Match needed to be a little more robust, and to
know about the X-Backend-Etag-Is-At header.

A Content-Range header needed to be added to 416 responses.

Container GET/HEAD needed a Last-Modified header, and that needs to
be updated on container POST.