### PR TITLE
formpost middleware

### DIFF
--- a/proxyserver/main.go
+++ b/proxyserver/main.go
@@ -80,6 +80,7 @@ func (server *ProxyServer) GetHandler(config conf.Config) http.Handler {
 		{middleware.NewCatchError, "filter:catch_errors"},
 		{middleware.NewHealthcheck, "filter:healthcheck"},
 		{middleware.NewRequestLogger, "filter:proxy-logging"},
+		{middleware.NewFormPost, "filter:formpost"},
 		{middleware.NewTempURL, "filter:tempurl"},
 		{middleware.NewTempAuth, "filter:tempauth"},
 		{middleware.NewRatelimiter, "filter:ratelimit"},

--- a/proxyserver/middleware/formpost.go
+++ b/proxyserver/middleware/formpost.go
@@ -1,0 +1,265 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"html"
+	"io"
+	"io/ioutil"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/srv"
+)
+
+const (
+	FP_INVALID = iota
+	FP_ERROR
+	FP_EXPIRED
+	FP_SCOPE_ACCOUNT
+	FP_SCOPE_CONTAINER
+)
+
+type fpLimitReader struct {
+	io.Reader
+	l int64
+	r int64
+}
+
+func (o *fpLimitReader) overRead() bool {
+	return o.r > o.l
+}
+
+func (o *fpLimitReader) Read(p []byte) (int, error) {
+	i, err := o.Reader.Read(p)
+	o.r += int64(i)
+	if o.r > o.l {
+		return 0, errors.New("Read over limit")
+	}
+	return i, err
+}
+
+func authenticateFormpost(ctx *ProxyContext, account, container, path string, attrs map[string]string) int {
+	if expires, err := parseExpires(attrs["expires"]); err != nil {
+		return FP_ERROR
+	} else if time.Now().After(expires) {
+		return FP_EXPIRED
+	}
+
+	sigb, err := hex.DecodeString(attrs["signature"])
+	if err != nil || len(sigb) == 0 {
+		return FP_ERROR
+	}
+
+	checkhmac := func(key []byte) bool {
+		mac := hmac.New(sha1.New, key)
+		fmt.Fprintf(mac, "%s\n%s\n%s\n%s\n%s", path, attrs["redirect"],
+			attrs["max_file_size"], attrs["max_file_count"], attrs["expires"])
+		return hmac.Equal(sigb, mac.Sum(nil))
+	}
+
+	if ai := ctx.GetAccountInfo(account); ai != nil {
+		if key, ok := ai.Metadata["Temp-Url-Key"]; ok && checkhmac([]byte(key)) {
+			return FP_SCOPE_ACCOUNT
+		} else if key, ok := ai.Metadata["Temp-Url-Key-2"]; ok && checkhmac([]byte(key)) {
+			return FP_SCOPE_ACCOUNT
+		} else if ci := ctx.GetContainerInfo(account, container); ci != nil {
+			if key, ok := ci.Metadata["Temp-Url-Key"]; ok && checkhmac([]byte(key)) {
+				return FP_SCOPE_CONTAINER
+			} else if key, ok := ci.Metadata["Temp-Url-Key-2"]; ok && checkhmac([]byte(key)) {
+				return FP_SCOPE_CONTAINER
+			}
+		}
+	}
+	return FP_INVALID
+}
+
+func formpostRespond(writer http.ResponseWriter, status int, message, redirect string) {
+	if redirect == "" {
+		body := fmt.Sprintf("<h1>%d %s</h1>%s", status, http.StatusText(status), message)
+		writer.Header().Set("Content-Type", "text/html")
+		writer.Header().Set("Content-Length", strconv.FormatInt(int64(len(body)), 10))
+		writer.WriteHeader(status)
+		writer.Write([]byte(body))
+	} else {
+		glue := "?"
+		if strings.Contains(redirect, "?") {
+			glue = "&"
+		}
+		redir := fmt.Sprintf("%s%sstatus=%d&message=%s", redirect, glue, status, common.Urlencode(message))
+		body := fmt.Sprintf("<html><body><p><a href=\"%s\">Click to continue...</a></p></body></html>",
+			html.EscapeString(redir))
+		writer.Header().Set("Location", redir)
+		writer.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		writer.WriteHeader(303)
+		io.WriteString(writer, body)
+	}
+}
+
+func formpostAuthorizer(scope int, account, container string) func(r *http.Request) bool {
+	return func(r *http.Request) bool {
+		ar, a, c, _ := getPathParts(r)
+		if scope == FP_SCOPE_ACCOUNT {
+			return ar && a == account
+		} else if scope == FP_SCOPE_CONTAINER {
+			return ar && a == account && c == container
+		}
+		return false
+	}
+}
+
+func formpost(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != "POST" {
+			next.ServeHTTP(writer, request)
+			return
+		}
+
+		contentType, params, err := mime.ParseMediaType(request.Header.Get("Content-Type"))
+		if err != nil {
+			srv.StandardResponse(writer, 400)
+			return
+		} else if contentType != "multipart/form-data" || params["boundary"] == "" {
+			next.ServeHTTP(writer, request)
+			return
+		}
+
+		apiReq, account, container, _ := getPathParts(request)
+		if !apiReq || account == "" || container == "" {
+			srv.StandardResponse(writer, 401)
+			return
+		}
+
+		ctx := GetProxyContext(request)
+		if ctx.Authorize != nil {
+			next.ServeHTTP(writer, request)
+			return
+		}
+
+		validated := false
+		attrs := map[string]string{
+			"redirect":       "",
+			"max_file_size":  "0",
+			"max_file_count": "0",
+			"expires":        "0",
+		}
+		dat, err := ioutil.ReadAll(request.Body)
+		mr := multipart.NewReader(bytes.NewBuffer(dat), params["boundary"])
+		var maxFileCount, fileCount, maxFileSize int64
+		for {
+			p, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				formpostRespond(writer, 400, "invalid request", attrs["redirect"])
+				return
+			}
+			if fn := p.FileName(); fn == "" {
+				data, err := ioutil.ReadAll(&io.LimitedReader{R: p, N: 8192})
+				if err != nil {
+					formpostRespond(writer, 400, "error yo", attrs["redirect"])
+					return
+				}
+				if len(attrs) > 64 {
+					formpostRespond(writer, 400, "too many form post values", attrs["redirect"])
+					return
+				}
+				attrs[p.FormName()] = string(data)
+			} else {
+				if !validated {
+					if maxFileCount, err = strconv.ParseInt(attrs["max_file_count"], 10, 64); err != nil || maxFileCount <= 0 {
+						formpostRespond(writer, 400, "max_file_count not valid", attrs["redirect"])
+						return
+					}
+					if maxFileSize, err = strconv.ParseInt(attrs["max_file_size"], 10, 64); err != nil || maxFileSize < 0 {
+						formpostRespond(writer, 400, "max_file_size not valid", attrs["redirect"])
+						return
+					}
+					scope := authenticateFormpost(ctx, account, container, request.URL.Path, attrs)
+					switch scope {
+					case FP_EXPIRED:
+						formpostRespond(writer, 401, "request expired", attrs["redirect"])
+						return
+					case FP_INVALID:
+						formpostRespond(writer, 401, "invalid signature", attrs["redirect"])
+						return
+					case FP_ERROR:
+						formpostRespond(writer, 400, "invalid request", attrs["redirect"])
+						return
+					default:
+						ctx.Authorize = formpostAuthorizer(scope, account, container)
+						validated = true
+					}
+				}
+
+				fileCount++
+				if fileCount > maxFileCount {
+					formpostRespond(writer, 400, "max file count exceeded", attrs["redirect"])
+					return
+				}
+
+				path := request.URL.Path
+				if !strings.HasSuffix(path, "/") && strings.Count(path, "/") < 4 {
+					path += "/"
+				}
+				path += fn
+				neww := httptest.NewRecorder()
+				flr := &fpLimitReader{Reader: p, l: maxFileSize}
+				newreq, err := ctx.Subrequest("PUT", path, flr, neww)
+				if err != nil {
+					formpostRespond(writer, 500, "internal server error", attrs["redirect"])
+					return
+				}
+				newreq.Header.Set("X-Delete-At", attrs["x_delete_at"])
+				newreq.Header.Set("X-Delete-After", attrs["x_delete_after"])
+				if attrs["content-type"] != "" {
+					newreq.Header.Set("Content-Type", attrs["content-type"])
+				} else {
+					newreq.Header.Set("Content-Type", "application/octet-stream")
+				}
+				next.ServeHTTP(neww, newreq)
+				if flr.overRead() {
+					formpostRespond(writer, 400, "max_file_size exceeded", attrs["redirect"])
+					return
+				}
+				if neww.Code/100 != 2 {
+					formpostRespond(writer, neww.Code, "upload error", attrs["redirect"])
+					return
+				}
+			}
+			p.Close()
+		}
+		formpostRespond(writer, 201, "Success.", attrs["redirect"])
+	})
+}
+
+func NewFormPost(config conf.Section) (func(http.Handler) http.Handler, error) {
+	RegisterInfo("formpost", map[string]interface{}{})
+	return formpost, nil
+}

--- a/proxyserver/middleware/formpost.go
+++ b/proxyserver/middleware/formpost.go
@@ -183,7 +183,7 @@ func formpost(next http.Handler) http.Handler {
 			if fn := p.FileName(); fn == "" {
 				data, err := ioutil.ReadAll(&io.LimitedReader{R: p, N: 8192})
 				if err != nil {
-					formpostRespond(writer, 400, "error yo", attrs["redirect"])
+					formpostRespond(writer, 400, "error reading form value", attrs["redirect"])
 					return
 				}
 				if len(attrs) > 64 {

--- a/proxyserver/middleware/formpost_test.go
+++ b/proxyserver/middleware/formpost_test.go
@@ -1,0 +1,193 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func makeFormpostRequest(t *testing.T, body, boundary string, next http.Handler) *httptest.ResponseRecorder {
+	br := bytes.NewBufferString(body)
+	newr, err := http.NewRequest("POST", "/v1/AUTH_test/container", br)
+	require.Nil(t, err)
+	newr.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
+	neww := httptest.NewRecorder()
+	ctx := &ProxyContext{
+		containerInfoCache: map[string]*ContainerInfo{
+			"container/AUTH_test/container": {Metadata: map[string]string{"Temp-Url-Key": "mykey"}},
+		},
+		accountInfoCache: map[string]*AccountInfo{
+			"account/AUTH_test": {Metadata: map[string]string{"Temp-Url-Key": "mykey"}}},
+		capWriter: &proxyWriter{ResponseWriter: neww, Status: 501},
+	}
+	newr = newr.WithContext(context.WithValue(newr.Context(), "proxycontext", ctx))
+	formpost(next).ServeHTTP(neww, newr)
+	return neww
+}
+
+func formPostBody(key, boundary, redirect string, maxFileSize, maxFileCount int, expires time.Time) string {
+	exp := strconv.FormatInt(expires.Unix(), 10)
+	mac := hmac.New(sha1.New, []byte(key))
+	fmt.Fprintf(mac, "%s\n%s\n%d\n%d\n%s", "/v1/AUTH_test/container", redirect,
+		maxFileSize, maxFileCount, exp)
+	sig := mac.Sum(nil)
+
+	br := &bytes.Buffer{}
+	w := multipart.NewWriter(br)
+	w.SetBoundary(boundary)
+
+	if redirect != "" {
+		w.WriteField("redirect", redirect)
+	}
+	w.WriteField("max_file_size", strconv.Itoa(maxFileSize))
+	w.WriteField("max_file_count", strconv.Itoa(maxFileCount))
+	w.WriteField("expires", exp)
+	w.WriteField("signature", hex.EncodeToString(sig))
+
+	ff, _ := w.CreateFormFile("file1", "testfile1.txt")
+	io.WriteString(ff, "Test File\nOne\n")
+
+	ff, _ = w.CreateFormFile("file2", "testfile2.txt")
+	io.WriteString(ff, "Test\nFile\nTwo\n")
+
+	ff, _ = w.CreateFormFile("file3", "")
+	io.WriteString(ff, "some stuff")
+
+	w.Close()
+
+	return br.String()
+}
+
+func TestFormPost(t *testing.T) {
+	puts := []string{}
+	next := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method == "PUT" {
+			puts = append(puts, request.URL.Path)
+			writer.WriteHeader(201)
+		}
+	})
+	boundary := "168072824752491622650073"
+	body := formPostBody("mykey", boundary, "http://brim.net", 1024, 10, time.Now().Add(time.Minute))
+	neww := makeFormpostRequest(t, body, boundary, next)
+	require.Equal(t, 303, neww.Code)
+	require.Equal(t, 2, len(puts))
+}
+
+func TestExpiredFormPost(t *testing.T) {
+	next := http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {})
+	boundary := "168072824752491622650073"
+	body := formPostBody("mykey", boundary, "", 1024, 10, time.Now().Add(-time.Hour))
+	neww := makeFormpostRequest(t, body, boundary, next)
+	require.Equal(t, 401, neww.Code)
+}
+
+func TestFormPostAuthorizer(t *testing.T) {
+	auth := formpostAuthorizer(FP_SCOPE_ACCOUNT, "a", "c")
+	req, err := http.NewRequest("GET", "/v1/a", nil)
+	require.Nil(t, err)
+	require.True(t, auth(req))
+	req, err = http.NewRequest("GET", "/v1/a2", nil)
+	require.Nil(t, err)
+	require.False(t, auth(req))
+
+	auth = formpostAuthorizer(FP_SCOPE_CONTAINER, "a", "c")
+	req, err = http.NewRequest("GET", "/v1/a/c", nil)
+	require.Nil(t, err)
+	require.True(t, auth(req))
+	req, err = http.NewRequest("GET", "/v1/a/c2", nil)
+	require.Nil(t, err)
+	require.False(t, auth(req))
+	req, err = http.NewRequest("GET", "/v1/a2/c", nil)
+	require.Nil(t, err)
+	require.False(t, auth(req))
+
+	auth = formpostAuthorizer(FP_INVALID, "a", "c")
+	req, err = http.NewRequest("GET", "/v1/a2/c", nil)
+	require.Nil(t, err)
+	require.False(t, auth(req))
+}
+
+func TestFpLimitReader(t *testing.T) {
+	ur := strings.NewReader("hello")
+	r := fpLimitReader{Reader: ur, l: 2}
+	scratch := make([]byte, 1)
+	r.Read(scratch)
+	require.False(t, r.overRead())
+	r.Read(scratch)
+	require.False(t, r.overRead())
+	r.Read(scratch)
+	require.True(t, r.overRead())
+}
+
+// func authorizeFormpost(ctx *ProxyContext, account, container, path string, attrs map[string]string) int {
+func TestAuthenticateFormpost(t *testing.T) {
+	ctx := &ProxyContext{
+		containerInfoCache: map[string]*ContainerInfo{
+			"container/a/c": {Metadata: map[string]string{
+				"Temp-Url-Key":   "containerkey",
+				"Temp-Url-Key-2": "containerkey2",
+			}},
+		},
+		accountInfoCache: map[string]*AccountInfo{
+			"account/a": {Metadata: map[string]string{
+				"Temp-Url-Key":   "accountkey",
+				"Temp-Url-Key-2": "accountkey2",
+			}}},
+	}
+
+	require.Equal(t, FP_ERROR,
+		authenticateFormpost(ctx, "a", "c", "/v1/a/c", map[string]string{"expires": "X"}))
+	require.Equal(t, FP_EXPIRED,
+		authenticateFormpost(ctx, "a", "c", "/v1/a/c", map[string]string{"expires": "12345"}))
+	require.Equal(t, FP_ERROR,
+		authenticateFormpost(ctx, "a", "c", "/v1/a/c", map[string]string{"expires": "9999999999", "signature": "X"}))
+
+	// account key 1
+	require.Equal(t, FP_SCOPE_ACCOUNT,
+		authenticateFormpost(ctx, "a", "c", "/v1/a/c", map[string]string{"expires": "9999999999",
+			"signature": "1d4cb17a0d70b32f7987fe49b1990020bab52ae6"}))
+	// account key 2
+	require.Equal(t, FP_SCOPE_ACCOUNT,
+		authenticateFormpost(ctx, "a", "c", "/v1/a/c", map[string]string{"expires": "9999999999",
+			"signature": "9749158451be0383af1ec6d8e10f09a2d0d5f2b1"}))
+	// container key 1
+	require.Equal(t, FP_SCOPE_CONTAINER,
+		authenticateFormpost(ctx, "a", "c", "/v1/a/c", map[string]string{"expires": "9999999999",
+			"signature": "3320ff06b119d287a1c8d18d4356cd91e8518fe7"}))
+	// container key 2
+	require.Equal(t, FP_SCOPE_CONTAINER,
+		authenticateFormpost(ctx, "a", "c", "/v1/a/c", map[string]string{"expires": "9999999999",
+			"signature": "a3c3dd56ad65f5b87eeb384f9e0406c79511b556"}))
+	// invalid key
+	require.Equal(t, FP_INVALID,
+		authenticateFormpost(ctx, "a", "c", "/v1/a/c", map[string]string{"expires": "9999999999",
+			"signature": "1111111111111111111111111111111111111111"}))
+}


### PR DESCRIPTION
Implements formpost middleware, which allows objects to be uploaded
by browser form post.  The POST requests are authenticated by a
hidden "signature" field in the form.

Unfortunately there are no functional tests for this.

fixes #47