### PR TITLE
Proxy layer ratelimiting

### DIFF
--- a/common/ring/memcachering.go
+++ b/common/ring/memcachering.go
@@ -43,12 +43,12 @@ const (
 )
 
 type MemcacheRing interface {
-	Decr(key string, delta int, timeout int) (int64, error)
+	Decr(key string, delta int64, timeout int) (int64, error)
 	Delete(key string) error
 	Get(key string) (interface{}, error)
 	GetStructured(key string, val interface{}) error
 	GetMulti(serverKey string, keys []string) (map[string]interface{}, error)
-	Incr(key string, delta int, timeout int) (int64, error)
+	Incr(key string, delta int64, timeout int) (int64, error)
 	Set(key string, value interface{}, timeout int) error
 	SetMulti(serverKey string, values map[string]interface{}, timeout int) error
 }
@@ -133,7 +133,7 @@ func (ring *memcacheRing) sortServerKeys() {
 	sort.Strings(ring.serverKeys)
 }
 
-func (ring *memcacheRing) Decr(key string, delta int, timeout int) (int64, error) {
+func (ring *memcacheRing) Decr(key string, delta int64, timeout int) (int64, error) {
 	return ring.Incr(key, -delta, timeout)
 }
 
@@ -225,7 +225,7 @@ func (ring *memcacheRing) GetMulti(serverKey string, keys []string) (map[string]
 	return ret.value, ring.loop(serverKey, fn)
 }
 
-func (ring *memcacheRing) Incr(key string, delta int, timeout int) (int64, error) {
+func (ring *memcacheRing) Incr(key string, delta int64, timeout int) (int64, error) {
 	type Return struct {
 		value int64
 	}

--- a/common/ring/memcachering_test.go
+++ b/common/ring/memcachering_test.go
@@ -157,7 +157,7 @@ func testIncr(t *testing.T, ring *memcacheRing) {
 	// increment multiple times and check running total
 	key := "testIncr"
 	var running_total int64 = 0
-	for i := 1; i <= 10; i++ {
+	for i := int64(1); i <= 10; i++ {
 		running_total += int64(i)
 		if j, err := ring.Incr(key, i, 2); err != nil {
 			t.Error(err)
@@ -184,14 +184,14 @@ func testDecr(t *testing.T, ring *memcacheRing) {
 		assert.EqualValues(t, int64(0), value)
 	}
 	// test running total goes to and stays at zero
-	var running_total int = 30
+	var running_total int64 = 30
 	if value, err := ring.Incr(key, running_total, 2); err != nil {
 		t.Error(err)
 		return
 	} else {
 		assert.EqualValues(t, running_total, value)
 	}
-	for i := 1; i <= 10; i++ {
+	for i := int64(1); i <= 10; i++ {
 		if i < running_total {
 			running_total -= i
 		} else {

--- a/common/test/test.go
+++ b/common/test/test.go
@@ -164,3 +164,65 @@ func (s FakeLogger) LogError(format string, args ...interface{}) {}
 func (s FakeLogger) LogInfo(format string, args ...interface{})  {}
 func (s FakeLogger) LogDebug(format string, args ...interface{}) {}
 func (s FakeLogger) LogPanics(format string)                     {}
+
+// Fake MemcacheRing
+type FakeMemcacheRing struct {
+	MockIncrResults []int64
+	MockIncrKeys    []string
+	MockSetValues   []interface{}
+}
+
+func (mr *FakeMemcacheRing) Decr(key string, delta int64, timeout int) (int64, error) {
+	return int64(0), nil
+}
+
+func (mr *FakeMemcacheRing) Delete(key string) error {
+	return nil
+}
+
+func (mr *FakeMemcacheRing) Get(key string) (interface{}, error) {
+	return nil, nil
+}
+
+func (mr *FakeMemcacheRing) GetStructured(key string, val interface{}) error {
+	return nil
+}
+
+func (mr *FakeMemcacheRing) GetMulti(serverKey string, keys []string) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (mr *FakeMemcacheRing) Incr(key string, delta int64, timeout int) (int64, error) {
+	mr.MockIncrKeys = append(mr.MockIncrKeys, key)
+	if len(mr.MockIncrResults) > 0 {
+		res := mr.MockIncrResults[0] + delta
+		mr.MockIncrResults = mr.MockIncrResults[1:]
+		return res, nil
+	}
+	return int64(0), nil
+}
+
+func (mr *FakeMemcacheRing) Set(key string, value interface{}, timeout int) error {
+	mr.MockSetValues = append(mr.MockSetValues, value)
+	return nil
+}
+
+func (mr *FakeMemcacheRing) SetMulti(serverKey string, values map[string]interface{}, timeout int) error {
+	return nil
+}
+
+type MockResponseWriter struct{}
+
+func (m MockResponseWriter) Header() (h http.Header) {
+	return http.Header{}
+}
+
+func (m MockResponseWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func (m MockResponseWriter) WriteString(s string) (n int, err error) {
+	return len(s), nil
+}
+
+func (m MockResponseWriter) WriteHeader(int) {}

--- a/common/utils.go
+++ b/common/utils.go
@@ -247,6 +247,28 @@ func StandardizeTimestamp(timestamp string) (string, error) {
 	return timestamp, nil
 }
 
+// will split out url path the proxy would receive and return map
+// with keys: "vrs", "account", "container", "object"
+func ParseProxyPath(path string) (pathMap map[string]string, err error) {
+	pathParts := []string{"", "vrs", "account", "container", "object"}
+	pathSplit := strings.SplitN(path, "/", 5)
+	if pathSplit[0] != "" {
+		return nil, errors.New(fmt.Sprintf("Invalid path: %s", path))
+	}
+	pathMap = map[string]string{}
+	for i := 1; i < len(pathParts); i++ {
+		if len(pathSplit) <= i {
+			pathMap[pathParts[i]] = ""
+		} else {
+			if pathSplit[i] == "" && len(pathSplit)-1 != i {
+				return nil, errors.New(fmt.Sprintf("Invalid path: %s", path))
+			}
+			pathMap[pathParts[i]] = pathSplit[i]
+		}
+	}
+	return pathMap, err
+}
+
 var buf64kpool = NewFreePool(128)
 
 func Copy(src io.Reader, dsts ...io.Writer) (written int64, err error) {

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -230,3 +230,38 @@ func TestCopyN(t *testing.T) {
 	assert.Equal(t, []byte("WELL HELLO"), dst1.Bytes())
 	assert.Equal(t, []byte("WELL HELLO"), dst2.Bytes())
 }
+
+func TestParseProxyPath(t *testing.T) {
+	tests := [][]string{
+		[]string{"", "vrs", ""},
+		[]string{"", "account", ""},
+		[]string{"/", "vrs", ""},
+		[]string{"/", "object", ""},
+		[]string{"/v/a/c/o/a/b/c/d", "vrs", "v"},
+		[]string{"/v/a/c/o/a/b/c/d", "account", "a"},
+		[]string{"/v/a/c/o/a/b/c/d", "container", "c"},
+		[]string{"/v/a/c/o/a/b/c/d", "object", "o/a/b/c/d"},
+		[]string{"/v/a/c/o/a/b/c///d", "object", "o/a/b/c///d"},
+		[]string{"/v/a/c//o/b/c///d", "object", "/o/b/c///d"},
+		[]string{"/v", "vrs", "v"},
+		[]string{"/v/", "vrs", "v"},
+		[]string{"/v/a", "account", "a"},
+		[]string{"/v/a/", "account", "a"},
+		[]string{"/v/a/", "container", ""},
+	}
+	for i := 0; i < len(tests); i++ {
+		tSlice := tests[i]
+		res, err := ParseProxyPath(tSlice[0])
+		assert.Equal(t, res[tSlice[1]], tSlice[2])
+		assert.Equal(t, err, nil)
+	}
+	res, err := ParseProxyPath("v/a")
+	assert.Equal(t, len(res), 0)
+	assert.NotEqual(t, err, nil)
+	res, err = ParseProxyPath("//")
+	assert.Equal(t, len(res), 0)
+	assert.NotEqual(t, err, nil)
+	res, err = ParseProxyPath("/v//c")
+	assert.Equal(t, len(res), 0)
+	assert.NotEqual(t, err, nil)
+}

--- a/proxyserver/main.go
+++ b/proxyserver/main.go
@@ -81,6 +81,7 @@ func (server *ProxyServer) GetHandler(config conf.Config) http.Handler {
 		{middleware.NewHealthcheck, "filter:healthcheck"},
 		{middleware.NewRequestLogger, "filter:proxy-logging"},
 		{middleware.NewTempAuth, "filter:tempauth"},
+		{middleware.NewRatelimiter, "filter:ratelimit"},
 	}
 	pipeline := alice.New(middleware.NewContext(server.mc, server.C, server.logger))
 	for _, m := range middlewares {

--- a/proxyserver/middleware/ratelimit.go
+++ b/proxyserver/middleware/ratelimit.go
@@ -1,0 +1,131 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/ring"
+	"github.com/troubling/hummingbird/common/srv"
+)
+
+const rateBuffer = int64(5 * time.Second)
+const maxSleep = int64(60 * time.Second)
+const nsPerSecond = int64(1000000000)
+
+var writeMethods = map[string]bool{"PUT": true, "DELETE": true, "POST": true}
+
+// will sleep on write requests if the client starts to exceed the
+// specified rate. The maximum rate allowed per sec is only as
+// accurate as the clocks in the proxy layer- meaning if your clocks
+// are accurate to 1/100 of a second then the max reliable rate/sec
+// you can set is 100/sec.
+
+type ratelimiter struct {
+	accountLimit   int64
+	containerLimit int64
+	next           http.Handler
+}
+
+var sleep = func(s time.Duration) {
+	time.Sleep(s)
+}
+
+var nowNano = func() int64 {
+	return time.Now().UnixNano()
+}
+
+// returns int64 of ns to sleep before serving request
+func (r *ratelimiter) getSleepTime(mc ring.MemcacheRing, key string, ratePs int64) (int64, error) {
+	nsPerRequest := nsPerSecond / ratePs
+	runningTime, err := mc.Incr(key, nsPerRequest, 3600)
+	if err != nil {
+		return 0, err
+	}
+	sleepTime := int64(0)
+	now := nowNano()
+	if int64(now-runningTime) > rateBuffer {
+		// nothing has happened in a while, set new clocktime
+		mc.Set(key, now+nsPerRequest, 3600)
+	} else {
+		sleepTime = runningTime - now - nsPerRequest
+		if sleepTime < 0 {
+			sleepTime = 0
+		}
+	}
+	return sleepTime, nil
+}
+
+func (r *ratelimiter) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	isWrite := writeMethods[request.Method]
+	pathParts, err := common.ParseProxyPath(request.URL.Path)
+	if !isWrite || err != nil || pathParts["container"] == "" {
+		r.next.ServeHTTP(writer, request)
+		return
+	}
+	ctx := GetProxyContext(request)
+	if ctx == nil {
+		ctx.Logger.LogDebug("Error ratelimiter getting ctx")
+		return
+	}
+	limit := int64(0)
+	var ratekey string
+	if pathParts["object"] == "" {
+		ratekey = fmt.Sprintf(
+			"ratelimit/%s", pathParts["account"])
+		limit = r.accountLimit
+	} else {
+		ratekey = fmt.Sprintf(
+			"ratelimit/%s/%s", pathParts["account"], pathParts["container"])
+		limit = r.containerLimit
+	}
+	if limit > 0 {
+		sleepTime, err := r.getSleepTime(ctx.Cache, ratekey, limit)
+		if err == nil {
+			if sleepTime > maxSleep {
+				sleep(time.Second)
+				srv.StandardResponse(writer, 498)
+				return
+			}
+			sleep(time.Duration(sleepTime))
+		} else {
+			if ctx := GetProxyContext(request); ctx != nil {
+				ctx.Logger.LogDebug(fmt.Sprintf(
+					"Error ratelimitint getting sleep time: %v", err))
+			}
+		}
+	}
+	r.next.ServeHTTP(writer, request)
+}
+
+func NewRatelimiter(config conf.Section) (func(http.Handler) http.Handler, error) {
+
+	accLimit := int64(config.GetInt("account_db_max_writes_per_sec", 0))
+	contLimit := int64(config.GetInt("container_db_max_writes_per_sec", 0))
+	//TODO: add account metadata global-write-ratelimit ratelimiter
+	RegisterInfo("ratelimit", map[string]interface{}{"account_ratelimit": accLimit, "container_ratelimits": [][]int64{[]int64{contLimit}}, "max_sleep_time_seconds": float64(60.0)})
+	return func(next http.Handler) http.Handler {
+		return &ratelimiter{
+			accountLimit:   accLimit,
+			containerLimit: contLimit,
+			next:           next,
+		}
+	}, nil
+}

--- a/proxyserver/middleware/ratelimit_test.go
+++ b/proxyserver/middleware/ratelimit_test.go
@@ -1,0 +1,126 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/troubling/hummingbird/common/test"
+)
+
+var now = 10 * nsPerSecond
+
+type sleeper struct {
+	SleepVals []time.Duration
+}
+
+func (s *sleeper) fakeSleep(t time.Duration) {
+	s.SleepVals = append(s.SleepVals, t)
+}
+
+func fakeNowNano() int64 {
+	return now
+}
+
+type FakeHandler struct {
+}
+
+func (h FakeHandler) ServeHTTP(http.ResponseWriter, *http.Request) {
+}
+
+func TestGetSleepTime(t *testing.T) {
+	fakeMr := &test.FakeMemcacheRing{MockIncrResults: []int64{now}}
+
+	rt := ratelimiter{accountLimit: 0, containerLimit: 0}
+
+	oldSleep := sleep
+	oldNowNano := nowNano
+	defer func() {
+		sleep = oldSleep
+		nowNano = oldNowNano
+	}()
+	s := sleeper{}
+	sleep = s.fakeSleep
+	nowNano = fakeNowNano
+
+	sleepTime, err := rt.getSleepTime(fakeMr, "hey", int64(1000))
+	assert.Equal(t, sleepTime, int64(0))
+	assert.Equal(t, err, nil)
+
+	fakeMr = &test.FakeMemcacheRing{MockIncrResults: []int64{now + 2000}}
+	sleepTime, err = rt.getSleepTime(fakeMr, "hey", int64(1000))
+	assert.Equal(t, sleepTime, int64(2000))
+	assert.Equal(t, err, nil)
+
+	fakeMr = &test.FakeMemcacheRing{MockIncrResults: []int64{nsPerSecond}}
+	sleepTime, err = rt.getSleepTime(fakeMr, "hey", int64(1000))
+	assert.Equal(t, sleepTime, int64(0))
+	assert.Equal(t, err, nil)
+	assert.Equal(t, fakeMr.MockSetValues[0], now+nsPerSecond/1000)
+}
+
+/*
+TODO:
+need to figure out a decent way to put the FakeMemcacheRing
+into the request's context
+
+func TestServeHTTP(t *testing.T) {
+	fakeMr := test.FakeMemcacheRing{MockIncrResults: []int64{now + 2000}}
+
+	rt := ratelimiter{accountLimit: 10, containerLimit: 100, mc: &fakeMr}
+	oldSleep := sleep
+	oldNowNano := nowNano
+	defer func() {
+		sleep = oldSleep
+		nowNano = oldNowNano
+	}()
+	s := sleeper{}
+	sleep = s.fakeSleep
+	nowNano = fakeNowNano
+	fakeWriter := test.MockResponseWriter{}
+	rt.next = FakeHandler{}
+
+	req, _ := http.NewRequest("GET", "/v/a/co", nil)
+	rt.ServeHTTP(fakeWriter, req)
+	assert.Equal(t, len(s.SleepVals), 0)
+	assert.Equal(t, len(fakeMr.MockIncrKeys), 0)
+
+	req, _ = http.NewRequest("PUT", "/v/a/c", nil)
+	rt.ServeHTTP(fakeWriter, req)
+	assert.Equal(t, len(s.SleepVals), 1)
+
+	rt.accountLimit = 0
+	rt.ServeHTTP(fakeWriter, req)
+	assert.Equal(t, len(s.SleepVals), 1)
+
+	req, _ = http.NewRequest("PUT", "/v/a/c/o", nil)
+	rt.ServeHTTP(fakeWriter, req)
+	assert.Equal(t, len(s.SleepVals), 2)
+
+	assert.Equal(t, fakeMr.MockIncrKeys[0], "ratelimit/a")
+	assert.Equal(t, fakeMr.MockIncrKeys[1], "ratelimit/a/c")
+
+	fakeMr = test.FakeMemcacheRing{MockIncrResults: []int64{now + 2000 + MaxSleep}}
+	rt.mc = &fakeMr
+	req, _ = http.NewRequest("PUT", "/v/a/c/o", nil)
+	rt.ServeHTTP(fakeWriter, req)
+	assert.Equal(t, len(s.SleepVals), 3)
+	assert.Equal(t, s.SleepVals[len(s.SleepVals)-1], time.Second)
+}
+*/


### PR DESCRIPTION
If you set a [filter:ratelimit] section in the proxy-server.conf with

[filter:ratelimit]
account_db_max_writes_per_sec = 20
container_db_max_writes_per_sec = 100

it will limit the object writes (PUT/POST/DELETE) per container to 100/s
and writes directly to containers (PUTs to /v/a/c) to 10/s

fixes #43