### PR TITLE
Content length checking

### DIFF
--- a/proxyserver/constraints.go
+++ b/proxyserver/constraints.go
@@ -73,11 +73,10 @@ func CheckMetadata(req *http.Request, targetType string) (int, string) {
 }
 
 func CheckObjPut(req *http.Request, objectName string) (int, string) {
-	if req.ContentLength >= 0 {
-		if req.ContentLength > MAX_FILE_SIZE {
-			return http.StatusRequestEntityTooLarge, "Your request is too large."
-		}
-	} else if req.Header.Get("Transfer-Encoding") != "chunked" {
+	if req.ContentLength > MAX_FILE_SIZE {
+		return http.StatusRequestEntityTooLarge, "Your request is too large."
+	}
+	if req.ContentLength <= 0 && req.Header.Get("Content-Length") == "" && req.Header.Get("Transfer-Encoding") != "chunked" {
 		return http.StatusLengthRequired, "Missing Content-Length header."
 	}
 	if req.Header.Get("X-Copy-From") != "" && req.ContentLength != 0 {

--- a/proxyserver/constraints_test.go
+++ b/proxyserver/constraints_test.go
@@ -57,6 +57,7 @@ func TestLengthOnCopyFrom(t *testing.T) {
 func TestNameTooLong(t *testing.T) {
 	req, err := http.NewRequest("PUT", "/v1/a/c/o", nil)
 	require.Nil(t, err)
+	req.ContentLength = 1
 	status, _ := CheckObjPut(req, strings.Repeat("o", MAX_OBJECT_NAME_LENGTH+1))
 	require.Equal(t, status, http.StatusBadRequest)
 }
@@ -68,6 +69,15 @@ func TestNoContentType(t *testing.T) {
 	req.Header.Set("Content-Type", "")
 	status, _ := CheckObjPut(req, "o")
 	require.Equal(t, status, http.StatusBadRequest)
+}
+
+func TestNoContentLength(t *testing.T) {
+	req, err := http.NewRequest("PUT", "/v1/a/c/o", nil)
+	require.Nil(t, err)
+	req.ContentLength = 0
+	req.Header.Set("Content-Length", "")
+	status, _ := CheckObjPut(req, "o")
+	require.Equal(t, status, http.StatusLengthRequired)
 }
 
 func TestBadXDeleteAt(t *testing.T) {


### PR DESCRIPTION
Golang's http.Request makes it a little tough to tell if the content length header is missing.