### PR TITLE
handle custom array types in pickles

### DIFF
--- a/common/pickle/pickle.go
+++ b/common/pickle/pickle.go
@@ -152,6 +152,19 @@ func pickleobj(o interface{}, buf *bytes.Buffer, scratch []byte) error {
 			buf.WriteByte('l') // TUPLE
 			buf.WriteByte('R') // REDUCE
 		default: // why not serialize arbitrary structs as dicts while we're here
+			if v.NumField() == 2 && v.Type().Field(0).Name == "ArrayType" {
+				buf.WriteString("carray\narray\n")
+				buf.WriteByte('(') // MARK
+				if err := pickleobj(v.Field(0).Interface(), buf, scratch); err != nil {
+					return err
+				}
+				if err := pickleobj(v.Field(1).Interface(), buf, scratch); err != nil {
+					return err
+				}
+				buf.WriteByte('l') // TUPLE
+				buf.WriteByte('R') // REDUCE
+				return nil
+			}
 			buf.WriteByte('(') // MARK
 			for i := 0; i < v.Type().NumField(); i++ {
 				field := v.Type().Field(i)

--- a/common/pickle/unmarshal.go
+++ b/common/pickle/unmarshal.go
@@ -54,8 +54,11 @@ func unpack(src reflect.Value, dst reflect.Value) error {
 			dst.SetMapIndex(nk.Elem(), nv.Elem())
 		}
 	case reflect.Struct:
-		if src.Kind() != reflect.Map {
-			return errors.New("Unable to assign struct from non-map")
+		if src.Type() == reflect.TypeOf(PickleArray{}) && dst.NumField() == 2 && dst.Type().Field(0).Name == "ArrayType" {
+			if err := unpack(src.Field(0), dst.Field(0)); err != nil {
+				return err
+			}
+			return unpack(src.Field(1), dst.Field(1))
 		}
 		for _, k := range src.MapKeys() {
 			for k.Kind() == reflect.Ptr || k.Kind() == reflect.Interface {

--- a/common/pickle/unmarshal_test.go
+++ b/common/pickle/unmarshal_test.go
@@ -185,21 +185,27 @@ func TestUnmarshalRingBuilder(t *testing.T) {
 		Id              int64   `pickle:"id"`
 	}
 	type RingBuilder struct {
-		LastPartGatherStart int64                         `pickle:"_last_part_gather_start"`
-		LastPartMovesEpoch  int64                         `pickle:"_last_part_moves_epoch"`
-		PartPower           int64                         `pickle:"part_power"`
-		DevsChanged         bool                          `pickle:"devs_changed"`
-		Replicas            float64                       `pickle:"replicas"`
-		MinPartHours        int64                         `pickle:"min_part_hours"`
-		Parts               int64                         `pickle:"parts"`
-		Overload            float64                       `pickle:"overload"`
-		Dispersion          float64                       `pickle:"dispersion"`
-		Version             int64                         `pickle:"version"`
-		Devices             []RingBuilderDevice           `pickle:"devs"`
-		RemoveDevs          []interface{}                 `pickle:"_remove_devs"`
-		LastPartMoves       PickleArray                   `pickle:"_last_part_moves"`
-		Replica2Part2Dev    []PickleArray                 `pickle:"_replica2part2dev"`
-		DispersionGraph     map[PickleTuple][]interface{} `pickle:"_dispersion_graph"`
+		LastPartGatherStart int64               `pickle:"_last_part_gather_start"`
+		LastPartMovesEpoch  int64               `pickle:"_last_part_moves_epoch"`
+		PartPower           int64               `pickle:"part_power"`
+		DevsChanged         bool                `pickle:"devs_changed"`
+		Replicas            float64             `pickle:"replicas"`
+		MinPartHours        int64               `pickle:"min_part_hours"`
+		Parts               int64               `pickle:"parts"`
+		Overload            float64             `pickle:"overload"`
+		Dispersion          float64             `pickle:"dispersion"`
+		Version             int64               `pickle:"version"`
+		Devices             []RingBuilderDevice `pickle:"devs"`
+		RemoveDevs          []interface{}       `pickle:"_remove_devs"`
+		LastPartMoves       struct {
+			ArrayType string // should be "B"
+			Data      []uint8
+		} `pickle:"_last_part_moves"`
+		Replica2Part2Dev []struct {
+			ArrayType string // should be "H"
+			Data      []uint
+		} `pickle:"_replica2part2dev"`
+		DispersionGraph map[PickleTuple][]interface{} `pickle:"_dispersion_graph"`
 	}
 	var dst RingBuilder
 	require.Nil(t, Unmarshal(data, &dst))


### PR DESCRIPTION
Treat any struct with two fields with the first one is named
"ArrayType" as an array for pickle purposes.  I could tighten up that
interface a bit, but it doesn't seem likely to get triggered
accidentally.