### PR TITLE
fix metadata saving

### DIFF
--- a/accountserver/server.go
+++ b/accountserver/server.go
@@ -222,8 +222,8 @@ func (server *AccountServer) AccountPutHandler(writer http.ResponseWriter, reque
 		return
 	}
 	metadata := make(map[string][]string)
-	for key, values := range request.Header {
-		if (strings.HasPrefix(key, "X-Account-Meta-") || strings.HasPrefix(key, "X-Account-Sysmeta-")) && len(values) > 0 || values[0] != "" {
+	for key := range request.Header {
+		if strings.HasPrefix(key, "X-Account-Meta-") || strings.HasPrefix(key, "X-Account-Sysmeta-") {
 			metadata[key] = []string{request.Header.Get(key), timestamp}
 		}
 	}


### PR DESCRIPTION
order of operations is hard.

I messed up an if-check that causes basically all headers to be saved
in account metadata.  I made the filter checks for both account and
containers a little more robust.