### PR TITLE
Add structured logging using zap.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install:
   - sudo mkfs.xfs /tmp/hb-disk
   - sudo mkdir -p /srv
   - sudo mount -o loop /tmp/hb-disk /srv
-  - sudo mkdir -p /var/cache/swift /var/cache/swift2 /var/cache/swift3 /var/cache/swift4 /var/run/swift /srv/1/node/sdb1 /srv/2/node/sdb2 /srv/3/node/sdb3 /srv/4/node/sdb4 /var/run/hummingbird /etc/hummingbird /etc/swift
-  - sudo chown -R "${USER}" /etc/swift /etc/hummingbird /srv/* /var/cache/swift* /var/run/swift /var/run/hummingbird
+  - sudo mkdir -p /var/cache/swift /var/cache/swift2 /var/cache/swift3 /var/cache/swift4 /var/run/swift /srv/1/node/sdb1 /srv/2/node/sdb2 /srv/3/node/sdb3 /srv/4/node/sdb4 /var/run/hummingbird /etc/hummingbird /etc/swift /var/log/swift
+  - sudo chown -R "${USER}" /etc/swift /etc/hummingbird /srv/* /var/cache/swift* /var/run/swift /var/run/hummingbird /var/log/swift
   - git clone --depth 1 'https://github.com/openstack/swift.git' ~/swift
   - virtualenv ~/swift-venv
   - ~/swift-venv/bin/pip install -U pip setuptools python-subunit

--- a/accountserver/replicator.go
+++ b/accountserver/replicator.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/troubling/hummingbird/common"
@@ -34,6 +35,7 @@ import (
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/srv"
+	"go.uber.org/zap"
 )
 
 var (
@@ -224,19 +226,29 @@ func (rd *replicationDevice) replicateDatabaseToDevice(dev *ring.Device, c Repli
 	rd.i.incrementStat(strategy)
 	switch strategy {
 	case "empty", "hashmatch", "no_change":
-		rd.r.LogDebug("Not replicating anything (%s): %s", strategy, c.RingHash())
+		rd.r.logger.Debug("Not replicating anything.",
+			zap.String("strategy", strategy),
+			zap.String("RingHash", c.RingHash()))
 	case "complete_rsync", "rsync_then_merge":
-		rd.r.LogDebug("Replicating %s to %s/%s via %s", c.RingHash(), dev.ReplicationIp, dev.Device, strategy)
+		rd.r.logger.Debug("Replicating ringhash",
+			zap.String("RingHash", c.RingHash()),
+			zap.String("ReplicationIp", dev.ReplicationIp),
+			zap.String("Device", dev.Device),
+			zap.String("strategy", strategy))
 		return rd.i.rsync(dev, c, part, strategy)
 	case "diff":
-		rd.r.LogDebug("Replicating %s to %s/%s via %s", c.RingHash(), dev.ReplicationIp, dev.Device, strategy)
+		rd.r.logger.Debug("Replicating ringhash",
+			zap.String("RingHash", c.RingHash()),
+			zap.String("ReplicationIp", dev.ReplicationIp),
+			zap.String("Device", dev.Device),
+			zap.String("strategy", strategy))
 		return rd.i.usync(dev, c, part, info.ID, remoteInfo.Point)
 	}
 	return nil
 }
 
 func (rd *replicationDevice) replicateDatabase(dbFile string) error {
-	rd.r.LogDebug("Replicating database: %s", filepath.Base(dbFile))
+	rd.r.logger.Debug("Replicating database.", zap.String("dbFile", filepath.Base(dbFile)))
 	parts := filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(dbFile))))
 	part, err := strconv.ParseUint(parts, 10, 64)
 	if err != nil {
@@ -256,15 +268,23 @@ func (rd *replicationDevice) replicateDatabase(dbFile string) error {
 	for i := 0; i < len(devices); i++ {
 		if err := rd.i.replicateDatabaseToDevice(devices[i], c, part); err == nil {
 			rd.i.incrementStat("success")
-			rd.r.LogDebug("Succeeded replicating database %s to %s/%s", dbFile, devices[i].ReplicationIp, devices[i].Device)
+			rd.r.logger.Debug("Succeeded replicating database.",
+				zap.String("dbFile", dbFile),
+				zap.String("ReplicationIp", devices[i].ReplicationIp),
+				zap.String("Device", devices[i].Device))
 			successes++
 		} else {
 			rd.i.incrementStat("failure")
-			rd.r.LogError("Error replicating database %s to %s/%s: %v", dbFile, devices[i].ReplicationIp, devices[i].Device, err)
+			rd.r.logger.Error("Error replicating database.",
+				zap.String("dbFile", dbFile),
+				zap.String("ReplicationIp", devices[i].ReplicationIp),
+				zap.String("Device", devices[i].Device),
+				zap.Error(err))
 			if err == errDeviceNotMounted && !handoff {
 				next := moreNodes.Next()
 				if next == nil {
-					rd.r.LogError("Ran out of handoffs to talk to: %s", dbFile)
+					rd.r.logger.Error("Ran out of handoffs to talk to.",
+						zap.String("dbFile", dbFile))
 				} else {
 					devices = append(devices, moreNodes.Next())
 				}
@@ -283,19 +303,25 @@ func (rd *replicationDevice) findAccountDbs(devicePath string, results chan stri
 	accountsDir := filepath.Join(devicePath, "accounts")
 	partitions, err := filepath.Glob(filepath.Join(accountsDir, "[0-9]*"))
 	if err != nil {
-		rd.r.LogError("Error getting partitions in %s: %v", accountsDir, err)
+		rd.r.logger.Error("Error getting partitions.",
+			zap.String("accountsDir", accountsDir),
+			zap.Error(err))
 		return
 	}
 	for _, part := range partitions {
 		suffixes, err := filepath.Glob(filepath.Join(part, "[a-f0-9][a-f0-9][a-f0-9]"))
 		if err != nil {
-			rd.r.LogError("Error getting suffixes in %s: %v", part, err)
+			rd.r.logger.Error("Error getting suffixes.",
+				zap.String("part", part),
+				zap.Error(err))
 			return
 		}
 		for _, suff := range suffixes {
 			hashes, err := filepath.Glob(filepath.Join(suff, "????????????????????????????????"))
 			if err != nil {
-				rd.r.LogError("Error getting hashes in %s: %v", suff, err)
+				rd.r.logger.Error("Error getting hashes",
+					zap.String("suff", suff),
+					zap.Error(err))
 				return
 			}
 			for _, hash := range hashes {
@@ -313,16 +339,19 @@ func (rd *replicationDevice) findAccountDbs(devicePath string, results chan stri
 }
 
 func (rd *replicationDevice) replicate() {
-	rd.r.LogInfo("Beginning replication for device %s", rd.dev.Device)
+	rd.r.logger.Info("Beginning replication for device.",
+		zap.String("device", rd.dev.Device))
 	rd.r.startRun <- rd.dev.Device
 	devicePath := filepath.Join(rd.r.deviceRoot, rd.dev.Device)
 	stat, err := os.Stat(devicePath)
 	if err != nil || !stat.IsDir() {
-		rd.r.LogError("Device doesn't exist: %s", devicePath)
+		rd.r.logger.Error("Device doesn't exist.",
+			zap.String("devicePath", devicePath))
 		return
 	}
 	if mount, err := fs.IsMount(devicePath); rd.r.checkMounts && (err != nil || !mount) {
-		rd.r.LogError("Device not mounted: %s", devicePath)
+		rd.r.logger.Error("Device not mounted.",
+			zap.String("devicePath", devicePath))
 		return
 	}
 	results := make(chan string, 100)
@@ -334,7 +363,9 @@ func (rd *replicationDevice) replicate() {
 		case rd.r.concurrencySem <- struct{}{}:
 			rd.r.checkin <- rd.dev.Device
 			if err := rd.i.replicateDatabase(dbFile); err != nil {
-				rd.r.LogError("Error replicating database file %s: %v", dbFile, err)
+				rd.r.logger.Error("Error replicating database file.",
+					zap.String("dbFile", dbFile),
+					zap.Error(err))
 			}
 			<-rd.r.concurrencySem
 		}
@@ -404,7 +435,8 @@ func (r *Replicator) verifyDevices() {
 	}
 	ringDevices, err := r.Ring.LocalDevices(r.serverPort)
 	if err != nil {
-		r.LogError("Error getting local devices from ring: %v", err)
+		r.logger.Error("Error getting local devices from ring.",
+			zap.Error(err))
 		return
 	}
 	// look for devices that aren't running but should be
@@ -446,11 +478,18 @@ func (r *Replicator) reportStats() {
 		if runningTime > 0 {
 			rate = float64(aggStats["attempted"]) / runningTime
 		}
-		r.LogInfo("Attempted to replicate %d dbs in %.5f seconds (%.5f/s)", aggStats["attempted"], runningTime, rate)
-		r.LogInfo("Removed %d dbs", aggStats["remove"])
-		r.LogInfo("%d successes, %d failures", aggStats["success"], aggStats["failure"])
+		r.logger.Info("Attempted to replicate dbs",
+			zap.Int64("aggStats['attempted']", aggStats["attempted"]),
+			zap.Float64("runningTime", runningTime),
+			zap.Float64("rate", rate))
+
+		r.logger.Info("Removed dbs",
+			zap.Int64("aggStats['remove']", aggStats["remove"]))
+		r.logger.Info("Sucess & Failure",
+			zap.Int64("success", aggStats["success"]),
+			zap.Int64("failure", aggStats["failure"]))
 	} else {
-		r.LogInfo("No devices replicating.")
+		r.logger.Info("No devices replicating.")
 	}
 }
 
@@ -494,7 +533,8 @@ func (r *Replicator) Run() {
 	done := make(chan struct{})
 	devices, err := r.Ring.LocalDevices(r.serverPort)
 	if err != nil {
-		r.LogError("Error getting local devices from ring: %v", err)
+		r.logger.Error("Error getting local devices from ring.",
+			zap.Error(err))
 		return
 	}
 	for _, dev := range devices {
@@ -520,38 +560,30 @@ func (r *Replicator) Run() {
 	r.reportStats()
 }
 
-// LogDebug formats and logs debug messages to the underlying logger.
-func (r *Replicator) LogDebug(format string, args ...interface{}) {
-	r.logger.Debug(fmt.Sprintf(format, args...))
-}
-
-// LogInfo formats and  logs info messages to the underlying logger.
-func (r *Replicator) LogInfo(format string, args ...interface{}) {
-	r.logger.Info(fmt.Sprintf(format, args...))
-}
-
-// LogError formats and logs info messages to the underlying logger.
-func (r *Replicator) LogError(format string, args ...interface{}) {
-	r.logger.Err(fmt.Sprintf(format, args...))
-}
-
 // GetReplicator uses the config settings and command-line flags to configure and return a replicator daemon struct.
-func GetReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, error) {
+func GetReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, srv.LowLevelLogger, error) {
 	if !serverconf.HasSection("account-replicator") {
-		return nil, fmt.Errorf("Unable to find account-replicator config section")
+		return nil, nil, fmt.Errorf("Unable to find account-replicator config section")
 	}
 	hashPathPrefix, hashPathSuffix, err := GetHashPrefixAndSuffix()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to get hash prefix and suffix")
+		return nil, nil, fmt.Errorf("Unable to get hash prefix and suffix")
 	}
 	ring, err := GetRing("account", hashPathPrefix, hashPathSuffix, 0)
 	if err != nil {
-		return nil, fmt.Errorf("Error loading account ring")
+		return nil, nil, fmt.Errorf("Error loading account ring")
 	}
 	concurrency := int(serverconf.GetInt("account-replicator", "concurrency", 4))
+
+	logLevelString := serverconf.GetDefault("account-replicator", "log_level", "INFO")
+	logLevel := zap.NewAtomicLevel()
+	logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
+
+	logPath := serverconf.GetDefault("account-replicator", "log_path", "/var/log/swift/accountreplicator.log")
+
 	var logger srv.LowLevelLogger
-	if logger, err = srv.SetupLogger(serverconf, flags, "app:account-server", "account-server"); err != nil {
-		return nil, fmt.Errorf("Error setting up logger: %v", err)
+	if logger, err = srv.SetupLogger("account-replicator", &logLevel, flags, logPath); err != nil {
+		return nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	return &Replicator{
 		runningDevices: make(map[string]*replicationDevice),
@@ -572,5 +604,5 @@ func GetReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, err
 			Timeout:   time.Minute * 15,
 			Transport: &http.Transport{Dial: (&net.Dialer{Timeout: time.Second}).Dial},
 		},
-	}, nil
+	}, logger, nil
 }

--- a/accountserver/server_test.go
+++ b/accountserver/server_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
 	"github.com/troubling/hummingbird/common/test"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func makeTestServer() (http.Handler, func(), error) {
@@ -40,8 +42,8 @@ func makeTestServer() (http.Handler, func(), error) {
 		driveRoot:        dir,
 		hashPathPrefix:   "changeme",
 		hashPathSuffix:   "changeme",
-		logLevel:         "INFO",
-		logger:           test.FakeLowLevelLogger{},
+		logLevel:         zap.NewAtomicLevelAt(zapcore.InfoLevel),
+		logger:           zap.NewNop(),
 		checkMounts:      false,
 		updateClient:     http.DefaultClient,
 		accountEngine:    newLRUEngine(dir, "changeme", "changeme", 32),

--- a/common/srv/context.go
+++ b/common/srv/context.go
@@ -24,14 +24,14 @@ type KeyType int
 
 const logkey KeyType = iota
 
-func GetLogger(r *http.Request) LoggingContext {
+func GetLogger(r *http.Request) LowLevelLogger {
 	if rv := r.Context().Value(logkey); rv != nil {
-		return rv.(LoggingContext)
+		return rv.(LowLevelLogger)
 	}
 	return nil
 }
 
-func SetLogger(r *http.Request, l LoggingContext) *http.Request {
+func SetLogger(r *http.Request, l LowLevelLogger) *http.Request {
 	return r.WithContext(context.WithValue(r.Context(), logkey, l))
 }
 

--- a/common/srv/server.go
+++ b/common/srv/server.go
@@ -22,14 +22,12 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log/syslog"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"sync"
 	"syscall"
@@ -37,6 +35,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/troubling/hummingbird/common/conf"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var responseTemplate = "<html><h1>%s</h1><p>%s</p></html>"
@@ -136,102 +136,46 @@ func CopyRequestHeaders(r *http.Request, dst *http.Request) {
 	}
 }
 
-type RequestLogger struct {
-	Request *http.Request
-	Logger  LowLevelLogger
-	W       interface {
-		http.ResponseWriter
-		Response() (bool, int)
-	}
-}
-
-func (r RequestLogger) LogError(format string, args ...interface{}) {
-	transactionId := r.Request.Header.Get("X-Trans-Id")
-	r.Logger.Err(fmt.Sprintf(format, args...) + " (txn:" + transactionId + ")")
-}
-
-func (r RequestLogger) LogInfo(format string, args ...interface{}) {
-	transactionId := r.Request.Header.Get("X-Trans-Id")
-	r.Logger.Info(fmt.Sprintf(format, args...) + " (txn:" + transactionId + ")")
-}
-
-func (r RequestLogger) LogDebug(format string, args ...interface{}) {
-	transactionId := r.Request.Header.Get("X-Trans-Id")
-	r.Logger.Debug(fmt.Sprintf(format, args...) + " (txn:" + transactionId + ")")
-}
-
-func (r RequestLogger) LogPanics(msg string) {
-	if e := recover(); e != nil {
-		transactionId := r.Request.Header.Get("X-Trans-Id")
-		r.Logger.Err(fmt.Sprintf("PANIC (%s): %s: %s", msg, e, debug.Stack()) + " (txn:" + transactionId + ")")
-		// if we haven't set a status code yet, we can send a 500 response.
-		if started, _ := r.W.Response(); !started {
-			StandardResponse(r.W, http.StatusInternalServerError)
-		}
-	}
+type WebWriterInterface interface {
+	http.ResponseWriter
+	Response() (bool, int)
 }
 
 func ValidateRequest(r *http.Request) bool {
 	return utf8.ValidString(r.URL.Path) && utf8.ValidString(r.Header.Get("Content-Type"))
 }
 
-type LoggingContext interface {
-	LogError(format string, args ...interface{})
-	LogInfo(format string, args ...interface{})
-	LogDebug(format string, args ...interface{})
-	LogPanics(format string)
-}
-
 type LowLevelLogger interface {
-	Err(string) error
-	Info(string) error
-	Debug(string) error
+	Error(msg string, fields ...zapcore.Field)
+	Info(msg string, fields ...zapcore.Field)
+	Debug(msg string, fields ...zapcore.Field)
+	With(fields ...zapcore.Field) *zap.Logger
 }
 
-type consoleLogger struct{}
-
-func (c *consoleLogger) Err(m string) error {
-	fmt.Println("ERROR:", m)
-	return nil
+func LogPanics(logger LowLevelLogger, msg string) {
+	if e := recover(); e != nil {
+		recoveredMsg := fmt.Sprintf("PANIC (%s)", msg)
+		logger.Error(recoveredMsg, zap.Any("err", e))
+	}
 }
 
-func (c *consoleLogger) Info(m string) error {
-	fmt.Println("INFO:", m)
-	return nil
-}
-
-func (c *consoleLogger) Debug(m string) error {
-	fmt.Println("DEBUG:", m)
-	return nil
-}
-
-var syslogFacilityMapping = map[string]syslog.Priority{"LOG_USER": syslog.LOG_USER,
-	"LOG_MAIL": syslog.LOG_MAIL, "LOG_DAEMON": syslog.LOG_DAEMON,
-	"LOG_AUTH": syslog.LOG_AUTH, "LOG_SYSLOG": syslog.LOG_SYSLOG,
-	"LOG_LPR": syslog.LOG_LPR, "LOG_NEWS": syslog.LOG_NEWS,
-	"LOG_UUCP": syslog.LOG_UUCP, "LOG_CRON": syslog.LOG_CRON,
-	"LOG_AUTHPRIV": syslog.LOG_AUTHPRIV, "LOG_FTP": syslog.LOG_FTP,
-	"LOG_LOCAL0": syslog.LOG_LOCAL0, "LOG_LOCAL1": syslog.LOG_LOCAL1,
-	"LOG_LOCAL2": syslog.LOG_LOCAL2, "LOG_LOCAL3": syslog.LOG_LOCAL3,
-	"LOG_LOCAL4": syslog.LOG_LOCAL4, "LOG_LOCAL5": syslog.LOG_LOCAL5,
-	"LOG_LOCAL6": syslog.LOG_LOCAL6, "LOG_LOCAL7": syslog.LOG_LOCAL7}
-
-// SetupLogger pulls configuration information from the config and flags to create a UDP syslog logger.
-// If -d was not specified, it also logs to the console.
-func SetupLogger(conf conf.Config, flags *flag.FlagSet, section, prefix string) (LowLevelLogger, error) {
+// SetupLogger configures structured logging using uber's zap library.
+func SetupLogger(prefix string, atomicLevel *zap.AtomicLevel, flags *flag.FlagSet, logPath string) (LowLevelLogger, error) {
+	productionConfig := zap.NewProductionConfig()
+	productionConfig.Level = *atomicLevel
+	productionConfig.OutputPaths = []string{logPath}
+	productionConfig.ErrorOutputPaths = []string{logPath}
 	vFlag := flags.Lookup("v")
 	dFlag := flags.Lookup("d")
 	if vFlag != nil && dFlag != nil && vFlag.Value.(flag.Getter).Get().(bool) && !dFlag.Value.(flag.Getter).Get().(bool) {
-		return &consoleLogger{}, nil
+		productionConfig.OutputPaths = []string{"stdout"}
+		productionConfig.ErrorOutputPaths = []string{"stderr"}
 	}
-	facility := conf.GetDefault(section, "log_facility", "LOG_LOCAL0")
-	host := conf.GetDefault(section, "log_udp_host", "127.0.0.1")
-	port := conf.GetInt(section, "log_udp_port", 514)
-	dialHost := fmt.Sprintf("%s:%d", host, port)
-	logger, err := syslog.Dial("udp", dialHost, syslogFacilityMapping[facility], prefix)
+	baseLogger, err := productionConfig.Build()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to dial logger: %v", err)
+		return nil, fmt.Errorf("Unable to create logger: %v", err)
 	}
+	logger := baseLogger.With(zap.String("name", prefix))
 	return logger, nil
 }
 
@@ -317,7 +261,7 @@ func RunServers(GetServer func(conf.Config, *flag.FlagSet) (string, int, Server,
 		sock, err := RetryListen(ip, port)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error listening: %v\n", err)
-			logger.Err(fmt.Sprintf("Error listening: %v", err))
+			logger.Error("Error listening", zap.Error(err))
 			os.Exit(1)
 		}
 		srv := HummingbirdServer{
@@ -332,8 +276,7 @@ func RunServers(GetServer func(conf.Config, *flag.FlagSet) (string, int, Server,
 		}
 		go srv.Serve(sock)
 		servers = append(servers, &srv)
-		logger.Err(fmt.Sprintf("Server started on port %d", port))
-		fmt.Printf("Server started on port %d\n", port)
+		logger.Info("Server started", zap.Int("port", port))
 	}
 
 	if len(servers) > 0 {
@@ -354,7 +297,7 @@ func RunServers(GetServer func(conf.Config, *flag.FlagSet) (string, int, Server,
 					defer wg.Done()
 					if err := hserv.Shutdown(ctx); err != nil {
 						// failure/timeout shutting down the server gracefully
-						hserv.logger.Err(fmt.Sprintf("Error with graceful shutdown: %v", err))
+						hserv.logger.Error("Error with graceful shutdown", zap.Error(err))
 					}
 					// Wait for any async processes to quit
 					hserv.finalize()
@@ -382,7 +325,7 @@ func RunServers(GetServer func(conf.Config, *flag.FlagSet) (string, int, Server,
 		} else {
 			for _, srv := range servers {
 				if err := srv.Close(); err != nil {
-					srv.logger.Err(fmt.Sprintf("Error shutdown: %v", err))
+					srv.logger.Error("Error shutdown", zap.Error(err))
 				}
 			}
 		}
@@ -392,10 +335,9 @@ func RunServers(GetServer func(conf.Config, *flag.FlagSet) (string, int, Server,
 type Daemon interface {
 	Run()
 	RunForever()
-	LogError(format string, args ...interface{})
 }
 
-func RunDaemon(GetDaemon func(conf.Config, *flag.FlagSet) (Daemon, error), flags *flag.FlagSet) {
+func RunDaemon(GetDaemon func(conf.Config, *flag.FlagSet) (Daemon, LowLevelLogger, error), flags *flag.FlagSet) {
 	var daemons []Daemon
 
 	if flags.NArg() != 0 {
@@ -413,16 +355,16 @@ func RunDaemon(GetDaemon func(conf.Config, *flag.FlagSet) (Daemon, error), flags
 	once := flags.Lookup("once").Value.(flag.Getter).Get() == true
 
 	for _, config := range configs {
-		if daemon, err := GetDaemon(config, flags); err == nil {
+		if daemon, logger, err := GetDaemon(config, flags); err == nil {
 			if once {
 				daemon.Run()
 				fmt.Fprintf(os.Stderr, "Daemon pass completed.\n")
-				daemon.LogError("Daemon pass completed.")
+				logger.Error("Daemon pass completed.")
 			} else {
 				daemons = append(daemons, daemon)
 				go daemon.RunForever()
 				fmt.Fprintf(os.Stderr, "Daemon started.\n")
-				daemon.LogError("Daemon started.")
+				logger.Error("Daemon started.")
 			}
 		} else {
 			fmt.Fprintf(os.Stderr, "Failed to create daemon: %v", err)

--- a/common/test/test.go
+++ b/common/test/test.go
@@ -50,20 +50,6 @@ func MakeCaptureResponse() *CaptureResponse {
 	}
 }
 
-type FakeLowLevelLogger struct{}
-
-func (FakeLowLevelLogger) Err(s string) error {
-	return nil
-}
-
-func (FakeLowLevelLogger) Info(s string) error {
-	return nil
-}
-
-func (FakeLowLevelLogger) Debug(s string) error {
-	return nil
-}
-
 // FakeRing
 type FakeRing struct {
 	// Overrides for function returns
@@ -158,13 +144,6 @@ type fakeMoreNodes struct {
 func (m *fakeMoreNodes) Next() *ring.Device {
 	return m.dev
 }
-
-type FakeLogger struct{}
-
-func (s FakeLogger) LogError(format string, args ...interface{}) {}
-func (s FakeLogger) LogInfo(format string, args ...interface{})  {}
-func (s FakeLogger) LogDebug(format string, args ...interface{}) {}
-func (s FakeLogger) LogPanics(format string)                     {}
 
 // Fake MemcacheRing
 type FakeMemcacheRing struct {

--- a/containerserver/lib_test.go
+++ b/containerserver/lib_test.go
@@ -24,7 +24,8 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
-	"github.com/troubling/hummingbird/common/test"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // a place for utility functions and interface satisifiers that are used across tests
@@ -71,8 +72,8 @@ func makeTestServer() (http.Handler, func(), error) {
 		driveRoot:        dir,
 		hashPathPrefix:   "changeme",
 		hashPathSuffix:   "changeme",
-		logLevel:         "INFO",
-		logger:           test.FakeLowLevelLogger{},
+		logLevel:         zap.NewAtomicLevelAt(zap.InfoLevel),
+		logger:           zap.NewNop(),
 		checkMounts:      false,
 		updateClient:     http.DefaultClient,
 		containerEngine:  newLRUEngine(dir, "changeme", "changeme", 32),
@@ -97,8 +98,8 @@ func makeTestServer2() (*ContainerServer, http.Handler, func(), error) {
 		driveRoot:       dir,
 		hashPathPrefix:  "changeme",
 		hashPathSuffix:  "changeme",
-		logLevel:        "INFO",
-		logger:          test.FakeLowLevelLogger{},
+		logLevel:        zap.NewAtomicLevelAt(zapcore.InfoLevel),
+		logger:          zap.NewNop(),
 		checkMounts:     false,
 		updateClient:    http.DefaultClient,
 		containerEngine: newLRUEngine(dir, "changeme", "changeme", 32),

--- a/containerserver/replicator_test.go
+++ b/containerserver/replicator_test.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +36,9 @@ import (
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/test"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 type patchableReplicationDevice struct {
@@ -117,7 +119,7 @@ func newTestReplicationDevice(dev *ring.Device, r *Replicator) *patchableReplica
 		r.sendStat = make(chan statUpdate, 100)
 	}
 	if r.logger == nil {
-		r.logger = test.FakeLowLevelLogger{}
+		r.logger = zap.NewNop()
 	}
 	if r.Ring == nil {
 		r.Ring = &test.FakeRing{}
@@ -469,7 +471,7 @@ func (r *localDevicesRing) LocalDevices(localPort int) (devs []*ring.Device, err
 func TestVerifyDevicesRemoveStuck(t *testing.T) {
 	r := &Replicator{
 		Ring:   &localDevicesRing{localDevs: []*ring.Device{}},
-		logger: test.FakeLowLevelLogger{},
+		logger: zap.NewNop(),
 		runningDevices: map[string]*replicationDevice{
 			"sda": {lastCheckin: time.Now().Add(time.Hour * -2), cancel: make(chan struct{})},
 			"sdb": {lastCheckin: time.Now().Add(time.Hour * -2), cancel: make(chan struct{})},
@@ -488,7 +490,7 @@ func TestVerifyDevicesLaunchMissing(t *testing.T) {
 				{Device: "sdb"},
 			},
 		},
-		logger:         test.FakeLowLevelLogger{},
+		logger:         zap.NewNop(),
 		runningDevices: map[string]*replicationDevice{},
 	}
 	r.verifyDevices()
@@ -501,7 +503,7 @@ func TestVerifyDevicesRemoveMissing(t *testing.T) {
 		Ring: &localDevicesRing{
 			localDevs: []*ring.Device{},
 		},
-		logger: test.FakeLowLevelLogger{},
+		logger: zap.NewNop(),
 		runningDevices: map[string]*replicationDevice{
 			"sda": {lastCheckin: time.Now(), cancel: make(chan struct{})},
 			"sdb": {lastCheckin: time.Now(), cancel: make(chan struct{})},
@@ -526,8 +528,9 @@ func TestGetReplicator(t *testing.T) {
 	}
 	config, err := conf.StringConfig("[container-replicator]\nmount_check=false\nbind_port=1000")
 	require.Nil(t, err)
-	r, err := GetReplicator(config, &flag.FlagSet{})
+	r, logger, err := GetReplicator(config, &flag.FlagSet{})
 	require.Nil(t, err)
+	require.NotNil(t, logger)
 	replicator, ok := r.(*Replicator)
 	require.True(t, ok)
 	require.Equal(t, 1000, replicator.serverPort)
@@ -540,30 +543,23 @@ func TestGetReplicator(t *testing.T) {
 
 	config, err = conf.StringConfig("")
 	require.Nil(t, err)
-	r, err = GetReplicator(config, &flag.FlagSet{})
+	r, logger, err = GetReplicator(config, &flag.FlagSet{})
 	require.NotNil(t, err)
+	require.Nil(t, logger)
 
 	GetHashPrefixAndSuffix = func() (pfx string, sfx string, err error) {
 		return "", "", errors.New("I AM A BAD CONFIGURATION")
 	}
 	config, err = conf.StringConfig("[container-replicator]\nmount_check=false\nbind_port=1000")
 	require.Nil(t, err)
-	r, err = GetReplicator(config, &flag.FlagSet{})
+	r, logger, err = GetReplicator(config, &flag.FlagSet{})
 	require.NotNil(t, err)
-}
-
-type savingLowLevelLogger struct {
-	test.FakeLowLevelLogger
-	logs []string
-}
-
-func (s *savingLowLevelLogger) Info(l string) error {
-	s.logs = append(s.logs, l)
-	return nil
+	require.Nil(t, logger)
 }
 
 func TestReportStats(t *testing.T) {
-	logger := &savingLowLevelLogger{logs: make([]string, 0)}
+	obs, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(obs)
 	r := &Replicator{
 		logger: logger,
 		runningDevices: map[string]*replicationDevice{
@@ -589,13 +585,28 @@ func TestReportStats(t *testing.T) {
 		},
 	}
 	r.reportStats()
-	require.True(t, strings.HasPrefix(logger.logs[0], "Attempted to replicate 20 dbs in 600."))
-	require.Equal(t, "Removed 10 dbs", logger.logs[1])
-	require.Equal(t, "14 successes, 6 failures", logger.logs[2])
+	require.Equal(t, 3, logs.Len())
+	want := []observer.LoggedEntry{{
+		Entry: zapcore.Entry{Level: zap.InfoLevel, Message: "Attempted to replicate dbs"},
+		Context: []zapcore.Field{zap.Int64("aggStats['attempted']", 20),
+			zap.Float64("runningTime", 600.000008246),
+			zap.Float64("rate", 0.03333333150538899)},
+	}, {
+		Entry:   zapcore.Entry{Level: zap.InfoLevel, Message: "Removed dbs"},
+		Context: []zapcore.Field{zap.Int64("aggStats['remove']", 10)},
+	}, {
+		Entry: zapcore.Entry{Level: zap.InfoLevel, Message: "Sucess & Failure"},
+		Context: []zapcore.Field{zap.Int64("success", 14),
+			zap.Int64("failure", 6)},
+	}}
+	require.Equal(t, want[0].Message, logs.AllUntimed()[0].Message)
+	require.Equal(t, want[1], logs.AllUntimed()[1])
+	require.Equal(t, want[2], logs.AllUntimed()[2])
 }
 
 func TestRunLoop(t *testing.T) {
-	logger := &savingLowLevelLogger{logs: make([]string, 0)}
+	obs, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(obs)
 	r := &Replicator{
 		logger: logger,
 		Ring: &localDevicesRing{
@@ -629,7 +640,7 @@ func TestRunLoop(t *testing.T) {
 	rpTimer := make(chan time.Time, 1)
 	rpTimer <- time.Now()
 	r.runLoopCheck(rpTimer)
-	require.True(t, strings.HasPrefix(logger.logs[0], "Attempted to replicate "))
+	require.Equal(t, logs.AllUntimed()[0].Message, "Attempted to replicate dbs")
 
 	r.sendStat <- statUpdate{"sda", "attempted", 1}
 	r.runLoopCheck(rpTimer)
@@ -656,7 +667,7 @@ func TestReplicatorRun(t *testing.T) {
 			{Device: "sda"},
 			{Device: "sdb"},
 		}},
-		logger:         test.FakeLowLevelLogger{},
+		logger:         zap.NewNop(),
 		deviceRoot:     dir,
 		sendStat:       make(chan statUpdate, 10),
 		startRun:       make(chan string, 10),

--- a/containerserver/server.go
+++ b/containerserver/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/middleware"
+	"go.uber.org/zap"
 )
 
 // GetHashPrefixAndSuffix is a pointer to hummingbird's function of the same name, for overriding in tests.
@@ -51,7 +52,7 @@ type ContainerServer struct {
 	hashPathPrefix   string
 	hashPathSuffix   string
 	logger           srv.LowLevelLogger
-	logLevel         string
+	logLevel         zap.AtomicLevel
 	diskInUse        *common.KeyedLimit
 	checkMounts      bool
 	containerEngine  ContainerEngine
@@ -99,14 +100,14 @@ func (server *ContainerServer) ContainerGetHandler(writer http.ResponseWriter, r
 		srv.StandardResponse(writer, http.StatusNotFound)
 		return
 	} else if err != nil {
-		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.GetLogger(request).Error("Unable to get container.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
 	defer server.containerEngine.Return(db)
 	info, err := db.GetInfo()
 	if err != nil {
-		srv.GetLogger(request).LogError("Unable to get container info: %v", err)
+		srv.GetLogger(request).Error("Unable to get container info.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -132,7 +133,7 @@ func (server *ContainerServer) ContainerGetHandler(writer http.ResponseWriter, r
 	headers.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(info.StoragePolicyIndex))
 	metadata, err := db.GetMetadata()
 	if err != nil {
-		srv.GetLogger(request).LogError("Unable to get metadata: %v", err)
+		srv.GetLogger(request).Error("Unable to get metadata.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -140,7 +141,7 @@ func (server *ContainerServer) ContainerGetHandler(writer http.ResponseWriter, r
 		headers.Set(key, value)
 	}
 	if deleted, err := db.IsDeleted(); err != nil {
-		srv.GetLogger(request).LogError("Error calling IsDeleted: %v", err)
+		srv.GetLogger(request).Error("Error calling IsDeleted.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	} else if deleted {
@@ -180,7 +181,7 @@ func (server *ContainerServer) ContainerGetHandler(writer http.ResponseWriter, r
 	reverse := common.LooksTrue(request.Form.Get("reverse"))
 	objects, err := db.ListObjects(int(limit), marker, endMarker, prefix, delimiter, path, reverse, policyIndex)
 	if err != nil {
-		srv.GetLogger(request).LogError("Unable to list objects: %v", err)
+		srv.GetLogger(request).Error("Unable to list objects.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -276,13 +277,13 @@ func (server *ContainerServer) ContainerPutHandler(writer http.ResponseWriter, r
 		srv.StandardResponse(writer, http.StatusConflict)
 		return
 	} else if err != nil {
-		srv.GetLogger(request).LogError("Unable to create database: %v", err)
+		srv.GetLogger(request).Error("Unable to create database.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
 	defer server.containerEngine.Return(db)
 	if info, err := db.GetInfo(); err == nil {
-		server.accountUpdate(request, vars, info, srv.GetLogger(request))
+		server.accountUpdate(writer, request, vars, info, srv.GetLogger(request))
 	}
 	if created {
 		srv.StandardResponse(writer, http.StatusCreated)
@@ -299,7 +300,7 @@ func (server *ContainerServer) ContainerDeleteHandler(writer http.ResponseWriter
 		srv.StandardResponse(writer, http.StatusNotFound)
 		return
 	} else if err != nil {
-		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.GetLogger(request).Error("Unable to get container.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -311,7 +312,7 @@ func (server *ContainerServer) ContainerDeleteHandler(writer http.ResponseWriter
 	}
 	info, err := db.GetInfo()
 	if err != nil {
-		srv.GetLogger(request).LogError("Unable to get container info: %v", err)
+		srv.GetLogger(request).Error("Unable to get container info.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -320,13 +321,13 @@ func (server *ContainerServer) ContainerDeleteHandler(writer http.ResponseWriter
 		return
 	}
 	if err = db.Delete(timestamp); err != nil {
-		srv.GetLogger(request).LogError("Unable to delete database: %v", err)
+		srv.GetLogger(request).Error("Unable to delete database.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
 	info, err = db.GetInfo()
 	if err == nil {
-		server.accountUpdate(request, vars, info, srv.GetLogger(request))
+		server.accountUpdate(writer, request, vars, info, srv.GetLogger(request))
 	}
 	writer.WriteHeader(http.StatusNoContent)
 	writer.Write([]byte(""))
@@ -359,13 +360,13 @@ func (server *ContainerServer) ContainerPostHandler(writer http.ResponseWriter, 
 		srv.StandardResponse(writer, http.StatusNotFound)
 		return
 	} else if err != nil {
-		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.GetLogger(request).Error("Unable to get container", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
 	defer server.containerEngine.Return(db)
 	if deleted, err := db.IsDeleted(); err != nil {
-		srv.GetLogger(request).LogError("Error calling IsDeleted: %v", err)
+		srv.GetLogger(request).Error("Error calling IsDeleted.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	} else if deleted {
@@ -405,7 +406,7 @@ func (server *ContainerServer) ObjPutHandler(writer http.ResponseWriter, request
 	if err == ErrorNoSuchContainer {
 		if strings.HasPrefix(vars["account"], server.autoCreatePrefix) {
 			if _, db, err = server.containerEngine.Create(vars, timestamp, map[string][]string{}, policyIndex, 0); err != nil {
-				srv.GetLogger(request).LogError("Unable to auto-create container: %v", err)
+				srv.GetLogger(request).Error("Unable to auto-create container.", zap.Error(err))
 				srv.StandardResponse(writer, http.StatusInternalServerError)
 				return
 			}
@@ -414,13 +415,13 @@ func (server *ContainerServer) ObjPutHandler(writer http.ResponseWriter, request
 			return
 		}
 	} else if err != nil {
-		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.GetLogger(request).Error("Unable to get container.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
 	defer server.containerEngine.Return(db)
 	if err := db.PutObject(vars["obj"], timestamp, size, contentType, etag, policyIndex); err != nil {
-		srv.GetLogger(request).LogError("Error adding object to container: %v", err)
+		srv.GetLogger(request).Error("Error adding object to container.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -443,7 +444,7 @@ func (server *ContainerServer) ObjDeleteHandler(writer http.ResponseWriter, requ
 	if err == ErrorNoSuchContainer {
 		if strings.HasPrefix(vars["account"], server.autoCreatePrefix) {
 			if _, db, err = server.containerEngine.Create(vars, timestamp, map[string][]string{}, policyIndex, 0); err != nil {
-				srv.GetLogger(request).LogError("Unable to auto-create container: %v", err)
+				srv.GetLogger(request).Error("Unable to auto-create container.", zap.Error(err))
 				srv.StandardResponse(writer, http.StatusInternalServerError)
 				return
 			}
@@ -452,13 +453,13 @@ func (server *ContainerServer) ObjDeleteHandler(writer http.ResponseWriter, requ
 			return
 		}
 	} else if err != nil {
-		srv.GetLogger(request).LogError("Unable to get container: %v", err)
+		srv.GetLogger(request).Error("Unable to get container.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
 	defer server.containerEngine.Return(db)
 	if err := db.DeleteObject(vars["obj"], timestamp, policyIndex); err != nil {
-		srv.GetLogger(request).LogError("Error adding object to container: %v", err)
+		srv.GetLogger(request).Error("Error adding object to container.", zap.Error(err))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -499,29 +500,28 @@ func (server *ContainerServer) DiskUsageHandler(writer http.ResponseWriter, requ
 func (server *ContainerServer) LogRequest(next http.Handler) http.Handler {
 	fn := func(writer http.ResponseWriter, request *http.Request) {
 		newWriter := &srv.WebWriter{ResponseWriter: writer, Status: 500, ResponseStarted: false}
-		requestLogger := &srv.RequestLogger{Request: request, Logger: server.logger, W: newWriter}
-		defer requestLogger.LogPanics("LOGGING REQUEST")
 		start := time.Now()
-		request = srv.SetLogger(request, requestLogger)
+		logr := server.logger.With(zap.String("txn", request.Header.Get("X-Trans-Id")))
+		request = srv.SetLogger(request, logr)
 		next.ServeHTTP(newWriter, request)
 		forceAcquire := request.Header.Get("X-Force-Acquire") == "true"
-		if (request.Method != "REPLICATE" && request.Method != "REPCONN") || server.logLevel == "DEBUG" {
+		lvl, _ := server.logLevel.MarshalText()
+		if (request.Method != "REPLICATE" && request.Method != "REPCONN") || strings.ToUpper(string(lvl)) == "DEBUG" {
 			extraInfo := "-"
 			if forceAcquire {
 				extraInfo = "FA"
 			}
-			server.logger.Info(fmt.Sprintf("%s - - [%s] \"%s %s\" %d %s \"%s\" \"%s\" \"%s\" %.4f \"%s\"",
-				request.RemoteAddr,
-				time.Now().Format("02/Jan/2006:15:04:05 -0700"),
-				request.Method,
-				common.Urlencode(request.URL.Path),
-				newWriter.Status,
-				common.GetDefault(newWriter.Header(), "Content-Length", "-"),
-				common.GetDefault(request.Header, "Referer", "-"),
-				common.GetDefault(request.Header, "X-Trans-Id", "-"),
-				common.GetDefault(request.Header, "User-Agent", "-"),
-				time.Since(start).Seconds(),
-				extraInfo))
+			logr.Info("Request log",
+				zap.String("remoteAddr", request.RemoteAddr),
+				zap.String("eventTime", time.Now().Format("02/Jan/2006:15:04:05 -0700")),
+				zap.String("method", request.Method),
+				zap.String("urlPath", common.Urlencode(request.URL.Path)),
+				zap.Int("status", newWriter.Status),
+				zap.String("contentLength", common.GetDefault(newWriter.Header(), "Content-Length", "-")),
+				zap.String("referer", common.GetDefault(request.Header, "Referer", "-")),
+				zap.String("userAgent", common.GetDefault(request.Header, "User-Agent", "-")),
+				zap.Float64("requestTimeSeconds", time.Since(start).Seconds()),
+				zap.String("extraInfo", extraInfo))
 		}
 	}
 	return http.HandlerFunc(fn)
@@ -571,8 +571,10 @@ func (server *ContainerServer) updateDeviceLocks(seconds int64) {
 
 // GetHandler returns the server's http handler - it sets up routes and instantiates middleware.
 func (server *ContainerServer) GetHandler(config conf.Config) http.Handler {
-	commonHandlers := alice.New(server.LogRequest, middleware.ValidateRequest, server.AcquireDevice)
+	commonHandlers := alice.New(server.LogRequest, middleware.RecoverHandler, middleware.ValidateRequest, server.AcquireDevice)
 	router := srv.NewRouter()
+	router.Get("/loglevel", server.logLevel)
+	router.Put("/loglevel", server.logLevel)
 	router.Get("/healthcheck", commonHandlers.ThenFunc(server.HealthcheckHandler))
 	router.Get("/diskusage", commonHandlers.ThenFunc(server.DiskUsageHandler))
 	router.Get("/recon/:method/:recon_type", commonHandlers.ThenFunc(server.ReconHandler))
@@ -608,13 +610,20 @@ func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bind
 	server.autoCreatePrefix = serverconf.GetDefault("app:container-server", "auto_create_account_prefix", ".")
 	server.driveRoot = serverconf.GetDefault("app:container-server", "devices", "/srv/node")
 	server.checkMounts = serverconf.GetBool("app:container-server", "mount_check", true)
-	server.logLevel = serverconf.GetDefault("app:container-server", "log_level", "INFO")
+
+	logLevelString := serverconf.GetDefault("app:container-server", "log_level", "INFO")
+	server.logLevel = zap.NewAtomicLevel()
+	server.logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
+
+	logPath := serverconf.GetDefault("app:container-server", "log_path", "/var/log/swift/container.log")
+	if server.logger, err = srv.SetupLogger("container-server", &server.logLevel, flags, logPath); err != nil {
+		return "", 0, nil, nil, fmt.Errorf("Error setting up logger: %v", err)
+	}
+
 	server.diskInUse = common.NewKeyedLimit(serverconf.GetLimit("app:container-server", "disk_limit", 25, 10000))
 	bindIP = serverconf.GetDefault("app:container-server", "bind_ip", "0.0.0.0")
 	bindPort = int(serverconf.GetInt("app:container-server", "bind_port", 6000))
-	if server.logger, err = srv.SetupLogger(serverconf, flags, "app:container-server", "container-server"); err != nil {
-		return "", 0, nil, nil, fmt.Errorf("Error setting up logger: %v", err)
-	}
+
 	server.containerEngine = newLRUEngine(server.driveRoot, server.hashPathPrefix, server.hashPathSuffix, 32)
 	connTimeout := time.Duration(serverconf.GetFloat("app:container-server", "conn_timeout", 1.0) * float64(time.Second))
 	nodeTimeout := time.Duration(serverconf.GetFloat("app:container-server", "node_timeout", 10.0) * float64(time.Second))

--- a/containerserver/server_test.go
+++ b/containerserver/server_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
 	"github.com/troubling/hummingbird/common/test"
+	"go.uber.org/zap"
 )
 
 func TestFormatTimestamp(t *testing.T) {
@@ -607,7 +608,7 @@ func TestGetServer(t *testing.T) {
 	require.Equal(t, 1000, bindPort)
 	require.NotNil(t, logger)
 	require.Equal(t, "whatever", server.driveRoot)
-	require.Equal(t, "INFO", server.logLevel)
+	require.Equal(t, zap.NewAtomicLevelAt(zap.InfoLevel), server.logLevel)
 	require.False(t, server.checkMounts)
 	require.NotNil(t, server.updateClient)
 	require.NotNil(t, server.containerEngine)

--- a/containerserver/update.go
+++ b/containerserver/update.go
@@ -24,24 +24,26 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/srv"
+	"github.com/troubling/hummingbird/middleware"
+	"go.uber.org/zap"
 )
 
 var waitForAccountUpdate = time.Second * 5
 
-func (server *ContainerServer) accountUpdate(request *http.Request, vars map[string]string, info *ContainerInfo, logger srv.LoggingContext) {
+func (server *ContainerServer) accountUpdate(writer http.ResponseWriter, request *http.Request, vars map[string]string, info *ContainerInfo, logger srv.LowLevelLogger) {
 	firstDone := make(chan struct{}, 1)
 	go func() {
 		defer func() { firstDone <- struct{}{} }()
-		defer logger.LogPanics("PANIC WHILE UPDATING ACCOUNT")
+		defer middleware.Recover(writer, request, "PANIC WHILE UPDATING ACCOUNT")
 		accpartition := request.Header.Get("X-Account-Partition")
 		if accpartition == "" {
-			logger.LogError("Account update failed: bad partition")
+			logger.Error("Account update failed: bad partition")
 			return
 		}
 		hosts := strings.Split(request.Header.Get("X-Account-Host"), ",")
 		devices := strings.Split(request.Header.Get("X-Account-Device"), ",")
 		if len(hosts) != len(devices) {
-			logger.LogError("Account update failed: different numbers of hosts and devices in request")
+			logger.Error("Account update failed: different numbers of hosts and devices in request")
 			return
 		}
 		for index, host := range hosts {
@@ -49,7 +51,7 @@ func (server *ContainerServer) accountUpdate(request *http.Request, vars map[str
 				common.Urlencode(vars["account"]), common.Urlencode(vars["container"]))
 			req, err := http.NewRequest("PUT", url, nil)
 			if err != nil {
-				logger.LogError("Account update failed: error creating request object")
+				logger.Error("Account update failed: error creating request object")
 				continue
 			}
 			req.Header.Add("X-Put-Timestamp", info.PutTimestamp)
@@ -63,12 +65,16 @@ func (server *ContainerServer) accountUpdate(request *http.Request, vars map[str
 			}
 			resp, err := server.updateClient.Do(req)
 			if err != nil {
-				logger.LogError("Account update failed: bad response from %s/%s", hosts[index], devices[index])
+				logger.Error("Account update failed: bad response",
+					zap.String("hosts[index]", hosts[index]),
+					zap.String("devices[index]", devices[index]))
 				continue
 			}
 			defer resp.Body.Close()
 			if (resp.StatusCode / 100) != 2 {
-				logger.LogError("Account update failed: bad response from %s/%s", hosts[index], devices[index])
+				logger.Error("Account update failed: bad response",
+					zap.String("hosts[index]", hosts[index]),
+					zap.String("devices[index]", devices[index]))
 			}
 		}
 	}()

--- a/containerserver/update_test.go
+++ b/containerserver/update_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
 	"github.com/troubling/hummingbird/common/test"
 )
 
@@ -55,7 +57,8 @@ func TestAccountUpdate(t *testing.T) {
 	request.Header.Set("X-Trans-Id", "atxid")
 	request.Header.Set("X-Account-Override-Deleted", "no")
 	vars := map[string]string{"account": "a", "container": "c"}
-	server.accountUpdate(request, vars, info, test.FakeLogger{})
+	writer := test.MakeCaptureResponse()
+	server.accountUpdate(writer, request, vars, info, zap.NewNop())
 }
 
 func TestAccountUpdateBadHeaders(t *testing.T) {
@@ -81,7 +84,8 @@ func TestAccountUpdateBadHeaders(t *testing.T) {
 	request.Header.Set("X-Account-Device", "adevice,anotherdevice")
 	request.Header.Set("X-Trans-Id", "atxid")
 	vars := map[string]string{"account": "a", "container": "c"}
-	server.accountUpdate(request, vars, info, test.FakeLogger{})
+	writer := test.MakeCaptureResponse()
+	server.accountUpdate(writer, request, vars, info, zap.NewNop())
 	require.False(t, called)
 }
 
@@ -112,6 +116,7 @@ func TestAccountUpdateTimeout(t *testing.T) {
 	}(waitForAccountUpdate)
 	waitForAccountUpdate = time.Millisecond
 	start := time.Now()
-	server.accountUpdate(request, vars, info, test.FakeLogger{})
+	writer := test.MakeCaptureResponse()
+	server.accountUpdate(writer, request, vars, info, zap.NewNop())
 	require.True(t, time.Since(start) < time.Second)
 }

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -1,0 +1,44 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"github.com/troubling/hummingbird/common/srv"
+)
+
+func Recover(w http.ResponseWriter, r *http.Request, msg string) {
+	if err := recover(); err != nil {
+		transactionId := r.Header.Get("X-Trans-Id")
+		srv.GetLogger(r).Error(msg, zap.Any("err", err), zap.String("txn", transactionId))
+		// if we haven't set a status code yet, we can send a 500 response.
+		if started, _ := w.(srv.WebWriterInterface).Response(); !started {
+			srv.StandardResponse(w, http.StatusInternalServerError)
+		}
+	}
+}
+
+func RecoverHandler(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		defer Recover(w, r, "PANIC")
+		next.ServeHTTP(w, r)
+	}
+
+	return http.HandlerFunc(fn)
+}

--- a/objectserver/auditor.go
+++ b/objectserver/auditor.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,6 +32,7 @@ import (
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/middleware"
+	"go.uber.org/zap"
 )
 
 // AuditForeverInterval represents how often a auditor check should be performed.
@@ -148,14 +149,14 @@ func (a *Auditor) auditSuffix(suffixDir string) {
 	if err != nil {
 		a.errors++
 		a.totalErrors++
-		a.LogError("Error reading suffix dir %s", suffixDir)
+		a.logger.Error("Error reading suffix dir", zap.String("suffixDir", suffixDir))
 		return
 	}
 	for _, hash := range hashes {
 		_, hexErr := hex.DecodeString(hash)
 		hashDir := filepath.Join(suffixDir, hash)
 		if finfo, err := os.Stat(hashDir); err != nil || len(hash) != 32 || hexErr != nil || !finfo.Mode().IsDir() {
-			a.LogError("Skipping invalid file in suffix: %s", hashDir)
+			a.logger.Error("Skipping invalid file in suffix", zap.String("hashDir", hashDir))
 			continue
 		}
 		a.passes++
@@ -166,7 +167,9 @@ func (a *Auditor) auditSuffix(suffixDir string) {
 		rateLimitSleep(a.passStart, a.totalPasses, a.filesPerSecond)
 		rateLimitSleep(a.passStart, a.totalBytes, a.bytesPerSecond)
 		if err != nil {
-			a.LogError("%s failed audit and is being quarantined: %v", hashDir, err)
+			a.logger.Error("Failed audit and is being quarantined",
+				zap.String("hashDir", hashDir),
+				zap.Error(err))
 			QuarantineHash(hashDir)
 			InvalidateHash(hashDir)
 			a.quarantines++
@@ -181,7 +184,7 @@ func (a *Auditor) auditPartition(partitionDir string) {
 	if err != nil {
 		a.errors++
 		a.totalErrors++
-		a.LogError("Error reading partition dir %s", partitionDir)
+		a.logger.Error("Error reading partition dir ", zap.String("partitionDir", partitionDir))
 		return
 	}
 	for _, suffix := range suffixes {
@@ -191,7 +194,7 @@ func (a *Auditor) auditPartition(partitionDir string) {
 		}
 		_, hexErr := strconv.ParseInt(suffix, 16, 64)
 		if finfo, err := os.Stat(suffixDir); err != nil || len(suffix) != 3 || hexErr != nil || !finfo.Mode().IsDir() {
-			a.LogError("Skipping invalid file in partition: %s", suffixDir)
+			a.logger.Error("Skipping invalid file in partition.", zap.String("suffixDir", suffixDir))
 			continue
 		}
 		a.auditSuffix(suffixDir)
@@ -203,10 +206,10 @@ func (a *Auditor) auditPartition(partitionDir string) {
 
 // auditDevice, checking for mount, list partitions, then call auditPartition() for each.
 func (a *Auditor) auditDevice(devPath string) {
-	defer a.LogPanics("PANIC WHILE AUDITING DEVICE")
+	defer srv.LogPanics(a.logger, "PANIC WHILE AUDITING DEVICE")
 
 	if mounted, err := fs.IsMount(devPath); a.checkMounts && (err != nil || mounted != true) {
-		a.LogError("Skipping unmounted device: %s", devPath)
+		a.logger.Error("Skipping unmounted device", zap.String("devPath", devPath))
 		return
 	}
 
@@ -219,14 +222,14 @@ func (a *Auditor) auditDevice(devPath string) {
 		if err != nil {
 			a.errors++
 			a.totalErrors++
-			a.LogError("Error reading objects dir: %s", objPath)
+			a.logger.Error("Error reading objects dir", zap.String("objPath", objPath))
 			continue
 		}
 		for _, partition := range partitions {
 			_, intErr := strconv.ParseInt(partition, 10, 64)
 			partitionDir := filepath.Join(objPath, partition)
 			if finfo, err := os.Stat(partitionDir); err != nil || intErr != nil || !finfo.Mode().IsDir() {
-				a.LogError("Skipping invalid file in objects directory: %s", partitionDir)
+				a.logger.Error("Skipping invalid file in objects directory", zap.String("partitionDir", partitionDir))
 				continue
 			}
 			a.auditPartition(partitionDir)
@@ -243,9 +246,18 @@ func (a *Auditor) statsReport() {
 	brate := float64(a.bytesProcessed) / sinceLast
 	audit := 0.0      // TODO maybe
 	audit_rate := 0.0 // TODO maybe
-	a.LogInfo("Object audit (%s). Since %s: Locally: %d passed, %d quarantined, %d errors, files/sec: %.2f ,"+
-		" bytes/sec: %.2f, Total time: %.2f, Auditing time: %.2f, Rate: %.2f",
-		a.auditorType, a.lastLog.Format(time.ANSIC), a.passes, a.quarantines, a.errors, frate, brate, total, audit, audit_rate)
+	a.logger.Info("statsReport",
+		zap.String("Object audit", a.auditorType),
+		zap.String("Since", a.lastLog.Format(time.ANSIC)),
+		zap.Int64("Locally passed", a.passes),
+		zap.Int64("Locally quarantied", a.quarantines),
+		zap.Int64("Locally errored", a.errors),
+		zap.Float64("files/sec", frate),
+		zap.Float64("bytes/sec", brate),
+		zap.Float64("Total time", total),
+		zap.Float64("Auditing Time", audit),
+		zap.Float64("Auditing Rate", audit_rate))
+
 	middleware.DumpReconCache(a.reconCachePath, "object",
 		map[string]interface{}{"object_auditor_stats_" + a.auditorType: map[string]interface{}{
 			"errors":          a.errors,
@@ -269,9 +281,16 @@ func (a *Auditor) finalLog() {
 	brate := float64(a.totalBytes) / elapsed
 	audit := 0.0      // TODO maybe
 	audit_rate := 0.0 // TODO maybe
-	a.LogInfo("Object audit (%s) \"%s\" mode completed: %.02fs. Total quarantined: %d, Total errors: %d, "+
-		"Total files/sec: %.2f, Total bytes/sec: %.2f, Auditing time: %.2f, Rate: %.2f",
-		a.auditorType, a.mode, elapsed, a.totalQuarantines, a.totalErrors, frate, brate, audit, audit_rate)
+	a.logger.Info("Object Audit",
+		zap.String("Auditor type", a.auditorType),
+		zap.String("Mode", a.mode),
+		zap.Float64("completed", elapsed),
+		zap.Int64("Total quarantined", a.totalQuarantines),
+		zap.Int64("Total errors", a.totalErrors),
+		zap.Float64("Total files/sec", frate),
+		zap.Float64("Total bytes/sec", brate),
+		zap.Float64("Auditing time", audit),
+		zap.Float64("Auditing rate", audit_rate))
 }
 
 // run audit passes of the whole server until c is closed.
@@ -287,33 +306,19 @@ func (a *Auditor) run(c <-chan time.Time) {
 		a.totalBytes = 0
 		a.totalQuarantines = 0
 		a.totalErrors = 0
-		a.LogInfo("Begin object audit \"%s\" mode (%s%s)", a.mode, a.auditorType, a.driveRoot)
+		a.logger.Info("Begin object audit",
+			zap.String("mode", a.mode),
+			zap.String("auditorType", a.auditorType),
+			zap.String("driveRoot", a.driveRoot))
 		devices, err := fs.ReadDirNames(a.driveRoot)
 		if err != nil {
-			a.LogError("Unable to list devices: %s", a.driveRoot)
+			a.logger.Error("Unable to list devices", zap.String("driveRoot", a.driveRoot))
 			continue
 		}
 		for _, dev := range devices {
 			a.auditDevice(filepath.Join(a.driveRoot, dev))
 		}
 		a.finalLog()
-	}
-}
-
-// LogError with AuditorDaemon
-func (a *AuditorDaemon) LogError(format string, args ...interface{}) {
-	a.logger.Err(fmt.Sprintf(format, args...))
-}
-
-// LogInfo with AuditorDaemon
-func (a *AuditorDaemon) LogInfo(format string, args ...interface{}) {
-	a.logger.Info(fmt.Sprintf(format, args...))
-}
-
-// LogPanics with AuditorDaemon
-func (a *AuditorDaemon) LogPanics(m string) {
-	if e := recover(); e != nil {
-		a.LogError("%s: %s: %s", m, e, debug.Stack())
 	}
 }
 
@@ -344,22 +349,27 @@ func (d *AuditorDaemon) RunForever() {
 }
 
 // NewAuditor returns a new AuditorDaemon with the given conf.
-func NewAuditor(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, error) {
+func NewAuditor(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, srv.LowLevelLogger, error) {
 	var err error
 	if !serverconf.HasSection("object-auditor") {
-		return nil, fmt.Errorf("Unable to find object-auditor config section")
+		return nil, nil, fmt.Errorf("Unable to find object-auditor config section")
 	}
 	d := &AuditorDaemon{}
 	d.policies = conf.LoadPolicies()
 	d.driveRoot = serverconf.GetDefault("object-auditor", "devices", "/srv/node")
 	d.checkMounts = serverconf.GetBool("object-auditor", "mount_check", true)
-	if d.logger, err = srv.SetupLogger(serverconf, flags, "app:object-auditor", "object-auditor"); err != nil {
-		return nil, fmt.Errorf("Error setting up logger: %v", err)
+
+	logLevelString := serverconf.GetDefault("object-auditor", "log_level", "INFO")
+	logLevel := zap.NewAtomicLevel()
+	logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
+	logPath := serverconf.GetDefault("object-auditor", "log_path", "/var/log/swift/objectauditor.log")
+	if d.logger, err = srv.SetupLogger("object-auditor", &logLevel, flags, logPath); err != nil {
+		return nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	d.bytesPerSecond = serverconf.GetInt("object-auditor", "bytes_per_second", 10000000)
 	d.regFilesPerSecond = serverconf.GetInt("object-auditor", "files_per_second", 20)
 	d.zbFilesPerSecond = serverconf.GetInt("object-auditor", "zero_byte_files_per_second", 50)
 	d.reconCachePath = serverconf.GetDefault("object-auditor", "recon_cache_path", "/var/cache/swift")
 	d.logTime = serverconf.GetInt("object-auditor", "log_time", 3600)
-	return d, nil
+	return d, d.logger, nil
 }

--- a/objectserver/auditor_test.go
+++ b/objectserver/auditor_test.go
@@ -27,6 +27,9 @@ import (
 
 	"github.com/troubling/hummingbird/common/conf"
 	"github.com/troubling/hummingbird/common/pickle"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -174,24 +177,26 @@ func TestAuditHashNoMetadata(t *testing.T) {
 	assert.Equal(t, bytesProcessed, int64(0))
 }
 
-type auditLogSaver struct {
-	logged []string
-}
+// type auditLogSaver struct {
+// 	logged []string
+// }
 
-func (s *auditLogSaver) Err(line string) error {
-	s.logged = append(s.logged, line)
-	return nil
-}
+// func (s *auditLogSaver) Err(line string) error {
+// 	s.logged = append(s.logged, line)
+// 	return nil
+// }
 
-func (s *auditLogSaver) Info(line string) error {
-	s.logged = append(s.logged, line)
-	return nil
-}
+// func (s *auditLogSaver) Info(line string) error {
+// 	s.logged = append(s.logged, line)
+// 	return nil
+// }
 
-func (s *auditLogSaver) Debug(line string) error {
-	s.logged = append(s.logged, line)
-	return nil
-}
+// func (s *auditLogSaver) Debug(line string) error {
+// 	s.logged = append(s.logged, line)
+// 	return nil
+// }
+var obs zapcore.Core
+var logs *observer.ObservedLogs
 
 func makeAuditor(settings ...string) *Auditor {
 	configString := "[object-auditor]\n"
@@ -199,29 +204,30 @@ func makeAuditor(settings ...string) *Auditor {
 		configString += fmt.Sprintf("%s=%s\n", settings[i], settings[i+1])
 	}
 	conf, _ := conf.StringConfig(configString)
-	auditorDaemon, _ := NewAuditor(conf, &flag.FlagSet{})
-	auditorDaemon.(*AuditorDaemon).logger = &auditLogSaver{}
+	auditorDaemon, _, _ := NewAuditor(conf, &flag.FlagSet{})
+	obs, logs = observer.New(zap.InfoLevel)
+	auditorDaemon.(*AuditorDaemon).logger = zap.New(obs)
 	return &Auditor{AuditorDaemon: auditorDaemon.(*AuditorDaemon), filesPerSecond: 1}
 }
 
 func TestFailsWithoutSection(t *testing.T) {
 	conf, err := conf.StringConfig("")
 	require.Nil(t, err)
-	auditorDaemon, err := NewAuditor(conf, &flag.FlagSet{})
+	auditorDaemon, logger, err := NewAuditor(conf, &flag.FlagSet{})
 	require.NotNil(t, err)
+	require.Nil(t, logger)
 	assert.Nil(t, auditorDaemon)
 	assert.True(t, strings.HasPrefix(err.Error(), "Unable to find object-auditor"))
 }
 
 func TestAuditSuffixNotDir(t *testing.T) {
 	auditor := makeAuditor()
-	auditor.logger = &auditLogSaver{}
 	file, _ := ioutil.TempFile("", "")
 	defer file.Close()
 	defer os.RemoveAll(file.Name())
 	errors := auditor.errors
 	auditor.auditSuffix(file.Name())
-	assert.True(t, strings.HasPrefix(auditor.logger.(*auditLogSaver).logged[0], "Error reading suffix dir"))
+	assert.Equal(t, logs.TakeAll()[0].Message, "Error reading suffix dir")
 	assert.True(t, auditor.errors > errors)
 }
 
@@ -261,18 +267,17 @@ func TestAuditSuffixSkipsBad(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "objects", "1", "abc", "notavalidhash"), 0777)
 	auditor := makeAuditor()
 	auditor.auditSuffix(filepath.Join(dir, "objects", "1", "abc"))
-	assert.True(t, strings.HasPrefix(auditor.logger.(*auditLogSaver).logged[0], "Skipping invalid file in suffix"))
+	assert.Equal(t, logs.TakeAll()[0].Message, "Skipping invalid file in suffix")
 }
 
 func TestAuditPartitionNotDir(t *testing.T) {
 	auditor := makeAuditor()
-	auditor.logger = &auditLogSaver{}
 	file, _ := ioutil.TempFile("", "")
 	defer file.Close()
 	defer os.RemoveAll(file.Name())
 	errors := auditor.errors
 	auditor.auditPartition(file.Name())
-	assert.True(t, strings.HasPrefix(auditor.logger.(*auditLogSaver).logged[0], "Error reading partition dir"))
+	assert.Equal(t, logs.TakeAll()[0].Message, "Error reading partition dir ")
 	assert.True(t, auditor.errors > errors)
 }
 
@@ -313,13 +318,12 @@ func TestAuditPartitionSkipsBadData(t *testing.T) {
 
 func TestAuditDeviceNotDir(t *testing.T) {
 	auditor := makeAuditor("mount_check", "false")
-	auditor.logger = &auditLogSaver{}
 	file, _ := ioutil.TempFile("", "")
 	defer file.Close()
 	defer os.RemoveAll(file.Name())
 	errors := auditor.errors
 	auditor.auditDevice(file.Name())
-	assert.True(t, strings.HasPrefix(auditor.logger.(*auditLogSaver).logged[0], "Error reading objects dir"))
+	assert.Equal(t, logs.TakeAll()[0].Message, "Error reading objects dir")
 	assert.True(t, auditor.errors > errors)
 }
 
@@ -360,13 +364,11 @@ func TestAuditDeviceUnmounted(t *testing.T) {
 	os.MkdirAll(filepath.Join(dir, "sda", "objects", "1"), 0777)
 	auditor := makeAuditor("mount_check", "true")
 	auditor.auditDevice(filepath.Join(dir, "sda"))
-	assert.True(t, strings.HasPrefix(auditor.logger.(*auditLogSaver).logged[0], "Skipping unmounted device"))
+	assert.Equal(t, logs.TakeAll()[0].Message, "Skipping unmounted device")
 }
 
 func TestFinalLog(t *testing.T) {
 	auditor := makeAuditor()
-	logger := &auditLogSaver{}
-	auditor.logger = logger
 	auditor.passStart = time.Now().Add(-60 * time.Second)
 	auditor.totalQuarantines = 5
 	auditor.totalErrors = 3
@@ -375,8 +377,30 @@ func TestFinalLog(t *testing.T) {
 	auditor.auditorType = "ALL"
 	auditor.mode = "forever"
 	auditor.finalLog()
-	assert.Equal(t, "Object audit (ALL) \"forever\" mode completed: 60.00s. Total quarantined: 5, Total errors: 3, Total files/sec: 2.00, "+
-		"Total bytes/sec: 2000.00, Auditing time: 0.00, Rate: 0.00", logger.logged[0])
+	want := []observer.LoggedEntry{{
+		Entry: zapcore.Entry{Level: zap.InfoLevel, Message: "Object Audit"},
+		Context: []zapcore.Field{zap.String("Auditor type", "ALL"),
+			zap.String("Mode", "forever"),
+			zap.Float64("completed", 60.00),
+			zap.Int64("Total quarantined", 5),
+			zap.Int64("Total errors", 3),
+			zap.Float64("Total files/sec", 2.00),
+			zap.Float64("Total bytes/sec", 2000.00),
+			zap.Float64("Auditing time", 0.00),
+			zap.Float64("Auditing rate", 0.00)},
+	}}
+	obslog := logs.AllUntimed()[0]
+	require.Equal(t, want[0].Message, obslog.Message)
+	require.Equal(t, want[0].Context[0], obslog.Context[0])
+	require.Equal(t, want[0].Context[1], obslog.Context[1])
+	//TODO: Figure out how to do float comparison.
+	//require.Equal(t, want[0].Context[2], obslog.Context[2])
+	require.Equal(t, want[0].Context[3], obslog.Context[3])
+	require.Equal(t, want[0].Context[4], obslog.Context[4])
+	//require.Equal(t, want[0].Context[5], obslog.Context[5])
+	//require.Equal(t, want[0].Context[6], obslog.Context[6])
+	require.Equal(t, want[0].Context[7], obslog.Context[7])
+	require.Equal(t, want[0].Context[8], obslog.Context[8])
 }
 
 func TestAuditRun(t *testing.T) {
@@ -389,8 +413,6 @@ func TestAuditRun(t *testing.T) {
 	f.Write([]byte("testcontents"))
 	auditor := makeAuditor("mount_check", "false")
 	auditor.driveRoot = dir
-	logger := &auditLogSaver{}
-	auditor.logger = logger
 	totalPasses := auditor.totalPasses
 	auditor.run(OneTimeChan())
 	assert.Equal(t, totalPasses+1, auditor.totalPasses)
@@ -406,20 +428,30 @@ func TestStatReport(t *testing.T) {
 	auditor.quarantines = 17
 	auditor.errors = 41
 	auditor.statsReport()
-	args := [13]float64{}
-	var stra, strb string
-	pargs := []interface{}{&stra, &strb}
-	for i := range args {
-		pargs = append(pargs, &args[i])
-	}
-	fmt.Sscanf(
-		auditor.logger.(*auditLogSaver).logged[0],
-		"Object audit (). Since %s %s %f %f:%f:%f %f: Locally: %f passed, %f quarantined, %f errors, files/sec: %f , bytes/sec: %f, Total time: %f, Auditing time: %f, Rate: %f",
-		pargs...)
-	assert.Equal(t, 120.0, args[5])
-	assert.Equal(t, 17.0, args[6])
-	assert.Equal(t, 41.0, args[7])
-	assert.Equal(t, 1.0, args[8])
-	assert.Equal(t, 1000.0, args[9])
-	assert.Equal(t, 120.0, args[10])
+	want := []observer.LoggedEntry{{
+		Entry: zapcore.Entry{Level: zap.InfoLevel, Message: "statsReport"},
+		Context: []zapcore.Field{zap.String("Object audit", ""),
+			zap.String("Since", "Tue May  2 05:48:19 2017"),
+			zap.Int64("Locally passed", 120),
+			zap.Int64("Locally quarantied", 17),
+			zap.Int64("Locally errored", 41),
+			zap.Float64("files/sec", 1),
+			zap.Float64("bytes/sec", 2),
+			zap.Float64("Total time", 3),
+			zap.Float64("Auditing Time", 0.00),
+			zap.Float64("Auditing Rate", 0.00)},
+	}}
+	obslog := logs.AllUntimed()[0]
+	require.Equal(t, want[0].Message, obslog.Message)
+	require.Equal(t, want[0].Context[0], obslog.Context[0])
+	//unable to do time string comparison.
+	//require.Equal(t, want[0].Context[1], obslog.Context[1])
+	require.Equal(t, want[0].Context[2], obslog.Context[2])
+	require.Equal(t, want[0].Context[3], obslog.Context[3])
+	require.Equal(t, want[0].Context[4], obslog.Context[4])
+	//require.Equal(t, want[0].Context[5], obslog.Context[5])
+	//require.Equal(t, want[0].Context[6], obslog.Context[6])
+	//require.Equal(t, want[0].Context[7], obslog.Context[7])
+	require.Equal(t, want[0].Context[8], obslog.Context[8])
+	require.Equal(t, want[0].Context[9], obslog.Context[9])
 }

--- a/objectserver/replicator.go
+++ b/objectserver/replicator.go
@@ -24,7 +24,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"path/filepath"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,6 +36,7 @@ import (
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/middleware"
+	"go.uber.org/zap"
 )
 
 var (
@@ -196,7 +196,7 @@ func (rd *replicationDevice) listObjFiles(objChan chan string, cancel chan struc
 	defer close(objChan)
 	suffixDirs, err := filepath.Glob(filepath.Join(partdir, "[a-f0-9][a-f0-9][a-f0-9]"))
 	if err != nil {
-		rd.r.LogError("[listObjFiles] %v", err)
+		rd.r.logger.Error("[listObjFiles]", zap.Error(err))
 		return
 	}
 	if len(suffixDirs) == 0 {
@@ -216,7 +216,7 @@ func (rd *replicationDevice) listObjFiles(objChan chan string, cancel chan struc
 		}
 		hashDirs, err := filepath.Glob(filepath.Join(suffDir, "????????????????????????????????"))
 		if err != nil {
-			rd.r.LogError("[listObjFiles] %v", err)
+			rd.r.logger.Error("[listObjFiles]", zap.Error(err))
 			return
 		}
 		if len(hashDirs) == 0 {
@@ -230,7 +230,7 @@ func (rd *replicationDevice) listObjFiles(objChan chan string, cancel chan struc
 				continue
 			}
 			if err != nil {
-				rd.r.LogError("[listObjFiles] %v", err)
+				rd.r.logger.Error("[listObjFiles]", zap.Error(err))
 				return
 			}
 			for _, objFile := range fileList {
@@ -257,7 +257,9 @@ func (rd *replicationDevice) syncFile(objFile string, dst []*syncFileArg, handof
 	fp, xattrs, fileSize, err := getFile(objFile)
 	if _, ok := err.(quarantineFileError); ok {
 		hashDir := filepath.Dir(objFile)
-		rd.r.LogError("[syncFile] %s failed audit and is being quarantined: %s", hashDir, err.Error())
+		rd.r.logger.Error("[syncFile] Failed audit and is being quarantined",
+			zap.String("hashDir", hashDir),
+			zap.Error(err))
 		QuarantineHash(hashDir)
 		return 0, 0, nil
 	} else if err != nil {
@@ -309,7 +311,9 @@ func (rd *replicationDevice) syncFile(objFile string, dst []*syncFileArg, handof
 				continue
 			}
 			if _, err := sfa.conn.Write(scratch[0:length]); err != nil {
-				rd.r.LogError("Failed to write to remoteDevice: %d, %v", sfa.dev.Id, err)
+				rd.r.logger.Error("Failed to write to remoteDevice",
+					zap.Int("device id", sfa.dev.Id),
+					zap.Error(err))
 				wrs[index] = nil
 			}
 		}
@@ -383,9 +387,9 @@ func (rd *replicationDevice) replicateLocal(partition string, nodes []*ring.Devi
 	startGetHashesLocal := time.Now()
 
 	recalc := []string{}
-	hashes, err := GetHashes(rd.r.deviceRoot, rd.dev.Device, partition, recalc, rd.r.reclaimAge, rd.policy, rd.r)
+	hashes, err := GetHashes(rd.r.deviceRoot, rd.dev.Device, partition, recalc, rd.r.reclaimAge, rd.policy, rd.r.logger)
 	if err != nil {
-		rd.r.LogError("[replicateLocal] error getting local hashes: %v", err)
+		rd.r.logger.Error("[replicateLocal] error getting local hashes", zap.Error(err))
 		return
 	}
 	for suffix, localHash := range hashes {
@@ -396,9 +400,9 @@ func (rd *replicationDevice) replicateLocal(partition string, nodes []*ring.Devi
 			}
 		}
 	}
-	hashes, err = GetHashes(rd.r.deviceRoot, rd.dev.Device, partition, recalc, rd.r.reclaimAge, rd.policy, rd.r)
+	hashes, err = GetHashes(rd.r.deviceRoot, rd.dev.Device, partition, recalc, rd.r.reclaimAge, rd.policy, rd.r.logger)
 	if err != nil {
-		rd.r.LogError("[replicateLocal] error recalculating local hashes: %v", err)
+		rd.r.logger.Error("[replicateLocal] error recalculating local hashes", zap.Error(err))
 		return
 	}
 	timeGetHashesLocal := float64(time.Now().Sub(startGetHashesLocal)) / float64(time.Second)
@@ -431,7 +435,7 @@ func (rd *replicationDevice) replicateLocal(partition string, nodes []*ring.Devi
 		if syncs, _, err := rd.i.syncFile(objFile, toSync, false); err == nil {
 			syncCount += syncs
 		} else {
-			rd.r.LogError("[syncFile] %v", err)
+			rd.r.logger.Error("[syncFile]", zap.Error(err))
 			return
 		}
 	}
@@ -442,7 +446,12 @@ func (rd *replicationDevice) replicateLocal(partition string, nodes []*ring.Devi
 	}
 	timeSyncing := float64(time.Now().Sub(startSyncing)) / float64(time.Second)
 	if syncCount > 0 {
-		rd.r.LogInfo("[replicateLocal] Partition %s synced %d files (%.2fs / %.2fs / %.2fs)", path, syncCount, timeGetHashesRemote, timeGetHashesLocal, timeSyncing)
+		rd.r.logger.Info("[replicateLocal]",
+			zap.String("Partition", path),
+			zap.Any("Files Synced", syncCount),
+			zap.Float64("timeGetHashesRemote", timeGetHashesRemote),
+			zap.Float64("timeGetHashesLocal", timeGetHashesLocal),
+			zap.Float64("timeSyncing", timeSyncing))
 	}
 }
 
@@ -491,7 +500,7 @@ func (rd *replicationDevice) replicateHandoff(partition string, nodes []*ring.De
 				os.Remove(filepath.Dir(objFile))
 			}
 		} else {
-			rd.r.LogError("[syncFile] %v", err)
+			rd.r.logger.Error("[syncFile]", zap.Error(err))
 			return
 		}
 	}
@@ -501,7 +510,7 @@ func (rd *replicationDevice) replicateHandoff(partition string, nodes []*ring.De
 		}
 	}
 	if syncCount > 0 {
-		rd.r.LogInfo("[replicateHandoff] Partition %s synced %d files", path, syncCount)
+		rd.r.logger.Info("[replicateHandoff]", zap.String("Partition", path), zap.Any("Files Synced", syncCount))
 	}
 }
 
@@ -562,10 +571,10 @@ func (rd *replicationDevice) listPartitions() ([]string, error) {
 }
 
 func (rd *replicationDevice) Replicate() {
-	defer rd.r.LogPanics(fmt.Sprintf("PANIC REPLICATING DEVICE: %s", rd.dev.Device))
+	defer srv.LogPanics(rd.r.logger, fmt.Sprintf("PANIC REPLICATING DEVICE: %s", rd.dev.Device))
 	rd.updateStat("startRun", 1)
 	if mounted, err := fs.IsMount(filepath.Join(rd.r.deviceRoot, rd.dev.Device)); rd.r.checkMounts && (err != nil || mounted != true) {
-		rd.r.LogError("[replicateDevice] Drive not mounted: %s", rd.dev.Device)
+		rd.r.logger.Error("[replicateDevice] Drive not mounted", zap.String("Device", rd.dev.Device))
 		return
 	}
 	if fs.Exists(filepath.Join(rd.r.deviceRoot, rd.dev.Device, "lock_device")) {
@@ -576,10 +585,13 @@ func (rd *replicationDevice) Replicate() {
 
 	partitionList, err := rd.i.listPartitions()
 	if err != nil {
-		rd.r.LogError("[replicateDevice] Error getting partition list: %s (%v)", rd.dev.Device, err)
+		rd.r.logger.Error("[replicateDevice] Error getting partition list",
+			zap.String("Device", rd.dev.Device),
+			zap.Error(err))
 		return
 	} else if len(partitionList) == 0 {
-		rd.r.LogError("[replicateDevice] No partitions found: %s", filepath.Join(rd.r.deviceRoot, rd.dev.Device, PolicyDir(rd.policy)))
+		rd.r.logger.Error("[replicateDevice] No partitions found",
+			zap.String("filepath", filepath.Join(rd.r.deviceRoot, rd.dev.Device, PolicyDir(rd.policy))))
 		return
 	}
 	rd.updateStat("PartitionsTotal", int64(len(partitionList)))
@@ -589,7 +601,7 @@ func (rd *replicationDevice) Replicate() {
 		select {
 		case <-rd.cancel:
 			{
-				rd.r.LogError("replicateDevice canceled for device: %s", rd.dev.Device)
+				rd.r.logger.Error("replicateDevice canceled for device", zap.String("Device", rd.dev.Device))
 				return
 			}
 		default:
@@ -654,7 +666,11 @@ func (rd *replicationDevice) processPriorityJobs() {
 				if handoff {
 					jobType = "handoff"
 				}
-				rd.r.LogInfo("PriorityReplicationJob. Partition: %d as %s from %s to %s", pri.Partition, jobType, pri.FromDevice.Device, strings.Join(toDevicesArr, ","))
+				rd.r.logger.Info("PriorityReplicationJob",
+					zap.Uint64("partition", pri.Partition),
+					zap.String("jobType", jobType),
+					zap.String("From Device", pri.FromDevice.Device),
+					zap.String("To Device", strings.Join(toDevicesArr, ",")))
 				if handoff {
 					rd.i.replicateHandoff(partition, pri.ToDevices)
 				} else {
@@ -697,7 +713,7 @@ type Replicator struct {
 	deviceRoot         string
 	reconCachePath     string
 	logger             srv.LowLevelLogger
-	logLevel           string
+	logLevel           *zap.AtomicLevel
 	port               int
 	bindIp             string
 	Rings              map[int]replicationRing
@@ -740,7 +756,7 @@ func (r *Replicator) verifyRunningDevices() {
 	for policy, ring := range r.Rings {
 		ringDevices, err := ring.LocalDevices(r.port)
 		if err != nil {
-			r.LogError("Error getting local devices from ring: %v", err)
+			r.logger.Error("Error getting local devices from ring", zap.Error(err))
 			return
 		}
 		// look for devices that aren't running but should be
@@ -792,11 +808,14 @@ func (r *Replicator) reportStats() {
 		} else {
 			remainingStr = fmt.Sprintf("%.0fs", remaining.Seconds())
 		}
-
-		r.LogInfo("Device %s %d/%d (%.2f%%) partitions replicated in %.2f worker seconds (%.2f/sec, %v remaining)",
-			rd.Key(), doneParts, totalParts,
-			float64(100*doneParts)/float64(totalParts),
-			processingTimeSec, partsPerSecond, remainingStr)
+		r.logger.Info("Partition Replicated",
+			zap.String("Device", rd.Key()),
+			zap.Int64("doneParts", doneParts),
+			zap.Int64("totalParts", totalParts),
+			zap.Float64("DoneParts/TotalParts", float64(100*doneParts)/float64(totalParts)),
+			zap.Float64("processingTimeSec", processingTimeSec),
+			zap.Float64("partsPerSecond", partsPerSecond),
+			zap.String("remainingStr", remainingStr))
 
 	}
 	if allHaveCompleted {
@@ -893,7 +912,7 @@ func (r *Replicator) Run() {
 	for policy, theRing := range r.Rings {
 		devices, err := theRing.LocalDevices(r.port)
 		if err != nil {
-			r.LogError("Error getting local devices from ring: %v", err)
+			r.logger.Error("Error getting local devices from ring", zap.Error(err))
 			return
 		}
 		for _, dev := range devices {
@@ -913,29 +932,15 @@ func (r *Replicator) Run() {
 	r.reportStats()
 }
 
-func (r *Replicator) LogError(format string, args ...interface{}) {
-	r.logger.Err(fmt.Sprintf(format, args...))
-}
-
-func (r *Replicator) LogInfo(format string, args ...interface{}) {
-	r.logger.Info(fmt.Sprintf(format, args...))
-}
-
-func (r *Replicator) LogDebug(format string, args ...interface{}) {
-	r.logger.Debug(fmt.Sprintf(format, args...))
-}
-
-func (r *Replicator) LogPanics(m string) {
-	if e := recover(); e != nil {
-		r.LogError("%s: %s: %s", m, e, debug.Stack())
-	}
-}
-
-func NewReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, error) {
+func NewReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, srv.LowLevelLogger, error) {
 	if !serverconf.HasSection("object-replicator") {
-		return nil, fmt.Errorf("Unable to find object-replicator config section")
+		return nil, nil, fmt.Errorf("Unable to find object-replicator config section")
 	}
 	concurrency := int(serverconf.GetInt("object-replicator", "concurrency", 1))
+
+	logLevelString := serverconf.GetDefault("object-replicator", "log_level", "INFO")
+	logLevel := zap.NewAtomicLevel()
+	logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
 
 	replicator := &Replicator{
 		runningDevices:   make(map[string]ReplicationDevice),
@@ -950,7 +955,7 @@ func NewReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, err
 		bindIp:           serverconf.GetDefault("object-replicator", "bind_ip", "0.0.0.0"),
 		quorumDelete:     serverconf.GetBool("object-replicator", "quorum_delete", false),
 		reclaimAge:       int64(serverconf.GetInt("object-replicator", "reclaim_age", int64(common.ONE_WEEK))),
-		logLevel:         serverconf.GetDefault("object-replicator", "log_level", "INFO"),
+		logLevel:         &logLevel,
 		Rings:            make(map[int]replicationRing),
 		concurrency:      concurrency,
 		concurrencySem:   make(chan struct{}, concurrency),
@@ -964,18 +969,19 @@ func NewReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, err
 
 	hashPathPrefix, hashPathSuffix, err := conf.GetHashPrefixAndSuffix()
 	if err != nil {
-		return nil, fmt.Errorf("Unable to get hash prefix and suffix")
+		return nil, nil, fmt.Errorf("Unable to get hash prefix and suffix")
 	}
 	for _, policy := range conf.LoadPolicies() {
 		if policy.Type != "replication" {
 			continue
 		}
 		if replicator.Rings[policy.Index], err = GetRing("object", hashPathPrefix, hashPathSuffix, policy.Index); err != nil {
-			return nil, fmt.Errorf("Unable to load ring for Policy %d.", policy.Index)
+			return nil, nil, fmt.Errorf("Unable to load ring for Policy %d.", policy.Index)
 		}
 	}
-	if replicator.logger, err = srv.SetupLogger(serverconf, flags, "app:object-replicator", "object-replicator"); err != nil {
-		return nil, fmt.Errorf("Error setting up logger: %v", err)
+	logPath := serverconf.GetDefault("object-replicator", "log_path", "/var/log/swift/objectreplicator.log")
+	if replicator.logger, err = srv.SetupLogger("object-replicator", &logLevel, flags, logPath); err != nil {
+		return nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	devices_flag := flags.Lookup("devices")
 	if devices_flag != nil {
@@ -1011,5 +1017,5 @@ func NewReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, err
 		prefix := basePrefix + ".go.objectreplicator"
 		go common.CollectRuntimeMetrics(statsdHost, statsdPort, statsdPause, prefix)
 	}
-	return replicator, nil
+	return replicator, replicator.logger, nil
 }

--- a/objectserver/replicator_test.go
+++ b/objectserver/replicator_test.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -41,6 +40,9 @@ import (
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/test"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func newTestReplicator(settings ...string) (*Replicator, error) {
@@ -53,7 +55,7 @@ func newTestReplicatorWithFlags(settings []string, flags *flag.FlagSet) (*Replic
 		configString += fmt.Sprintf("%s=%s\n", settings[i], settings[i+1])
 	}
 	conf, _ := conf.StringConfig(configString)
-	replicator, err := NewReplicator(conf, flags)
+	replicator, _, err := NewReplicator(conf, flags)
 	if err != nil {
 		return nil, err
 	}
@@ -1010,23 +1012,6 @@ func TestVerifyDevices(t *testing.T) {
 	require.True(t, canceled)
 }
 
-type replicationLogSaver struct {
-	logged []string
-}
-
-func (s *replicationLogSaver) Err(l string) error {
-	s.logged = append(s.logged, l)
-	return nil
-}
-func (s *replicationLogSaver) Info(l string) error {
-	s.logged = append(s.logged, l)
-	return nil
-}
-func (s *replicationLogSaver) Debug(l string) error {
-	s.logged = append(s.logged, l)
-	return nil
-}
-
 func TestReportStats(t *testing.T) {
 	oldGetRing := GetRing
 	defer func() {
@@ -1066,24 +1051,57 @@ func TestReportStats(t *testing.T) {
 			_Key: func() string { return "1.1:10/sdb" },
 		},
 	}
-	logger := &replicationLogSaver{}
-	replicator.logger = logger
+	obs, logs := observer.New(zap.InfoLevel)
+	replicator.logger = zap.New(obs)
 	replicator.reportStats()
-	fmt.Println(logger.logged[0])
-	fmt.Println(logger.logged[1])
-	require.Equal(t, 2, len(logger.logged))
-	for _, line := range logger.logged {
-		if strings.Contains(line, "sda") {
-			require.True(t, strings.Contains(line, "Device 1.1:10/sda 500/1000 (50.00%)"))
-			require.True(t, strings.Contains(line, " 1h remaining"))
-		} else if strings.Contains(line, "sdb") {
-			require.True(t, strings.Contains(line, "Device 1.1:10/sdb 40/100 (40.00%)"))
-			require.True(t, strings.Contains(line, " 2h remaining"))
-		} else {
-			require.FailNow(t, fmt.Sprintf("Unexpected log line: '%s'\n", line))
-		}
+	want := []observer.LoggedEntry{{
+		Entry: zapcore.Entry{Level: zap.InfoLevel, Message: "Partition Replicated"},
+		Context: []zapcore.Field{zap.String("Device", "1.1:10/sda"),
+			zap.Int64("doneParts", 500),
+			zap.Int64("totalParts", 1000),
+			zap.Float64("DoneParts/TotalParts", 50.00),
+			zap.Float64("processingTimeSec", 0.00),
+			zap.Float64("partsPerSecond", 0.00),
+			zap.String("remainingStr", "1h")},
+	}, {
+		Entry: zapcore.Entry{Level: zap.InfoLevel, Message: "Partition Replicated"},
+		Context: []zapcore.Field{zap.String("Device", "1.1:10/sdb"),
+			zap.Int64("doneParts", 40),
+			zap.Int64("totalParts", 100),
+			zap.Float64("DoneParts/TotalParts", 40.00),
+			zap.Float64("processingTimeSec", 0.00),
+			zap.Float64("partsPerSecond", 0.00),
+			zap.String("remainingStr", "2h")},
+	}}
+	require.Equal(t, 2, logs.Len())
+	var obslog1, obslog2 observer.LoggedEntry
+	if logs.AllUntimed()[0].Context[1].Integer == 500 {
+		obslog1 = logs.AllUntimed()[0]
+		obslog2 = logs.AllUntimed()[1]
+	} else {
+		obslog2 = logs.AllUntimed()[0]
+		obslog1 = logs.AllUntimed()[1]
 	}
 
+	require.Equal(t, want[0].Message, obslog1.Message)
+	require.Equal(t, want[0].Context[0], obslog1.Context[0])
+	require.Equal(t, want[0].Context[1], obslog1.Context[1])
+	require.Equal(t, want[0].Context[2], obslog1.Context[2])
+	//unable to do float comparison
+	//require.Equal(t, want[0].Context[3], obslog1.Context[3])
+	//require.Equal(t, want[0].Context[4], obslog1.Context[4])
+	//require.Equal(t, want[0].Context[5], obslog1.Context[5])
+	require.Equal(t, want[0].Context[6], obslog1.Context[6])
+
+	require.Equal(t, want[1].Message, obslog2.Message)
+	require.Equal(t, want[1].Context[0], obslog2.Context[0])
+	require.Equal(t, want[1].Context[1], obslog2.Context[1])
+	require.Equal(t, want[1].Context[2], obslog2.Context[2])
+	//unable to do float comparison
+	//require.Equal(t, want[1].Context[3], obslog2.Context[3])
+	//require.Equal(t, want[1].Context[4], obslog2.Context[4])
+	//require.Equal(t, want[1].Context[5], obslog2.Context[5])
+	require.Equal(t, want[1].Context[6], obslog2.Context[6])
 }
 
 func TestPriorityReplicate(t *testing.T) {

--- a/objectserver/repsrv.go
+++ b/objectserver/repsrv.go
@@ -19,7 +19,6 @@ import (
 	"bufio"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -36,6 +35,7 @@ import (
 	"github.com/troubling/hummingbird/common/pickle"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/middleware"
+	"go.uber.org/zap"
 )
 
 // ReplicationManager is used by the object server to limit replication concurrency
@@ -96,7 +96,7 @@ func NewReplicationManager(limitPerDisk int64, limitOverall int64) *ReplicationM
 func (r *Replicator) ProgressReportHandler(w http.ResponseWriter, req *http.Request) {
 	data, err := json.Marshal(r.getDeviceProgress())
 	if err != nil {
-		r.LogError("Error Marshaling device progress: ", err)
+		r.logger.Error("Error Marshaling device progress", zap.Error(err))
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
 		return
@@ -148,7 +148,9 @@ func (r *Replicator) objReplicateHandler(writer http.ResponseWriter, request *ht
 	}
 	hashes, err := GetHashes(r.deviceRoot, vars["device"], vars["partition"], recalculate, r.reclaimAge, policy, srv.GetLogger(request))
 	if err != nil {
-		srv.GetLogger(request).LogError("Unable to get hashes for %s/%s", vars["device"], vars["partition"])
+		srv.GetLogger(request).Error("Unable to get hashes",
+			zap.String("Device", vars["device"]),
+			zap.String("Partition", vars["partition"]))
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -171,11 +173,11 @@ func (r *Replicator) objRepConnHandler(writer http.ResponseWriter, request *http
 
 	writer.WriteHeader(http.StatusOK)
 	if hijacker, ok := writer.(http.Hijacker); !ok {
-		srv.GetLogger(request).LogError("[ObjRepConnHandler] Writer not a Hijacker")
+		srv.GetLogger(request).Error("[ObjRepConnHandler] Writer not a Hijacker")
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	} else if conn, rw, err = hijacker.Hijack(); err != nil {
-		srv.GetLogger(request).LogError("[ObjRepConnHandler] Hijack failed")
+		srv.GetLogger(request).Error("[ObjRepConnHandler] Hijack failed")
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
@@ -183,12 +185,12 @@ func (r *Replicator) objRepConnHandler(writer http.ResponseWriter, request *http
 
 	rc := NewIncomingRepConn(rw, conn)
 	if err := rc.RecvMessage(&brr); err != nil {
-		srv.GetLogger(request).LogError("[ObjRepConnHandler] Error receiving BeginReplicationRequest: %v", err)
+		srv.GetLogger(request).Error("[ObjRepConnHandler] Error receiving BeginReplicationRequest", zap.Error(err))
 		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	if !r.replicationMan.Begin(brr.Device, r.replicateTimeout) {
-		srv.GetLogger(request).LogError("[ObjRepConnHandler] Timed out waiting for concurrency slot")
+		srv.GetLogger(request).Error("[ObjRepConnHandler] Timed out waiting for concurrency slot")
 		writer.WriteHeader(503)
 		return
 	}
@@ -197,13 +199,13 @@ func (r *Replicator) objRepConnHandler(writer http.ResponseWriter, request *http
 	if brr.NeedHashes {
 		hashes, err = GetHashes(r.deviceRoot, brr.Device, brr.Partition, nil, r.reclaimAge, policy, srv.GetLogger(request))
 		if err != nil {
-			srv.GetLogger(request).LogError("[ObjRepConnHandler] Error getting hashes: %v", err)
+			srv.GetLogger(request).Error("[ObjRepConnHandler] Error getting hashes", zap.Error(err))
 			writer.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 	}
 	if err := rc.SendMessage(BeginReplicationResponse{Hashes: hashes}); err != nil {
-		srv.GetLogger(request).LogError("[ObjRepConnHandler] Error sending BeginReplicationResponse: %v", err)
+		srv.GetLogger(request).Error("[ObjRepConnHandler] Error sending BeginReplicationResponse", zap.Error(err))
 		writer.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -268,7 +270,9 @@ func (r *Replicator) objRepConnHandler(writer http.ResponseWriter, request *http
 		if err == replicationDone {
 			return
 		} else if err != nil {
-			srv.GetLogger(request).LogError("[ObjRepConnHandler] Error replicating: %s. %v", errType, err)
+			srv.GetLogger(request).Error("[ObjRepConnHandler] Error replicating",
+				zap.String("errType", errType),
+				zap.Error(err))
 			writer.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -278,24 +282,22 @@ func (r *Replicator) objRepConnHandler(writer http.ResponseWriter, request *http
 func (r *Replicator) LogRequest(next http.Handler) http.Handler {
 	fn := func(writer http.ResponseWriter, request *http.Request) {
 		newWriter := &srv.WebWriter{ResponseWriter: writer, Status: 500, ResponseStarted: false}
-		requestLogger := &srv.RequestLogger{Request: request, Logger: r.logger, W: newWriter}
-		defer requestLogger.LogPanics("LOGGING REQUEST")
 		start := time.Now()
-		request = srv.SetLogger(request, requestLogger)
+		logr := r.logger.With(zap.String("txn", request.Header.Get("X-Trans-Id")))
+		request = srv.SetLogger(request, logr)
 		next.ServeHTTP(newWriter, request)
-		if (request.Method != "REPLICATE" && request.Method != "REPCONN") || r.logLevel == "DEBUG" {
-			r.logger.Info(fmt.Sprintf("%s - - [%s] \"%s %s\" %d %s \"%s\" \"%s\" \"%s\" %.4f \"%s\"",
-				request.RemoteAddr,
-				time.Now().Format("02/Jan/2006:15:04:05 -0700"),
-				request.Method,
-				common.Urlencode(request.URL.Path),
-				newWriter.Status,
-				common.GetDefault(newWriter.Header(), "Content-Length", "-"),
-				common.GetDefault(request.Header, "Referer", "-"),
-				common.GetDefault(request.Header, "X-Trans-Id", "-"),
-				common.GetDefault(request.Header, "User-Agent", "-"),
-				time.Since(start).Seconds(),
-				"-"))
+		lvl, _ := r.logLevel.MarshalText()
+		if (request.Method != "REPLICATE" && request.Method != "REPCONN") || strings.ToUpper(string(lvl)) == "DEBUG" {
+			logr.Info("Request log",
+				zap.String("remoteAddr", request.RemoteAddr),
+				zap.String("eventTime", time.Now().Format("02/Jan/2006:15:04:05 -0700")),
+				zap.String("method", request.Method),
+				zap.String("urlPath", common.Urlencode(request.URL.Path)),
+				zap.Int("status", newWriter.Status),
+				zap.String("contentLength", common.GetDefault(newWriter.Header(), "Content-Length", "-")),
+				zap.String("referer", common.GetDefault(request.Header, "Referer", "-")),
+				zap.String("userAgent", common.GetDefault(request.Header, "User-Agent", "-")),
+				zap.Float64("requestTimeSeconds", time.Since(start).Seconds()))
 		}
 	}
 	return http.HandlerFunc(fn)
@@ -318,7 +320,7 @@ func (r *Replicator) GetHandler() http.Handler {
 func (r *Replicator) startWebServer() {
 	for {
 		if sock, err := srv.RetryListen(r.bindIp, r.port); err != nil {
-			r.LogError("Listen failed: %v", err)
+			r.logger.Error("Listen failed", zap.Error(err))
 		} else {
 			http.Serve(sock, r.GetHandler())
 		}

--- a/objectserver/update.go
+++ b/objectserver/update.go
@@ -31,6 +31,8 @@ import (
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/pickle"
 	"github.com/troubling/hummingbird/common/srv"
+	"github.com/troubling/hummingbird/middleware"
+	"go.uber.org/zap"
 )
 
 /*This hash is used to represent a zero byte async file that is
@@ -110,7 +112,7 @@ func (server *ObjectServer) saveAsync(method, account, container, obj, localDevi
 	}
 }
 
-func (server *ObjectServer) updateContainer(metadata map[string]string, request *http.Request, vars map[string]string, logger srv.LoggingContext) {
+func (server *ObjectServer) updateContainer(metadata map[string]string, request *http.Request, vars map[string]string, logger srv.LowLevelLogger) {
 	partition := request.Header.Get("X-Container-Partition")
 	hosts := splitHeader(request.Header.Get("X-Container-Host"))
 	devices := splitHeader(request.Header.Get("X-Container-Device"))
@@ -132,7 +134,9 @@ func (server *ObjectServer) updateContainer(metadata map[string]string, request 
 	failures := 0
 	for index := range hosts {
 		if !server.sendContainerUpdate(hosts[index], devices[index], request.Method, partition, vars["account"], vars["container"], vars["obj"], requestHeaders) {
-			logger.LogError("ERROR container update failed with %s/%s (saving for async update later)", hosts[index], devices[index])
+			logger.Error("ERROR container update failed (saving for async update later)",
+				zap.String("Host", hosts[index]),
+				zap.String("Device", devices[index]))
 			failures++
 		}
 	}
@@ -141,7 +145,7 @@ func (server *ObjectServer) updateContainer(metadata map[string]string, request 
 	}
 }
 
-func (server *ObjectServer) updateDeleteAt(request *http.Request, deleteAtStr string, vars map[string]string, logger srv.LoggingContext) {
+func (server *ObjectServer) updateDeleteAt(request *http.Request, deleteAtStr string, vars map[string]string, logger srv.LowLevelLogger) {
 	deleteAt, err := common.ParseDate(deleteAtStr)
 	if err != nil {
 		return
@@ -169,7 +173,9 @@ func (server *ObjectServer) updateDeleteAt(request *http.Request, deleteAtStr st
 	failures := 0
 	for index := range hosts {
 		if !server.sendContainerUpdate(hosts[index], devices[index], request.Method, partition, deleteAtAccount, container, obj, requestHeaders) {
-			logger.LogError("ERROR container update failed with %s/%s (saving for async update later)", hosts[index], devices[index])
+			logger.Error("ERROR container update failed with (saving for async update later)",
+				zap.String("Host", hosts[index]),
+				zap.String("Device", devices[index]))
 			failures++
 		}
 	}
@@ -178,8 +184,8 @@ func (server *ObjectServer) updateDeleteAt(request *http.Request, deleteAtStr st
 	}
 }
 
-func (server *ObjectServer) containerUpdates(request *http.Request, metadata map[string]string, deleteAt string, vars map[string]string, logger srv.LoggingContext) {
-	defer logger.LogPanics("PANIC WHILE UPDATING CONTAINER LISTINGS")
+func (server *ObjectServer) containerUpdates(writer http.ResponseWriter, request *http.Request, metadata map[string]string, deleteAt string, vars map[string]string, logger srv.LowLevelLogger) {
+	defer middleware.Recover(writer, request, "PANIC WHILE UPDATING CONTAINER LISTINGS")
 	if deleteAt != "" {
 		go server.updateDeleteAt(request, deleteAt, vars, logger)
 	}

--- a/objectserver/update_test.go
+++ b/objectserver/update_test.go
@@ -28,17 +28,8 @@ import (
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/pickle"
 	"github.com/troubling/hummingbird/common/srv"
+	"go.uber.org/zap"
 )
-
-type DummyLogger struct{}
-
-func (a *DummyLogger) LogDebug(format string, args ...interface{}) {}
-func (a *DummyLogger) LogError(format string, args ...interface{}) {}
-func (a *DummyLogger) LogInfo(format string, args ...interface{})  {}
-func (a *DummyLogger) LogPanics(m string) {
-	if e := recover(); e != nil {
-	}
-}
 
 func TestExpirerContainer(t *testing.T) {
 	ts, err := makeObjectServer()
@@ -88,16 +79,16 @@ func TestUpdateDeleteAt(t *testing.T) {
 	req.Header.Add("X-Delete-At-Device", "sdb")
 	req.Header.Add("X-Timestamp", "12345.6789")
 
-	dl := DummyLogger{}
+	dl := zap.NewNop()
 
 	vars := map[string]string{"account": "a", "container": "c", "obj": "o", "device": "sda"}
 	req = srv.SetVars(req, vars)
 	deleteAtStr := "1434707411"
-	server.updateDeleteAt(req, deleteAtStr, vars, &dl)
+	server.updateDeleteAt(req, deleteAtStr, vars, dl)
 	require.True(t, requestSent)
 
 	cs.Close()
-	server.updateDeleteAt(req, deleteAtStr, vars, &dl)
+	server.updateDeleteAt(req, deleteAtStr, vars, dl)
 	expectedFile := filepath.Join(ts.root, "sda", "async_pending", "8fc", "02cc012fe572f27e455edbea32da78fc-12345.6789")
 	require.True(t, fs.Exists(expectedFile))
 	data, err := ioutil.ReadFile(expectedFile)
@@ -125,7 +116,7 @@ func TestUpdateDeleteAtNoHeaders(t *testing.T) {
 	vars := map[string]string{"account": "a", "container": "c", "obj": "o", "device": "sda"}
 	req = srv.SetVars(req, vars)
 	deleteAtStr := "1434707411"
-	server.updateDeleteAt(req, deleteAtStr, vars, &DummyLogger{})
+	server.updateDeleteAt(req, deleteAtStr, vars, zap.NewNop())
 	expectedFile := filepath.Join(ts.root, "sda", "async_pending", "8fc", "02cc012fe572f27e455edbea32da78fc-12345.6789")
 	require.True(t, fs.Exists(expectedFile))
 	data, err := ioutil.ReadFile(expectedFile)
@@ -165,7 +156,7 @@ func TestUpdateContainer(t *testing.T) {
 	req.Header.Add("X-Container-Device", "sdb")
 	req.Header.Add("X-Timestamp", "12345.6789")
 
-	dl := DummyLogger{}
+	dl := zap.NewNop()
 
 	vars := map[string]string{"account": "a", "container": "c", "obj": "o", "device": "sda"}
 	req = srv.SetVars(req, vars)
@@ -175,11 +166,11 @@ func TestUpdateContainer(t *testing.T) {
 		"Content-Length": "30",
 		"ETag":           "ffffffffffffffffffffffffffffffff",
 	}
-	server.updateContainer(metadata, req, vars, &dl)
+	server.updateContainer(metadata, req, vars, dl)
 	require.True(t, requestSent)
 
 	cs.Close()
-	server.updateContainer(metadata, req, vars, &dl)
+	server.updateContainer(metadata, req, vars, dl)
 	expectedFile := filepath.Join(ts.root, "sda", "async_pending", "099", "2f714cd91b0e5d803cde2012b01d7099-12345.6789")
 	require.True(t, fs.Exists(expectedFile))
 	data, err := ioutil.ReadFile(expectedFile)
@@ -218,12 +209,12 @@ func TestUpdateContainerNoHeaders(t *testing.T) {
 		"Content-Length": "30",
 		"ETag":           "ffffffffffffffffffffffffffffffff",
 	}
-	dl := DummyLogger{}
-	server.updateContainer(metadata, req, vars, &dl)
+	dl := zap.NewNop()
+	server.updateContainer(metadata, req, vars, dl)
 	require.False(t, requestSent)
 
 	cs.Close()
-	server.updateContainer(metadata, req, vars, &dl)
+	server.updateContainer(metadata, req, vars, dl)
 	expectedFile := filepath.Join(ts.root, "sda", "async_pending", "099", "2f714cd91b0e5d803cde2012b01d7099-12345.6789")
 	require.False(t, fs.Exists(expectedFile))
 }

--- a/probe/base.go
+++ b/probe/base.go
@@ -192,7 +192,7 @@ func NewEnvironment(settings ...string) *Environment {
 		_, _, server, _, _ := objectserver.GetServer(conf, &flag.FlagSet{})
 		ts.Config.Handler = server.GetHandler(conf)
 
-		replicator, err := objectserver.NewReplicator(conf, &flag.FlagSet{})
+		replicator, _, err := objectserver.NewReplicator(conf, &flag.FlagSet{})
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -201,7 +201,7 @@ func NewEnvironment(settings ...string) *Environment {
 		trs.Config.Handler = replicator.(*objectserver.Replicator).GetHandler()
 
 		replicatorServer := &TestReplicatorWebServer{Server: trs, host: host, port: port, root: driveRoot, replicator: replicator.(*objectserver.Replicator)}
-		auditor, err := objectserver.NewAuditor(conf, &flag.FlagSet{})
+		auditor, _, err := objectserver.NewAuditor(conf, &flag.FlagSet{})
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/proxyserver/middleware/catcherror.go
+++ b/proxyserver/middleware/catcherror.go
@@ -1,0 +1,49 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+
+	"go.uber.org/zap"
+
+	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/srv"
+)
+
+func Recover(w http.ResponseWriter, r *http.Request, msg string) {
+	if err := recover(); err != nil {
+		transactionId := r.Header.Get("X-Trans-Id")
+		if ctx := GetProxyContext(r); ctx != nil {
+			ctx.Logger.Error(msg, zap.Any("err", err), zap.String("txn", transactionId))
+			// if we haven't set a status code yet, we can send a 500 response.
+			if started, _ := ctx.capWriter.Response(); !started {
+				srv.StandardResponse(w, http.StatusInternalServerError)
+			}
+		}
+	}
+}
+
+func NewCatchError(config conf.Section) (func(http.Handler) http.Handler, error) {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				defer Recover(w, r, "PANIC")
+				next.ServeHTTP(w, r)
+			},
+		)
+	}, nil
+}

--- a/proxyserver/middleware/logging.go
+++ b/proxyserver/middleware/logging.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
+	"go.uber.org/zap"
 )
 
 func NewRequestLogger(config conf.Section) (func(http.Handler) http.Handler, error) {
@@ -31,18 +32,16 @@ func NewRequestLogger(config conf.Section) (func(http.Handler) http.Handler, err
 				next.ServeHTTP(writer, request)
 				ctx := GetProxyContext(request)
 				_, status := ctx.Response()
-				ctx.Logger.LogInfo("%s - - [%s] \"%s %s\" %d %s \"%s\" \"%s\" \"%s\" %.4f \"%s\"",
-					request.RemoteAddr,
-					time.Now().Format("02/Jan/2006:15:04:05 -0700"),
-					request.Method,
-					common.Urlencode(request.URL.Path),
-					status,
-					common.GetDefault(writer.Header(), "Content-Length", "-"),
-					common.GetDefault(request.Header, "Referer", "-"),
-					common.GetDefault(request.Header, "X-Trans-Id", "-"),
-					common.GetDefault(request.Header, "User-Agent", "-"),
-					time.Since(start).Seconds(),
-					"-") // TODO: "additional info"?
+				ctx.Logger.Info("Request log",
+					zap.String("remoteAddr", request.RemoteAddr),
+					zap.String("eventTime", time.Now().Format("02/Jan/2006:15:04:05 -0700")),
+					zap.String("method", request.Method),
+					zap.String("urlPath", common.Urlencode(request.URL.Path)),
+					zap.Int("status", status),
+					zap.String("contentLength", common.GetDefault(writer.Header(), "Content-Length", "-")),
+					zap.String("referer", common.GetDefault(request.Header, "Referer", "-")),
+					zap.String("userAgent", common.GetDefault(request.Header, "User-Agent", "-")),
+					zap.Float64("requestTimeSeconds", time.Since(start).Seconds()))
 			},
 		)
 	}, nil

--- a/proxyserver/middleware/ratelimit.go
+++ b/proxyserver/middleware/ratelimit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/troubling/hummingbird/common/conf"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/srv"
+	"go.uber.org/zap"
 )
 
 const rateBuffer = int64(5 * time.Second)
@@ -82,7 +83,7 @@ func (r *ratelimiter) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 	}
 	ctx := GetProxyContext(request)
 	if ctx == nil {
-		ctx.Logger.LogDebug("Error ratelimiter getting ctx")
+		ctx.Logger.Debug("Error ratelimiter getting ctx")
 		return
 	}
 	limit := int64(0)
@@ -107,8 +108,7 @@ func (r *ratelimiter) ServeHTTP(writer http.ResponseWriter, request *http.Reques
 			sleep(time.Duration(sleepTime))
 		} else {
 			if ctx := GetProxyContext(request); ctx != nil {
-				ctx.Logger.LogDebug(fmt.Sprintf(
-					"Error ratelimitint getting sleep time: %v", err))
+				ctx.Logger.Debug("Ratelimiter errored while getting sleep time", zap.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
Switching from syslog based logging to structured logging.
Currently all the logs will logged to the specified log_path.
In future we plan to use upstart/systemd to redirect logs and daemonize.
Also added /loglevel endpoint to all the server that can report on or
change the current logging level. GET requests return a JSON description
of the current logging level. PUT requests change the logging level
and expect a payload like: 
{"level":"info"} 

It's safe to change the logging level while the server is running.

Removed abstractions like RequestLogger, LoggingContext globally.
Also added catch_error aka recovery middleware for all the services.

fixes #44