### PR TITLE
rename SwiftObjectFactory to SwiftEngine

### DIFF
--- a/objectserver/swiftobjeng.go
+++ b/objectserver/swiftobjeng.go
@@ -168,7 +168,7 @@ func (o *SwiftObject) Close() error {
 	return nil
 }
 
-type SwiftObjectFactory struct {
+type SwiftEngine struct {
 	driveRoot      string
 	hashPathPrefix string
 	hashPathSuffix string
@@ -178,7 +178,7 @@ type SwiftObjectFactory struct {
 }
 
 // New returns an instance of SwiftObject with the given parameters. Metadata is read in and if needData is true, the file is opened.  AsyncWG is a waitgroup if the object spawns any async operations
-func (f *SwiftObjectFactory) New(vars map[string]string, needData bool, asyncWG *sync.WaitGroup) (Object, error) {
+func (f *SwiftEngine) New(vars map[string]string, needData bool, asyncWG *sync.WaitGroup) (Object, error) {
 	var err error
 	sor := &SwiftObject{reclaimAge: f.reclaimAge, reserve: f.reserve, asyncWG: asyncWG}
 	sor.hashDir = ObjHashDir(vars, f.driveRoot, f.hashPathPrefix, f.hashPathSuffix, f.policy)
@@ -221,7 +221,7 @@ func (f *SwiftObjectFactory) New(vars map[string]string, needData bool, asyncWG 
 
 var replicationDone = fmt.Errorf("Replication done")
 
-// SwiftEngineConstructor creates a SwiftObjectFactory given the object server configs.
+// SwiftEngineConstructor creates a SwiftEngine given the object server configs.
 func SwiftEngineConstructor(config conf.Config, policy *conf.Policy, flags *flag.FlagSet) (ObjectEngine, error) {
 	driveRoot := config.GetDefault("app:object-server", "devices", "/srv/node")
 	reserve := config.GetInt("app:object-server", "fallocate_reserve", 0)
@@ -230,7 +230,7 @@ func SwiftEngineConstructor(config conf.Config, policy *conf.Policy, flags *flag
 		return nil, errors.New("Unable to load hashpath prefix and suffix")
 	}
 	reclaimAge := int64(config.GetInt("app:object-server", "reclaim_age", int64(common.ONE_WEEK)))
-	return &SwiftObjectFactory{
+	return &SwiftEngine{
 		driveRoot:      driveRoot,
 		hashPathPrefix: hashPathPrefix,
 		hashPathSuffix: hashPathSuffix,
@@ -246,4 +246,4 @@ func init() {
 // make sure these things satisfy interfaces at compile time
 var _ ObjectEngineConstructor = SwiftEngineConstructor
 var _ Object = &SwiftObject{}
-var _ ObjectEngine = &SwiftObjectFactory{}
+var _ ObjectEngine = &SwiftEngine{}

--- a/objectserver/swiftobjeng_test.go
+++ b/objectserver/swiftobjeng_test.go
@@ -18,7 +18,7 @@ func TestSwiftObjectRoundtrip(t *testing.T) {
 	defer os.RemoveAll(driveRoot)
 
 	vars := map[string]string{"device": "sda", "account": "a", "container": "c", "object": "o", "partition": "1"}
-	swcon := &SwiftObjectFactory{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
+	swcon := &SwiftEngine{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
 	var wg sync.WaitGroup
 	defer wg.Wait()
 	swo, err := swcon.New(vars, false, &wg)
@@ -51,7 +51,7 @@ func TestSwiftObjectFailAuditContentLengthWrong(t *testing.T) {
 	}()
 
 	vars := map[string]string{"device": "sda", "account": "a", "container": "c", "object": "o", "partition": "1"}
-	swcon := &SwiftObjectFactory{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
+	swcon := &SwiftEngine{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
 	swo, err := swcon.New(vars, false, &wg)
 	require.Nil(t, err)
 	defer swo.Close()
@@ -74,7 +74,7 @@ func TestSwiftObjectFailAuditBadContentLength(t *testing.T) {
 	}()
 
 	vars := map[string]string{"device": "sda", "account": "a", "container": "c", "object": "o", "partition": "1"}
-	swcon := &SwiftObjectFactory{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
+	swcon := &SwiftEngine{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
 	swo, err := swcon.New(vars, false, &wg)
 	require.Nil(t, err)
 	defer swo.Close()
@@ -97,7 +97,7 @@ func TestSwiftObjectQuarantine(t *testing.T) {
 	}()
 
 	vars := map[string]string{"device": "sda", "account": "a", "container": "c", "object": "o", "partition": "3"}
-	swcon := &SwiftObjectFactory{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
+	swcon := &SwiftEngine{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
 	swo, err := swcon.New(vars, false, &wg)
 	require.Nil(t, err)
 	defer swo.Close()
@@ -119,7 +119,7 @@ func TestSwiftObjectMultiCopy(t *testing.T) {
 	}()
 
 	vars := map[string]string{"device": "sda", "account": "a", "container": "c", "object": "o", "partition": "1"}
-	swcon := &SwiftObjectFactory{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
+	swcon := &SwiftEngine{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
 	swo, err := swcon.New(vars, false, &wg)
 	require.Nil(t, err)
 	defer swo.Close()
@@ -149,7 +149,7 @@ func TestSwiftObjectDelete(t *testing.T) {
 	}()
 
 	vars := map[string]string{"device": "sda", "account": "a", "container": "c", "object": "o", "partition": "1"}
-	swcon := &SwiftObjectFactory{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
+	swcon := &SwiftEngine{driveRoot: driveRoot, hashPathPrefix: "prefix", hashPathSuffix: "suffix"}
 	swo, err := swcon.New(vars, false, &wg)
 	require.Nil(t, err)
 	defer swo.Close()


### PR DESCRIPTION
Just because gholt mentioned how silly the name was.