### PR TITLE
Initial work for end user policy support

### DIFF
--- a/client/directclient.go
+++ b/client/directclient.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -51,6 +50,7 @@ type ClientInfoSource interface {
 	GetContainerInfo(account, container string) *ContainerInfo
 	DefaultPolicyIndex() int
 	PolicyByName(name string) *conf.Policy
+	HTTPClient() *http.Client
 }
 
 func NewProxyDirectClient(cis ClientInfoSource) (ProxyClient, error) {
@@ -70,15 +70,7 @@ func NewProxyDirectClient(cis ClientInfoSource) (ProxyClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	c.client = &http.Client{
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout:   10 * time.Second,
-				KeepAlive: 5 * time.Second,
-			}).Dial,
-		},
-		Timeout: 120 * time.Minute,
-	}
+	c.client = cis.HTTPClient()
 	return c, nil
 }
 

--- a/client/directclient.go
+++ b/client/directclient.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -31,10 +32,54 @@ func mkquery(options map[string]string) string {
 }
 
 type ProxyDirectClient struct {
-	client        *http.Client
-	AccountRing   ring.Ring
-	ContainerRing ring.Ring
-	ObjectRing    ring.Ring
+	client           *http.Client
+	clientInfoSource ClientInfoSource
+	AccountRing      ring.Ring
+	ContainerRing    ring.Ring
+}
+
+// ContainerInfo is persisted in memcache via JSON; so this needs to continue to have public fields.
+type ContainerInfo struct {
+	ObjectCount        int64
+	ObjectBytes        int64
+	Metadata           map[string]string
+	SysMetadata        map[string]string
+	StoragePolicyIndex int
+}
+
+type ClientInfoSource interface {
+	GetContainerInfo(account, container string) *ContainerInfo
+	DefaultPolicyIndex() int
+	PolicyByName(name string) *conf.Policy
+}
+
+func NewProxyDirectClient(cis ClientInfoSource) (ProxyClient, error) {
+	if cis == nil {
+		return nil, errors.New("nil ClientInfoSource")
+	}
+	c := &ProxyDirectClient{clientInfoSource: cis}
+	hashPathPrefix, hashPathSuffix, err := conf.GetHashPrefixAndSuffix()
+	if err != nil {
+		return nil, err
+	}
+	c.ContainerRing, err = ring.GetRing("container", hashPathPrefix, hashPathSuffix, 0)
+	if err != nil {
+		return nil, err
+	}
+	c.AccountRing, err = ring.GetRing("account", hashPathPrefix, hashPathSuffix, 0)
+	if err != nil {
+		return nil, err
+	}
+	c.client = &http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 5 * time.Second,
+			}).Dial,
+		},
+		Timeout: 120 * time.Minute,
+	}
+	return c, nil
 }
 
 type QuorumResponseEntry struct {
@@ -200,6 +245,16 @@ func (c *ProxyDirectClient) PutContainer(account string, container string, heade
 	partition := c.ContainerRing.GetPartition(account, container, "")
 	accountPartition := c.AccountRing.GetPartition(account, "", "")
 	accountDevices := c.AccountRing.GetNodes(accountPartition)
+	policyIndex := -1
+	policyDefault := c.clientInfoSource.DefaultPolicyIndex()
+	policyName := headers.Get("X-Storage-Policy")
+	if policyName != "" {
+		policy := c.clientInfoSource.PolicyByName(policyName)
+		if policy == nil || policy.Deprecated {
+			return 400
+		}
+		policyIndex = policy.Index
+	}
 	reqs := make([]*http.Request, 0)
 	for i, device := range c.ContainerRing.GetNodes(partition) {
 		url := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s", device.Ip, device.Port, device.Device, partition,
@@ -211,6 +266,8 @@ func (c *ProxyDirectClient) PutContainer(account string, container string, heade
 		req.Header.Set("X-Account-Partition", strconv.FormatUint(accountPartition, 10))
 		req.Header.Set("X-Account-Host", fmt.Sprintf("%s:%d", accountDevices[i].Ip, accountDevices[i].Port))
 		req.Header.Set("X-Account-Device", accountDevices[i].Device)
+		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(policyIndex))
+		req.Header.Set("X-Backend-Storage-Policy-Default", strconv.Itoa(policyDefault))
 		reqs = append(reqs, req)
 	}
 	headers, statusCode := c.quorumResponse(reqs...)
@@ -298,14 +355,99 @@ func (c *ProxyDirectClient) DeleteContainer(account string, container string, he
 }
 
 func (c *ProxyDirectClient) PutObject(account string, container string, obj string, headers http.Header, src io.Reader) (http.Header, int) {
-	partition := c.ObjectRing.GetPartition(account, container, obj)
-	containerPartition := c.ContainerRing.GetPartition(account, container, "")
-	containerDevices := c.ContainerRing.GetNodes(containerPartition)
+	oc, status := c.objectClient(account, container)
+	if status != 0 {
+		return nil, status
+	}
+	return oc.putObject(obj, headers, src)
+}
+
+func (c *ProxyDirectClient) PostObject(account string, container string, obj string, headers http.Header) int {
+	oc, status := c.objectClient(account, container)
+	if status != 0 {
+		return status
+	}
+	return oc.postObject(obj, headers)
+}
+
+func (c *ProxyDirectClient) GetObject(account string, container string, obj string, headers http.Header) (io.ReadCloser, http.Header, int) {
+	oc, status := c.objectClient(account, container)
+	if status != 0 {
+		return nil, nil, status
+	}
+	return oc.getObject(obj, headers)
+}
+
+func (c *ProxyDirectClient) GrepObject(account string, container string, obj string, search string) (io.ReadCloser, http.Header, int) {
+	oc, status := c.objectClient(account, container)
+	if status != 0 {
+		return nil, nil, status
+	}
+	return oc.grepObject(obj, search)
+}
+
+func (c *ProxyDirectClient) HeadObject(account string, container string, obj string, headers http.Header) (http.Header, int) {
+	oc, status := c.objectClient(account, container)
+	if status != 0 {
+		return nil, status
+	}
+	return oc.headObject(obj, headers)
+}
+
+func (c *ProxyDirectClient) DeleteObject(account string, container string, obj string, headers http.Header) int {
+	oc, status := c.objectClient(account, container)
+	if status != 0 {
+		return status
+	}
+	return oc.deleteObject(obj, headers)
+}
+
+func (c *ProxyDirectClient) objectClient(account string, container string) (proxyObjectClient, int) {
+	ci := c.clientInfoSource.GetContainerInfo(account, container)
+	if ci == nil {
+		return nil, 500
+	}
+	return newStandardObjectClient(c, account, container, ci.StoragePolicyIndex)
+}
+
+type proxyObjectClient interface {
+	putObject(obj string, headers http.Header, src io.Reader) (http.Header, int)
+	postObject(obj string, headers http.Header) int
+	getObject(obj string, headers http.Header) (io.ReadCloser, http.Header, int)
+	grepObject(obj string, search string) (io.ReadCloser, http.Header, int)
+	headObject(obj string, headers http.Header) (http.Header, int)
+	deleteObject(obj string, headers http.Header) int
+}
+
+type standardObjectClient struct {
+	proxyDirectClient *ProxyDirectClient
+	account           string
+	container         string
+	policy            int
+	objectRing        ring.Ring
+}
+
+func newStandardObjectClient(proxyDirectClient *ProxyDirectClient, account string, container string, policy int) (*standardObjectClient, int) {
+	hashPathPrefix, hashPathSuffix, err := conf.GetHashPrefixAndSuffix()
+	if err != nil {
+		return nil, 500
+	}
+	objectRing, err := ring.GetRing("object", hashPathPrefix, hashPathSuffix, policy)
+	if err != nil {
+		return nil, 500
+	}
+	return &standardObjectClient{proxyDirectClient: proxyDirectClient, account: account, container: container, policy: policy, objectRing: objectRing}, 0
+}
+
+func (oc *standardObjectClient) putObject(obj string, headers http.Header, src io.Reader) (http.Header, int) {
+	partition := oc.objectRing.GetPartition(oc.account, oc.container, obj)
+	containerPartition := oc.proxyDirectClient.ContainerRing.GetPartition(oc.account, oc.container, "")
+	containerDevices := oc.proxyDirectClient.ContainerRing.GetNodes(containerPartition)
 	var writers []*io.PipeWriter
 	reqs := make([]*http.Request, 0)
-	for i, device := range c.ObjectRing.GetNodes(partition) {
+	for i, device := range oc.objectRing.GetNodes(partition) {
 		url := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s/%s", device.Ip, device.Port, device.Device, partition,
-			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj))
+			common.Urlencode(oc.account), common.Urlencode(oc.container), common.Urlencode(obj))
 		rp, wp := io.Pipe()
 		defer wp.Close()
 		defer rp.Close()
@@ -324,6 +466,7 @@ func (c *ProxyDirectClient) PutObject(account string, container string, obj stri
 		req.Header.Set("X-Container-Partition", strconv.FormatUint(containerPartition, 10))
 		req.Header.Set("X-Container-Host", fmt.Sprintf("%s:%d", containerDevices[i].Ip, containerDevices[i].Port))
 		req.Header.Set("X-Container-Device", containerDevices[i].Device)
+		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(oc.policy))
 		req.Header.Set("Expect", "100-Continue")
 		reqs = append(reqs, req)
 	}
@@ -339,17 +482,17 @@ func (c *ProxyDirectClient) PutObject(account string, container string, obj stri
 			writer.Close()
 		}
 	}()
-	return c.quorumResponse(reqs...)
+	return oc.proxyDirectClient.quorumResponse(reqs...)
 }
 
-func (c *ProxyDirectClient) PostObject(account string, container string, obj string, headers http.Header) int {
-	partition := c.ObjectRing.GetPartition(account, container, obj)
-	containerPartition := c.ContainerRing.GetPartition(account, container, "")
-	containerDevices := c.ContainerRing.GetNodes(containerPartition)
+func (oc *standardObjectClient) postObject(obj string, headers http.Header) int {
+	partition := oc.objectRing.GetPartition(oc.account, oc.container, obj)
+	containerPartition := oc.proxyDirectClient.ContainerRing.GetPartition(oc.account, oc.container, "")
+	containerDevices := oc.proxyDirectClient.ContainerRing.GetNodes(containerPartition)
 	reqs := make([]*http.Request, 0)
-	for i, device := range c.ObjectRing.GetNodes(partition) {
+	for i, device := range oc.objectRing.GetNodes(partition) {
 		url := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s/%s", device.Ip, device.Port, device.Device, partition,
-			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj))
+			common.Urlencode(oc.account), common.Urlencode(oc.container), common.Urlencode(obj))
 		req, _ := http.NewRequest("POST", url, nil)
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
@@ -360,19 +503,20 @@ func (c *ProxyDirectClient) PostObject(account string, container string, obj str
 		req.Header.Set("X-Container-Partition", strconv.FormatUint(containerPartition, 10))
 		req.Header.Set("X-Container-Host", fmt.Sprintf("%s:%d", containerDevices[i].Ip, containerDevices[i].Port))
 		req.Header.Set("X-Container-Device", containerDevices[i].Device)
+		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(oc.policy))
 		reqs = append(reqs, req)
 	}
-	headers, statusCode := c.quorumResponse(reqs...)
+	headers, statusCode := oc.proxyDirectClient.quorumResponse(reqs...)
 	return statusCode
 }
 
-func (c *ProxyDirectClient) GetObject(account string, container string, obj string, headers http.Header) (io.ReadCloser, http.Header, int) {
-	partition := c.ObjectRing.GetPartition(account, container, obj)
-	nodes := c.ObjectRing.GetNodes(partition)
+func (oc *standardObjectClient) getObject(obj string, headers http.Header) (io.ReadCloser, http.Header, int) {
+	partition := oc.objectRing.GetPartition(oc.account, oc.container, obj)
+	nodes := oc.objectRing.GetNodes(partition)
 	reqs := make([]*http.Request, 0, len(nodes))
 	for _, device := range nodes {
 		url := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s/%s", device.Ip, device.Port, device.Device, partition,
-			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj))
+			common.Urlencode(oc.account), common.Urlencode(oc.container), common.Urlencode(obj))
 		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			continue
@@ -380,42 +524,44 @@ func (c *ProxyDirectClient) GetObject(account string, container string, obj stri
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
+		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(oc.policy))
 		reqs = append(reqs, req)
 	}
-	resp := c.firstResponse(reqs...)
+	resp := oc.proxyDirectClient.firstResponse(reqs...)
 	if resp == nil {
 		return nil, nil, 404
 	}
 	return resp.Body, resp.Header, resp.StatusCode
 }
 
-func (c *ProxyDirectClient) GrepObject(account string, container string, obj string, search string) (io.ReadCloser, http.Header, int) {
-	partition := c.ObjectRing.GetPartition(account, container, obj)
-	nodes := c.ObjectRing.GetNodes(partition)
+func (oc *standardObjectClient) grepObject(obj string, search string) (io.ReadCloser, http.Header, int) {
+	partition := oc.objectRing.GetPartition(oc.account, oc.container, obj)
+	nodes := oc.objectRing.GetNodes(partition)
 	reqs := make([]*http.Request, 0, len(nodes))
 	for _, device := range nodes {
 		url := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s/%s?e=%s", device.Ip, device.Port, device.Device, partition,
-			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj), common.Urlencode(search))
+			common.Urlencode(oc.account), common.Urlencode(oc.container), common.Urlencode(obj), common.Urlencode(search))
 		req, err := http.NewRequest("GREP", url, nil)
 		if err != nil {
 			continue
 		}
+		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(oc.policy))
 		reqs = append(reqs, req)
 	}
-	resp := c.firstResponse(reqs...)
+	resp := oc.proxyDirectClient.firstResponse(reqs...)
 	if resp == nil {
 		return nil, nil, 404
 	}
 	return resp.Body, resp.Header, resp.StatusCode
 }
 
-func (c *ProxyDirectClient) HeadObject(account string, container string, obj string, headers http.Header) (http.Header, int) {
-	partition := c.ObjectRing.GetPartition(account, container, obj)
-	nodes := c.ObjectRing.GetNodes(partition)
+func (oc *standardObjectClient) headObject(obj string, headers http.Header) (http.Header, int) {
+	partition := oc.objectRing.GetPartition(oc.account, oc.container, obj)
+	nodes := oc.objectRing.GetNodes(partition)
 	reqs := make([]*http.Request, 0, len(nodes))
 	for _, device := range nodes {
 		url := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s/%s", device.Ip, device.Port, device.Device, partition,
-			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj))
+			common.Urlencode(oc.account), common.Urlencode(oc.container), common.Urlencode(obj))
 		req, err := http.NewRequest("HEAD", url, nil)
 		if err != nil {
 			continue
@@ -423,9 +569,10 @@ func (c *ProxyDirectClient) HeadObject(account string, container string, obj str
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
+		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(oc.policy))
 		reqs = append(reqs, req)
 	}
-	resp := c.firstResponse(reqs...)
+	resp := oc.proxyDirectClient.firstResponse(reqs...)
 	if resp == nil {
 		return nil, 404
 	}
@@ -433,14 +580,14 @@ func (c *ProxyDirectClient) HeadObject(account string, container string, obj str
 	return resp.Header, resp.StatusCode
 }
 
-func (c *ProxyDirectClient) DeleteObject(account string, container string, obj string, headers http.Header) int {
-	partition := c.ObjectRing.GetPartition(account, container, obj)
-	containerPartition := c.ContainerRing.GetPartition(account, container, "")
-	containerDevices := c.ContainerRing.GetNodes(containerPartition)
+func (oc *standardObjectClient) deleteObject(obj string, headers http.Header) int {
+	partition := oc.objectRing.GetPartition(oc.account, oc.container, obj)
+	containerPartition := oc.proxyDirectClient.ContainerRing.GetPartition(oc.account, oc.container, "")
+	containerDevices := oc.proxyDirectClient.ContainerRing.GetNodes(containerPartition)
 	reqs := make([]*http.Request, 0)
-	for i, device := range c.ObjectRing.GetNodes(partition) {
+	for i, device := range oc.objectRing.GetNodes(partition) {
 		url := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s/%s", device.Ip, device.Port, device.Device, partition,
-			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj))
+			common.Urlencode(oc.account), common.Urlencode(oc.container), common.Urlencode(obj))
 		req, _ := http.NewRequest("DELETE", url, nil)
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
@@ -451,57 +598,11 @@ func (c *ProxyDirectClient) DeleteObject(account string, container string, obj s
 		req.Header.Set("X-Container-Partition", strconv.FormatUint(containerPartition, 10))
 		req.Header.Set("X-Container-Host", fmt.Sprintf("%s:%d", containerDevices[i].Ip, containerDevices[i].Port))
 		req.Header.Set("X-Container-Device", containerDevices[i].Device)
+		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(oc.policy))
 		reqs = append(reqs, req)
 	}
-	headers, statusCode := c.quorumResponse(reqs...)
+	headers, statusCode := oc.proxyDirectClient.quorumResponse(reqs...)
 	return statusCode
-}
-
-func NewProxyDirectClient() (ProxyClient, error) {
-	c := &ProxyDirectClient{}
-	hashPathPrefix, hashPathSuffix, err := conf.GetHashPrefixAndSuffix()
-	if err != nil {
-		return nil, err
-	}
-	c.ObjectRing, err = ring.GetRing("object", hashPathPrefix, hashPathSuffix, 0)
-	if err != nil {
-		return nil, err
-	}
-	c.ContainerRing, err = ring.GetRing("container", hashPathPrefix, hashPathSuffix, 0)
-	if err != nil {
-		return nil, err
-	}
-	c.AccountRing, err = ring.GetRing("account", hashPathPrefix, hashPathSuffix, 0)
-	if err != nil {
-		return nil, err
-	}
-	c.client = &http.Client{
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout:   10 * time.Second,
-				KeepAlive: 5 * time.Second,
-			}).Dial,
-		},
-		Timeout: 120 * time.Minute,
-	}
-	return c, nil
-}
-
-func NewProxyDirectClientWithRings(accountRing ring.Ring, containerRing ring.Ring, objectRing ring.Ring) (ProxyClient, error) {
-	c := &ProxyDirectClient{}
-	c.AccountRing = accountRing
-	c.ContainerRing = containerRing
-	c.ObjectRing = objectRing
-	c.client = &http.Client{
-		Transport: &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout:   10 * time.Second,
-				KeepAlive: 5 * time.Second,
-			}).Dial,
-		},
-		Timeout: 120 * time.Minute,
-	}
-	return c, nil
 }
 
 type directClient struct {
@@ -655,8 +756,8 @@ func (c *directClient) DeleteObject(container string, obj string, headers map[st
 }
 
 // NewDirectClient creates a new direct client with the given account name.
-func NewDirectClient(account string) (Client, error) {
-	rdc, err := NewProxyDirectClient()
+func NewDirectClient(cis ClientInfoSource, account string) (Client, error) {
+	rdc, err := NewProxyDirectClient(cis)
 	if err != nil {
 		return nil, err
 	}

--- a/client/directclient_test.go
+++ b/client/directclient_test.go
@@ -1,0 +1,44 @@
+package client
+
+import (
+	"github.com/troubling/hummingbird/common/conf"
+	"testing"
+)
+
+func TestClientInfoSourceNil(t *testing.T) {
+	c, err := NewProxyDirectClient(nil)
+	if c != nil {
+		t.Fatal("should have resulted in an error")
+	}
+	if err == nil {
+		t.Fatal("should have resulted in an error")
+	}
+}
+
+type testClientInfoSource int
+
+func (t *testClientInfoSource) GetContainerInfo(account, container string) *ContainerInfo {
+	return nil
+}
+
+func (t *testClientInfoSource) DefaultPolicyIndex() int {
+	return 0
+}
+
+func (t *testClientInfoSource) PolicyByName(name string) *conf.Policy {
+	return nil
+}
+
+func TestContainerInfoNil(t *testing.T) {
+	c, err := NewProxyDirectClient(new(testClientInfoSource))
+	if err != nil {
+		t.Fatal(err)
+	}
+	oc, s := c.(*ProxyDirectClient).objectClient("a", "c")
+	if oc != nil {
+		t.Fatal("should have resulted in an error status")
+	}
+	if s != 500 {
+		t.Fatal("should have resulted in an error status")
+	}
+}

--- a/client/directclient_test.go
+++ b/client/directclient_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"github.com/troubling/hummingbird/common/conf"
+	"net/http"
 	"testing"
 )
 
@@ -26,6 +27,10 @@ func (t *testClientInfoSource) DefaultPolicyIndex() int {
 }
 
 func (t *testClientInfoSource) PolicyByName(name string) *conf.Policy {
+	return nil
+}
+
+func (t *testClientInfoSource) HTTPClient() *http.Client {
 	return nil
 }
 

--- a/proxyserver/accounthandlers.go
+++ b/proxyserver/accounthandlers.go
@@ -43,7 +43,7 @@ func (server *ProxyServer) AccountGetHandler(writer http.ResponseWriter, request
 		"delimiter":  request.FormValue("delimiter"),
 		"reverse":    request.FormValue("reverse"),
 	}
-	r, headers, code := server.C.GetAccount(vars["account"], options, request.Header)
+	r, headers, code := ctx.C.GetAccount(vars["account"], options, request.Header)
 	for k := range headers {
 		writer.Header().Set(k, headers.Get(k))
 	}
@@ -65,7 +65,7 @@ func (server *ProxyServer) AccountHeadHandler(writer http.ResponseWriter, reques
 		srv.StandardResponse(writer, 401)
 		return
 	}
-	headers, code := server.C.HeadAccount(vars["account"], request.Header)
+	headers, code := ctx.C.HeadAccount(vars["account"], request.Header)
 	for k := range headers {
 		writer.Header().Set(k, headers.Get(k))
 	}
@@ -85,7 +85,7 @@ func (server *ProxyServer) AccountPutHandler(writer http.ResponseWriter, request
 	}
 	defer ctx.InvalidateAccountInfo(vars["account"])
 	request.Header.Set("X-Timestamp", common.GetTimestamp())
-	srv.StandardResponse(writer, server.C.PutAccount(vars["account"], request.Header))
+	srv.StandardResponse(writer, ctx.C.PutAccount(vars["account"], request.Header))
 }
 
 func (server *ProxyServer) AccountDeleteHandler(writer http.ResponseWriter, request *http.Request) {
@@ -101,5 +101,5 @@ func (server *ProxyServer) AccountDeleteHandler(writer http.ResponseWriter, requ
 	}
 	defer ctx.InvalidateAccountInfo(vars["account"])
 	request.Header.Set("X-Timestamp", common.GetTimestamp())
-	srv.StandardResponse(writer, server.C.DeleteAccount(vars["account"], request.Header))
+	srv.StandardResponse(writer, ctx.C.DeleteAccount(vars["account"], request.Header))
 }

--- a/proxyserver/containerhandlers.go
+++ b/proxyserver/containerhandlers.go
@@ -46,7 +46,7 @@ func (server *ProxyServer) ContainerGetHandler(writer http.ResponseWriter, reque
 		"prefix":     request.FormValue("prefix"),
 		"delimiter":  request.FormValue("delimiter"),
 	}
-	r, headers, code := server.C.GetContainer(vars["account"], vars["container"], options, request.Header)
+	r, headers, code := ctx.C.GetContainer(vars["account"], vars["container"], options, request.Header)
 	for k := range headers {
 		writer.Header().Set(k, headers.Get(k))
 	}
@@ -72,7 +72,7 @@ func (server *ProxyServer) ContainerHeadHandler(writer http.ResponseWriter, requ
 		srv.StandardResponse(writer, 401)
 		return
 	}
-	headers, code := server.C.HeadContainer(vars["account"], vars["container"], request.Header)
+	headers, code := ctx.C.HeadContainer(vars["account"], vars["container"], request.Header)
 	for k := range headers {
 		writer.Header().Set(k, headers.Get(k))
 	}
@@ -102,7 +102,7 @@ func (server *ProxyServer) ContainerPutHandler(writer http.ResponseWriter, reque
 	}
 	defer ctx.InvalidateContainerInfo(vars["account"], vars["container"])
 	request.Header.Set("X-Timestamp", common.GetTimestamp())
-	srv.StandardResponse(writer, server.C.PutContainer(vars["account"], vars["container"], request.Header))
+	srv.StandardResponse(writer, ctx.C.PutContainer(vars["account"], vars["container"], request.Header))
 }
 
 func (server *ProxyServer) ContainerDeleteHandler(writer http.ResponseWriter, request *http.Request) {
@@ -122,5 +122,5 @@ func (server *ProxyServer) ContainerDeleteHandler(writer http.ResponseWriter, re
 	}
 	defer ctx.InvalidateContainerInfo(vars["account"], vars["container"])
 	request.Header.Set("X-Timestamp", common.GetTimestamp())
-	srv.StandardResponse(writer, server.C.DeleteContainer(vars["account"], vars["container"], request.Header))
+	srv.StandardResponse(writer, ctx.C.DeleteContainer(vars["account"], vars["container"], request.Header))
 }

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/troubling/hummingbird/client"
 	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/srv"
 	"go.uber.org/zap"
@@ -65,20 +66,13 @@ type AccountInfo struct {
 	SysMetadata    map[string]string
 }
 
-type ContainerInfo struct {
-	ObjectCount int64
-	ObjectBytes int64
-	Metadata    map[string]string
-	SysMetadata map[string]string
-}
-
 type AuthorizeFunc func(r *http.Request) bool
 
 type ProxyContextMiddleware struct {
-	next  http.Handler
-	c     client.ProxyClient
-	log   srv.LowLevelLogger
-	Cache ring.MemcacheRing
+	next       http.Handler
+	log        srv.LowLevelLogger
+	Cache      ring.MemcacheRing
+	policyList conf.PolicyList
 }
 
 type proxyWriter struct {
@@ -107,9 +101,10 @@ func (w *proxyWriter) Response() (bool, int) {
 
 type ProxyContext struct {
 	*ProxyContextMiddleware
+	C                  client.ProxyClient
 	Authorize          AuthorizeFunc
 	Logger             srv.LowLevelLogger
-	containerInfoCache map[string]*ContainerInfo
+	containerInfoCache map[string]*client.ContainerInfo
 	accountInfoCache   map[string]*AccountInfo
 	capWriter          *proxyWriter
 }
@@ -125,7 +120,20 @@ func (ctx *ProxyContext) Response() (bool, int) {
 	return ctx.capWriter.Response()
 }
 
-func (ctx *ProxyContext) GetContainerInfo(account, container string) *ContainerInfo {
+func (ctx *ProxyContext) DefaultPolicyIndex() int {
+	return ctx.policyList.Default()
+}
+
+func (ctx *ProxyContext) PolicyByName(name string) *conf.Policy {
+	for _, v := range ctx.policyList {
+		if v.Name == name {
+			return v
+		}
+	}
+	return nil
+}
+
+func (ctx *ProxyContext) GetContainerInfo(account, container string) *client.ContainerInfo {
 	var err error
 	key := fmt.Sprintf("container/%s/%s", account, container)
 	ci := ctx.containerInfoCache[key]
@@ -135,11 +143,11 @@ func (ctx *ProxyContext) GetContainerInfo(account, container string) *ContainerI
 		}
 	}
 	if ci == nil {
-		headers, code := ctx.c.HeadContainer(account, container, nil)
+		headers, code := ctx.C.HeadContainer(account, container, nil)
 		if code/100 != 2 {
 			return nil
 		}
-		ci = &ContainerInfo{
+		ci = &client.ContainerInfo{
 			Metadata:    make(map[string]string),
 			SysMetadata: make(map[string]string),
 		}
@@ -147,6 +155,9 @@ func (ctx *ProxyContext) GetContainerInfo(account, container string) *ContainerI
 			return nil
 		}
 		if ci.ObjectBytes, err = strconv.ParseInt(headers.Get("X-Container-Bytes-Used"), 10, 64); err != nil {
+			return nil
+		}
+		if ci.StoragePolicyIndex, err = strconv.Atoi(headers.Get("X-Backend-Storage-Policy-Index")); err != nil {
 			return nil
 		}
 		for k := range headers {
@@ -190,10 +201,10 @@ func (ctx *ProxyContext) GetAccountInfo(account string) *AccountInfo {
 		}
 	}
 	if ai == nil {
-		headers, code := ctx.c.HeadAccount(account, nil)
+		headers, code := ctx.C.HeadAccount(account, nil)
 		if code == 404 && autoCreateAccounts {
-			ctx.c.PutAccount(account, http.Header{"X-Timestamp": []string{common.GetTimestamp()}})
-			headers, code = ctx.c.HeadAccount(account, nil)
+			ctx.C.PutAccount(account, http.Header{"X-Timestamp": []string{common.GetTimestamp()}})
+			headers, code = ctx.C.HeadAccount(account, nil)
 		}
 		if code/100 != 2 {
 			return nil
@@ -264,9 +275,15 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 		ProxyContextMiddleware: m,
 		Authorize:              nil,
 		Logger:                 logr,
-		containerInfoCache:     make(map[string]*ContainerInfo),
+		containerInfoCache:     make(map[string]*client.ContainerInfo),
 		accountInfoCache:       make(map[string]*AccountInfo),
 		capWriter:              newWriter,
+	}
+	var err error
+	ctx.C, err = client.NewProxyDirectClient(ctx)
+	if err != nil {
+		srv.StandardResponse(writer, 500)
+		return
 	}
 	// we'll almost certainly need the AccountInfo and ContainerInfo for the current path, so pre-fetch them in parallel.
 	apiRequest, account, container, _ := getPathParts(request)
@@ -278,7 +295,7 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 				hdr := http.Header{
 					"X-Timestamp": []string{common.GetTimestamp()},
 				}
-				m.c.PutAccount(account, hdr) // Auto-create the account if we can't get its info
+				ctx.C.PutAccount(account, hdr) // Auto-create the account if we can't get its info
 			}
 			wg.Done()
 		}()
@@ -295,13 +312,13 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 	m.next.ServeHTTP(newWriter, request)
 }
 
-func NewContext(mc ring.MemcacheRing, c client.ProxyClient, log srv.LowLevelLogger) func(http.Handler) http.Handler {
+func NewContext(mc ring.MemcacheRing, log srv.LowLevelLogger, policyList conf.PolicyList) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return &ProxyContextMiddleware{
-			Cache: mc,
-			c:     c,
-			log:   log,
-			next:  next,
+			Cache:      mc,
+			log:        log,
+			next:       next,
+			policyList: policyList,
 		}
 	}
 }

--- a/proxyserver/middleware/formpost_test.go
+++ b/proxyserver/middleware/formpost_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/troubling/hummingbird/client"
 )
 
 func makeFormpostRequest(t *testing.T, body, boundary string, next http.Handler) *httptest.ResponseRecorder {
@@ -41,7 +42,7 @@ func makeFormpostRequest(t *testing.T, body, boundary string, next http.Handler)
 	newr.Header.Set("Content-Type", "multipart/form-data; boundary="+boundary)
 	neww := httptest.NewRecorder()
 	ctx := &ProxyContext{
-		containerInfoCache: map[string]*ContainerInfo{
+		containerInfoCache: map[string]*client.ContainerInfo{
 			"container/AUTH_test/container": {Metadata: map[string]string{"Temp-Url-Key": "mykey"}},
 		},
 		accountInfoCache: map[string]*AccountInfo{
@@ -150,7 +151,7 @@ func TestFpLimitReader(t *testing.T) {
 // func authorizeFormpost(ctx *ProxyContext, account, container, path string, attrs map[string]string) int {
 func TestAuthenticateFormpost(t *testing.T) {
 	ctx := &ProxyContext{
-		containerInfoCache: map[string]*ContainerInfo{
+		containerInfoCache: map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{
 				"Temp-Url-Key":   "containerkey",
 				"Temp-Url-Key-2": "containerkey2",

--- a/proxyserver/middleware/tempurl_test.go
+++ b/proxyserver/middleware/tempurl_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/troubling/hummingbird/client"
 )
 
 func TestDispositionFormat(t *testing.T) {
@@ -193,7 +194,7 @@ func TestTempurlMiddleware400PuttingManifest(t *testing.T) {
 func TestTempurlMiddleware401NoKeys(t *testing.T) {
 	r := httptest.NewRequest("PUT", "/v1/a/c/o?temp_url_sig=ABCDEF&temp_url_expires=9999999999", nil)
 	ctx := &ProxyContext{
-		containerInfoCache: map[string]*ContainerInfo{
+		containerInfoCache: map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{}},
 		},
 		accountInfoCache: map[string]*AccountInfo{
@@ -211,7 +212,7 @@ func TestTempurlMiddleware401NoKeys(t *testing.T) {
 func TestTempurlMiddleware401WrongKeys(t *testing.T) {
 	r := httptest.NewRequest("PUT", "/v1/a/c/o?temp_url_sig=ABCDEF&temp_url_expires=9999999999", nil)
 	ctx := &ProxyContext{
-		containerInfoCache: map[string]*ContainerInfo{
+		containerInfoCache: map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{"Temp-Url-Key": "ABCD", "Temp-Url-Key-2": "012345"}},
 		},
 		accountInfoCache: map[string]*AccountInfo{
@@ -230,7 +231,7 @@ func TestTempurlMiddlewareContainerKey(t *testing.T) {
 	r := httptest.NewRequest("GET", "/v1/a/c/o?temp_url_sig=f2d61be897a27c03ac9a0dac3a8c4f6ce3a3d623&"+
 		"temp_url_expires=9999999999", nil)
 	ctx := &ProxyContext{
-		containerInfoCache: map[string]*ContainerInfo{
+		containerInfoCache: map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{"Temp-Url-Key": "mykey"}},
 		},
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -256,7 +257,7 @@ func TestTempurlMiddlewarePath(t *testing.T) {
 	r := httptest.NewRequest("GET", "/v1/a/c/o123?temp_url_sig=058e0771c69f7e1eb1eacbd68396920fd06ff261&"+
 		"temp_url_expires=9999999999&temp_url_prefix=o", nil)
 	ctx := &ProxyContext{
-		containerInfoCache: map[string]*ContainerInfo{
+		containerInfoCache: map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{"Temp-Url-Key": "mykey"}},
 		},
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -278,7 +279,7 @@ func TestTempurlMiddlewareAccountKey(t *testing.T) {
 	r := httptest.NewRequest("GET", "/v1/a/c/o?temp_url_sig=f2d61be897a27c03ac9a0dac3a8c4f6ce3a3d623&"+
 		"temp_url_expires=9999999999", nil)
 	ctx := &ProxyContext{
-		containerInfoCache: map[string]*ContainerInfo{
+		containerInfoCache: map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{}},
 		},
 		accountInfoCache: map[string]*AccountInfo{

--- a/proxyserver/objhandlers.go
+++ b/proxyserver/objhandlers.go
@@ -40,7 +40,7 @@ func (server *ProxyServer) ObjectGetHandler(writer http.ResponseWriter, request 
 		srv.StandardResponse(writer, 401)
 		return
 	}
-	r, headers, code := server.C.GetObject(vars["account"], vars["container"], vars["obj"], request.Header)
+	r, headers, code := ctx.C.GetObject(vars["account"], vars["container"], vars["obj"], request.Header)
 	for k := range headers {
 		writer.Header().Set(k, headers.Get(k))
 	}
@@ -66,7 +66,7 @@ func (server *ProxyServer) ObjectHeadHandler(writer http.ResponseWriter, request
 		srv.StandardResponse(writer, 401)
 		return
 	}
-	headers, code := server.C.HeadObject(vars["account"], vars["container"], vars["obj"], request.Header)
+	headers, code := ctx.C.HeadObject(vars["account"], vars["container"], vars["obj"], request.Header)
 	for k := range headers {
 		writer.Header().Set(k, headers.Get(k))
 	}
@@ -89,7 +89,7 @@ func (server *ProxyServer) ObjectDeleteHandler(writer http.ResponseWriter, reque
 		return
 	}
 	request.Header.Set("X-Timestamp", common.GetTimestamp())
-	srv.StandardResponse(writer, server.C.DeleteObject(vars["account"], vars["container"], vars["obj"], request.Header))
+	srv.StandardResponse(writer, ctx.C.DeleteObject(vars["account"], vars["container"], vars["obj"], request.Header))
 }
 
 func (server *ProxyServer) ObjectPutHandler(writer http.ResponseWriter, request *http.Request) {
@@ -121,7 +121,7 @@ func (server *ProxyServer) ObjectPutHandler(writer http.ResponseWriter, request 
 		return
 	}
 	request.Header.Set("X-Timestamp", common.GetTimestamp())
-	h, code := server.C.PutObject(vars["account"], vars["container"], vars["obj"], request.Header, request.Body)
+	h, code := ctx.C.PutObject(vars["account"], vars["container"], vars["obj"], request.Header, request.Body)
 	writer.Header().Set("Etag", h.Get("Etag"))
 	srv.StandardResponse(writer, code)
 }


### PR DESCRIPTION
This is work towards #80 

It allows creating containers with policies other than the default, and to work with objects in such containers.

Remaining work deals with returning the appropriate informative headers, to included account-level metrics.