### PR TITLE
Marshal/Unmarshal interface for pickle

### DIFF
--- a/common/pickle/unmarshal.go
+++ b/common/pickle/unmarshal.go
@@ -1,0 +1,86 @@
+package pickle
+
+import (
+	"errors"
+	"reflect"
+)
+
+func unpack(src reflect.Value, dst reflect.Value) error {
+	for src.Kind() == reflect.Ptr || src.Kind() == reflect.Interface {
+		if src.IsNil() {
+			dst.Set(dst)
+			return nil
+		}
+		src = src.Elem()
+	}
+	for dst.Kind() == reflect.Ptr || dst.Kind() == reflect.Interface {
+		if dst.IsNil() {
+			dst.Set(reflect.New(dst.Type().Elem()))
+		}
+		dst = dst.Elem()
+	}
+	if src.Type().ConvertibleTo(dst.Type()) {
+		dst.Set(src.Convert(dst.Type()))
+		return nil
+	}
+	switch dst.Kind() {
+	case reflect.Bool:
+		dst.SetBool(src.Interface() != reflect.Zero(src.Type()).Interface())
+		return nil
+	case reflect.Slice:
+		if k := src.Kind(); k != reflect.Slice && k != reflect.Array {
+			return errors.New("Unable to assign slice from non-slice")
+		}
+		dst.Set(reflect.MakeSlice(dst.Type(), src.Len(), src.Len()))
+		for i := 0; i < src.Len(); i++ {
+			if err := unpack(src.Index(i), dst.Index(i)); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		if src.Kind() != reflect.Map {
+			return errors.New("Unable to assign map from non-map")
+		}
+		dst.Set(reflect.MakeMap(dst.Type()))
+		nk := reflect.New(dst.Type().Key())
+		nv := reflect.New(dst.Type().Elem())
+		for _, k := range src.MapKeys() {
+			if err := unpack(k, nk); err != nil {
+				return err
+			}
+			if err := unpack(src.MapIndex(k), nv); err != nil {
+				return err
+			}
+			dst.SetMapIndex(nk.Elem(), nv.Elem())
+		}
+	case reflect.Struct:
+		if src.Kind() != reflect.Map {
+			return errors.New("Unable to assign struct from non-map")
+		}
+		for _, k := range src.MapKeys() {
+			for k.Kind() == reflect.Ptr || k.Kind() == reflect.Interface {
+				k = k.Elem()
+			}
+			for i := 0; i < dst.NumField(); i++ {
+				if f := dst.Type().Field(i); f.Name == k.String() || f.Tag.Get("pickle") == k.String() {
+					if err := unpack(src.MapIndex(k), dst.Field(i)); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	default:
+		return errors.New("Assign to unknown type")
+	}
+	return nil
+}
+
+// Unmarshal parses the pickled data and stores the result in the value pointed to by v.
+// Unmarshal is considerably less performant than PickleLoads, so think twice before using it in performance-sensitive code.
+func Unmarshal(data []byte, v interface{}) error {
+	src, err := PickleLoads(data)
+	if err != nil {
+		return err
+	}
+	return unpack(reflect.ValueOf(src), reflect.ValueOf(v))
+}

--- a/common/pickle/unmarshal_test.go
+++ b/common/pickle/unmarshal_test.go
@@ -1,0 +1,214 @@
+package pickle
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mystring string
+
+func BenchmarkUnmarshal(b *testing.B) {
+	pickled := PickleDumps(map[string]string{
+		"Content-Length": "65536", "Content-Type": "application/octet-stream", "ETag": "fcd6bcb56c1689fcef28b57c22475bad",
+		"X-Timestamp": "1422766779.57463", "name": "/someaccountname/somecontainername/5821142269423797100"})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var v map[string]string
+		Unmarshal(pickled, &v)
+	}
+}
+
+func TestUnmarshalStruct(t *testing.T) {
+	type Teststruct struct {
+		Tmap    map[mystring]int64
+		Tstring string
+		Tint    int64
+		Tfloat  float64
+		Tbool   bool
+		Tslice  []int
+	}
+	ts := Teststruct{
+		Tmap:    map[mystring]int64{"hello": 42},
+		Tstring: "testing",
+		Tint:    1000,
+		Tfloat:  3.14,
+		Tbool:   true,
+		Tslice:  []int{1, 2, 3},
+	}
+	serialized := PickleDumps(ts)
+	var rs Teststruct
+	require.Nil(t, Unmarshal(serialized, &rs))
+	require.Equal(t, ts, rs)
+}
+
+func TestUnmarshalSomeRecursion(t *testing.T) {
+	type Teststruct struct {
+		Depth int
+		Next  *Teststruct
+	}
+	ts := Teststruct{
+		Depth: 1,
+		Next: &Teststruct{
+			Depth: 2,
+			Next: &Teststruct{
+				Depth: 3,
+				Next: &Teststruct{
+					Depth: 4,
+				},
+			},
+		},
+	}
+	serialized := PickleDumps(ts)
+	var rs Teststruct
+	require.Nil(t, Unmarshal(serialized, &rs))
+	require.Equal(t, ts, rs)
+	require.Nil(t, rs.Next.Next.Next.Next)
+}
+
+func TestUnmarshalMap(t *testing.T) {
+	src := map[mystring]int64{
+		mystring("hello"): 42,
+		mystring("there"): 91,
+		mystring("you"):   113,
+	}
+	var result map[string]int
+	require.Nil(t, unpack(reflect.ValueOf(src), reflect.ValueOf(&result)))
+	require.Equal(t, 3, len(result))
+	require.Equal(t, 42, result["hello"])
+	require.Equal(t, 91, result["there"])
+	require.Equal(t, 113, result["you"])
+}
+
+func TestUnmarshalString(t *testing.T) {
+	var result string
+	require.Nil(t, unpack(reflect.ValueOf("1"), reflect.ValueOf(&result)))
+	require.Equal(t, "1", result)
+}
+
+func TestUnmarshalInt(t *testing.T) {
+	for _, src := range []interface{}{int64(1), int(1), float32(1), float64(1)} {
+		var result int64
+		require.Nil(t, unpack(reflect.ValueOf(src), reflect.ValueOf(&result)))
+		require.Equal(t, int64(1), result)
+	}
+}
+
+func TestUnmarshalFloat(t *testing.T) {
+	for _, src := range []interface{}{int64(1), int(1), float32(1), float64(1)} {
+		var result float64
+		require.Nil(t, unpack(reflect.ValueOf(src), reflect.ValueOf(&result)))
+		require.Equal(t, float64(1.0), result)
+	}
+}
+
+func TestUnmarshalBool(t *testing.T) {
+	for _, src := range []interface{}{int64(1), float32(1), true} {
+		var result bool
+		require.Nil(t, unpack(reflect.ValueOf(src), reflect.ValueOf(&result)))
+		require.True(t, result, fmt.Sprintf("%s", src))
+	}
+
+	for _, src := range []interface{}{int64(0), float32(0), false} {
+		var result bool
+		require.Nil(t, unpack(reflect.ValueOf(src), reflect.ValueOf(&result)))
+		require.False(t, result)
+	}
+}
+
+func TestUnmarshalSlice(t *testing.T) {
+	var result []int
+	src := []int8{1, 2, 3}
+	require.Nil(t, unpack(reflect.ValueOf(src), reflect.ValueOf(&result)))
+	require.Equal(t, 3, len(result))
+	require.Equal(t, 1, result[0])
+	require.Equal(t, 2, result[1])
+	require.Equal(t, 3, result[2])
+}
+
+func TestUnmarshalRingBuilder(t *testing.T) {
+	// a real life ring builder from my saio
+	b, err := hex.DecodeString("1f8b08084ffa285900036f626a6563742d312e6275696c64657200ed99e992db4410c775e" +
+		"d11b3188723e60e37e65ab24e20dc094960c30ee20819c2a508614f59aedab5ddf2b195546d151f20145ff8cc1bf0043c046" +
+		"fc32330f2a599ee56081fa9722625d9a356cfaffffd9f5a95f5a377046e436e4c5436ecf67be08935b999a9c17eb7950cc1d" +
+		"f3defccfec9e371bb3b1ccca2e24e960c52088e60ad215ce1dd8a60bd113a9efe2f1ca5675c796ca77976fb941e3bb0f14b0" +
+		"49be6e59f2338d6108e704227c8a37d33baa2a3efb292053afd969d5ecfdc5dcc4c19cc1c55e18e22b8c7ce6206d4f422c7a" +
+		"dcbbe4e79af9dd24d3784a3f3dc67057a6955df7cbf1d1aa435e1ebd007ec693fad084f4f9f28a6c7b23248b2513ce81faa0" +
+		"ceaa2226bf17e32d413f9ec417fa286f0602bc9b2e44665768487a47b218287a78aadc66aacc66aacc66aacc6ff7ba8fffc1" +
+		"75dddba028fc84af120068fee3ac503dafcb1ad993f4a34db6a028f45f07823d5cf0f972338b958cd9b0ff393631c17d7cce" +
+		"f1e73bd8832cf76b467c499f1c5a0b166942730d3ed783d94df26e43278ec5a0eb98712537d7845cc182ebf272821ce62aee" +
+		"5084e27da593b0ecfdbea507e4e21be9bdc0ab8b7767ddcba9eb015e07a83dd45fd893f51cda8d7b04e361557154784fbe60" +
+		"8ccc9f596ae823bcdf517ef425a1fee9d7de49de9a06c786f95bb11fba75c77aa357546f9bec3b979af7115507eac0c5741f" +
+		"94ec2cea67d28e7e63d41f5b467a9f7e999df337857d84addd98ea1fdc0a4bc7e7cedd495941aeb545e3d7603ad89ef27ce4" +
+		"d3d849d45dd8bfd4fd5e308391fd17ee38aa8df67cf0fff56bfc5903f3f3c317f1e78b221fce970e7c3fce41bc7c535f3bbc" +
+		"b5c2fa2ccb31ded1a71667c3168ac19e50acc743b5e17e5b709b90c2ebb964feea1c4541f5e113386cbef0a4a88b3986bf98" +
+		"2d38976d68ec3f3b63a949f5388ef26b702eead5d1fb7ae2b6c05b8de6077517fe24f5433ea35ac934dc555c511e1bef9027" +
+		"372bda5abe04e73fdc5bb90d6877b671f7967fa281bde5be56ec4fe29d79d6a4d9d51beef706ede6b5c05941f2bc35550be9" +
+		"3b0b3691fcab9794f503ded59ea7d7ae6f70cde15b65277b663683f3029af1f5f3b7525a5c63a95578fdd406be2fb8973530" +
+		"f616751f762ff53f53842ce47b4dfb822ea775f35ac3bca3a6130e4cf034f295937de40749251aab27838d25fe0e9f00f4f5" +
+		"60fbabdd9b5b43fce86f08c70e5667fa2b2fd7ed286678b1f2082b69a0ce1b9089e6f1c41a3216bf3df2346f91ba3415fe77" +
+		"b21dc3b29839bfd9e82177596f543d5eda4237869f7dcdff31c5e77002fa71b723d539dfcf78d57745830bd773bbc5997553" +
+		"3a50e7dd57ca9734aaee598c3d0f16470a04609ec4847ae6baa6e4b415306c3f60f3b705a6e4da3e2c3a437526d3823f255d" +
+		"bf09a70c647f03a877d36bcbac07e43784bec376decb7d2ea12fb6d8d9d277d479f31f3bb26f37b84f99cc17c7ecadc84f7d" +
+		"39c72a6c385f0a7ba06bdc8815e0aaf2f403f10fe12f4431b7437ad2c412f2ff5fd28fc8deabb67b20ac2fab1c11a4e594fc" +
+		"327e942d14f85a7413fe3403f0fd305e815112c41bfb041afa6b525a8d4a0c5f279fa2f758598f79ac9fbd59cf26b83f29b2" +
+		"9e519f8d650f4bbf0f7fa58c9addcbe712b4d7a1d6d8be8d7f972703d74027902bfa48bd5a0df4a21debbf1e75fd7e4569ca" +
+		"97c3a9e6e81ef2348c6dbff000ce59aa65a1d0000")
+	require.Nil(t, err)
+	r, err := gzip.NewReader(bytes.NewBuffer(b))
+	require.Nil(t, err)
+	data, err := ioutil.ReadAll(r)
+	require.Nil(t, err)
+	// load the ring builder into an old-school interface{}
+	unst1, err := PickleLoads(data)
+	require.Nil(t, err)
+
+	// round-trip the ring builder through a struct unmarshal/marshal
+	type RingBuilderDevice struct {
+		ReplicationPort int64   `pickle:"replication_port"`
+		Meta            string  `pickle:"meta"`
+		PartsWanted     int64   `pickle:"parts_wanted"`
+		Device          string  `pickle:"device"`
+		Zone            int64   `pickle:"zone"`
+		Weight          float64 `pickle:"weight"`
+		Ip              string  `pickle:"ip"`
+		Region          int64   `pickle:"region"`
+		Port            int64   `pickle:"port"`
+		ReplicationIp   string  `pickle:"replication_ip"`
+		Parts           int64   `pickle:"parts"`
+		Id              int64   `pickle:"id"`
+	}
+	type RingBuilder struct {
+		LastPartGatherStart int64                         `pickle:"_last_part_gather_start"`
+		LastPartMovesEpoch  int64                         `pickle:"_last_part_moves_epoch"`
+		PartPower           int64                         `pickle:"part_power"`
+		DevsChanged         bool                          `pickle:"devs_changed"`
+		Replicas            float64                       `pickle:"replicas"`
+		MinPartHours        int64                         `pickle:"min_part_hours"`
+		Parts               int64                         `pickle:"parts"`
+		Overload            float64                       `pickle:"overload"`
+		Dispersion          float64                       `pickle:"dispersion"`
+		Version             int64                         `pickle:"version"`
+		Devices             []RingBuilderDevice           `pickle:"devs"`
+		RemoveDevs          []interface{}                 `pickle:"_remove_devs"`
+		LastPartMoves       PickleArray                   `pickle:"_last_part_moves"`
+		Replica2Part2Dev    []PickleArray                 `pickle:"_replica2part2dev"`
+		DispersionGraph     map[PickleTuple][]interface{} `pickle:"_dispersion_graph"`
+	}
+	var dst RingBuilder
+	require.Nil(t, Unmarshal(data, &dst))
+	data2 := PickleDumps(dst)
+
+	// then load that into an interface{}
+	unst2, err := PickleLoads(data2)
+	require.Nil(t, err)
+
+	// make sure all the data was preserved in the round-trip.
+	require.Equal(t, unst1, unst2)
+}


### PR DESCRIPTION
Add Marshal and Unmarshal functions to the pickle package for
pickling/unpickling structs.  These mirror similar functions for
json and other serialization formats.

Unmarshal isn't very performant because it has to double-allocate,
but it is pretty handy for loading complex structures.

Pickles will prevail.