### PR TITLE
Implement couple of keystoneauth middleware along with acls.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -73,6 +73,9 @@ type ProxyClient interface {
 
 // ContainerInfo is persisted in memcache via JSON; so this needs to continue to have public fields.
 type ContainerInfo struct {
+	ReadACL            string
+	WriteACL           string
+	SyncKey            string
 	ObjectCount        int64
 	ObjectBytes        int64
 	Metadata           map[string]string

--- a/client/directclient.go
+++ b/client/directclient.go
@@ -438,6 +438,12 @@ func (c *ProxyDirectClient) GetContainerInfo(account string, container string, m
 				ci.Metadata[k[17:]] = headers.Get(k)
 			} else if strings.HasPrefix(k, "X-Container-Sysmeta-") {
 				ci.SysMetadata[k[20:]] = headers.Get(k)
+			} else if k == "X-Container-Read" {
+				ci.ReadACL = headers.Get(k)
+			} else if k == "X-Container-Write" {
+				ci.WriteACL = headers.Get(k)
+			} else if k == "X-Container-Sync-Key" {
+				ci.SyncKey = headers.Get(k)
 			}
 		}
 		if mc != nil {

--- a/common/utils.go
+++ b/common/utils.go
@@ -472,9 +472,19 @@ func ParseContentTypeForSlo(contentType string, listedSize int64) (string, int64
 	return contentType, listedSize, nil
 }
 
-func StringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
+func SliceFromCSV(csv string) []string {
+	s := []string{}
+	for _, val := range strings.Split(csv, ",") {
+		if strings.TrimSpace(val) != "" {
+			s = append(s, strings.TrimSpace(val))
+		}
+	}
+	return s
+}
+
+func StringInSlice(s string, slice []string) bool {
+	for _, x := range slice {
+		if x == s {
 			return true
 		}
 	}

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -18,8 +18,8 @@ package common
 import (
 	"bytes"
 	"net/http"
-	"strings"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"net/http"
 	"strings"
+	"reflect"
 	"testing"
 	"time"
 
@@ -298,4 +299,27 @@ func TestParseContentTypeForSlo(t *testing.T) {
 	ct, size, err = ParseContentTypeForSlo("text/html;swift_bytes=moo", int64(12))
 	require.Equal(t, ct, "")
 	require.NotNil(t, err)
+}
+
+func TestSliceFromCSV(t *testing.T) {
+	var tests = []struct {
+		s        string   // input
+		expected []string // expected result
+	}{
+		{"", []string{}},
+		{"fdfd", []string{"fdfd"}},
+		{"fd,fd", []string{"fd", "fd"}},
+		{"fd,   fd", []string{"fd", "fd"}},
+		{" fd  , fd ", []string{"fd", "fd"}},
+		{"fd fd", []string{"fd fd"}},
+		{"fd,fd, fdf", []string{"fd", "fd", "fdf"}},
+		{"fd,,fd", []string{"fd", "fd"}},
+	}
+
+	for _, tt := range tests {
+		actual := SliceFromCSV(tt.s)
+		if !reflect.DeepEqual(actual, tt.expected) {
+			t.Errorf("SliceFromCSV(%v): expected %v, actual %v", tt.s, tt.expected, actual)
+		}
+	}
 }

--- a/proxyserver/accounthandlers.go
+++ b/proxyserver/accounthandlers.go
@@ -31,6 +31,9 @@ func (server *ProxyServer) AccountGetHandler(writer http.ResponseWriter, request
 		return
 	}
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}
@@ -61,6 +64,9 @@ func (server *ProxyServer) AccountHeadHandler(writer http.ResponseWriter, reques
 		return
 	}
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}
@@ -79,6 +85,9 @@ func (server *ProxyServer) AccountPostHandler(writer http.ResponseWriter, reques
 		return
 	}
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}
@@ -100,6 +109,9 @@ func (server *ProxyServer) AccountPutHandler(writer http.ResponseWriter, request
 		return
 	}
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}
@@ -121,6 +133,9 @@ func (server *ProxyServer) AccountDeleteHandler(writer http.ResponseWriter, requ
 		return
 	}
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}

--- a/proxyserver/accounthandlers.go
+++ b/proxyserver/accounthandlers.go
@@ -33,6 +33,7 @@ func (server *ProxyServer) AccountGetHandler(writer http.ResponseWriter, request
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -66,6 +67,7 @@ func (server *ProxyServer) AccountHeadHandler(writer http.ResponseWriter, reques
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -87,6 +89,7 @@ func (server *ProxyServer) AccountPostHandler(writer http.ResponseWriter, reques
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -111,6 +114,7 @@ func (server *ProxyServer) AccountPutHandler(writer http.ResponseWriter, request
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -135,6 +139,7 @@ func (server *ProxyServer) AccountDeleteHandler(writer http.ResponseWriter, requ
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return

--- a/proxyserver/containerhandlers.go
+++ b/proxyserver/containerhandlers.go
@@ -45,10 +45,6 @@ func (server *ProxyServer) ContainerGetHandler(writer http.ResponseWriter, reque
 		srv.StandardResponse(writer, 404)
 		return
 	}
-	if ctx.Authorize != nil && !ctx.Authorize(request) {
-		srv.StandardResponse(writer, 401)
-		return
-	}
 	options := make(map[string]string)
 	if request.ParseForm() == nil {
 		for k, v := range request.Form {
@@ -62,6 +58,7 @@ func (server *ProxyServer) ContainerGetHandler(writer http.ResponseWriter, reque
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -92,6 +89,7 @@ func (server *ProxyServer) ContainerHeadHandler(writer http.ResponseWriter, requ
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -120,6 +118,7 @@ func (server *ProxyServer) ContainerPostHandler(writer http.ResponseWriter, requ
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -151,6 +150,7 @@ func (server *ProxyServer) ContainerPutHandler(writer http.ResponseWriter, reque
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -178,6 +178,7 @@ func (server *ProxyServer) ContainerDeleteHandler(writer http.ResponseWriter, re
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return

--- a/proxyserver/main.go
+++ b/proxyserver/main.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	_ "net/http/pprof"
 	"strings"
 
 	"github.com/troubling/hummingbird/client"
@@ -72,9 +71,6 @@ func (server *ProxyServer) GetHandler(config conf.Config) http.Handler {
 	router.Delete("/v1/:account/", http.HandlerFunc(server.AccountDeleteHandler))
 	router.Post("/v1/:account", http.HandlerFunc(server.AccountPostHandler))
 	router.Post("/v1/:account/", http.HandlerFunc(server.AccountPostHandler))
-
-	router.Get("/debug/pprof/:parm", http.DefaultServeMux)
-	router.Post("/debug/pprof/:parm", http.DefaultServeMux)
 
 	tempAuth := config.GetBool("proxy-server", "tempauth_enabled", true)
 	var middlewares []struct {

--- a/proxyserver/middleware/acl.go
+++ b/proxyserver/middleware/acl.go
@@ -1,0 +1,109 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/troubling/hummingbird/common"
+)
+
+// Returns a cleaned ACL header value, validating that it meets the formatting
+// requirements for standard Hummingbird ACL strings.
+func CleanACL(name string, value string) (string, error) {
+	name = strings.ToLower(name)
+	var values []string
+	for _, rawValue := range strings.Split(value, ",") {
+		rawValue = strings.TrimSpace(rawValue)
+		if rawValue == "" {
+			continue
+		}
+		if !strings.Contains(rawValue, ":") {
+			values = append(values, rawValue)
+			continue
+		}
+		v := strings.SplitN(rawValue, ":", 2)
+		v[0] = strings.TrimSpace(v[0])
+		v[1] = strings.TrimSpace(v[1])
+		if v[0] == "" || !strings.HasPrefix(v[0], ".") {
+			values = append(values, rawValue)
+		} else if common.StringInSlice(v[0], []string{".r", ".ref", ".referer", ".referrer"}) {
+			if strings.Contains(name, "write") {
+				return "", fmt.Errorf("Referrers not allowed in write ACL: %s", rawValue)
+			}
+			negate := false
+			if v[1] != "" && strings.HasPrefix(v[1], "-") {
+				negate = true
+				v[1] = strings.TrimSpace(v[1][1:])
+			}
+			if v[1] != "" && v[1] != "*" && strings.HasPrefix(v[1], "*") {
+				v[1] = strings.TrimSpace(v[1][1:])
+			}
+			if v[1] == "" || v[1] == "." {
+				return "", fmt.Errorf("No host/domain value after referrer designation in ACL: %s", rawValue)
+			}
+			if negate {
+				values = append(values, fmt.Sprintf(".r:-%s", v[1]))
+			} else {
+				values = append(values, fmt.Sprintf(".r:%s", v[1]))
+			}
+		} else {
+			return "", fmt.Errorf("Unknown designator %s in ACL: %s", v[0], rawValue)
+		}
+	}
+	return strings.Join(values, ","), nil
+
+}
+
+// Parses a standard Hummingbird ACL string into a referrers list and groups list.
+func ParseACL(acl string) ([]string, []string) {
+	referrers := []string{}
+	groups := []string{}
+	if acl != "" {
+		for _, value := range strings.Split(acl, ",") {
+			if strings.HasPrefix(value, ".r:") {
+				referrers = append(referrers, value[len(".r:"):])
+			} else {
+				groups = append(groups, value)
+			}
+		}
+	}
+	return referrers, groups
+}
+
+//Returns True if the referrer should be allowed based on the referrerACL list
+func ReferrerAllowed(referrer string, referrerACL []string) bool {
+	allow := false
+	if len(referrerACL) > 0 {
+		rHost := "unknown"
+		if u, err := url.Parse(referrer); err == nil {
+			rHost = u.Hostname()
+		}
+		for _, mHost := range referrerACL {
+			if strings.HasPrefix(mHost, "-") {
+				mHost = mHost[1:]
+				if mHost == rHost || (strings.HasPrefix(mHost, ".") && strings.HasSuffix(rHost, mHost)) {
+					allow = false
+				}
+			} else if mHost == "*" || mHost == rHost || (strings.HasPrefix(mHost, ".") && strings.HasSuffix(rHost, mHost)) {
+				allow = true
+			}
+		}
+	}
+	return allow
+}

--- a/proxyserver/middleware/acl_test.go
+++ b/proxyserver/middleware/acl_test.go
@@ -1,0 +1,139 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCleanACL(t *testing.T) {
+	var tests = []struct {
+		s        string // input
+		expected string // expected result
+	}{
+		{"bob, sue", "bob,sue"},
+		{"bob , sue", "bob,sue"},
+		{"bob,,,sue", "bob,sue"},
+		{".r:-*.ending.with", ".r:-.ending.with"},
+		{".ref:*", ".r:*"},
+		{" .r : one , ,, .r:two , .r : - three ", ".r:one,.r:two,.r:-three"},
+		{".r:one,.r:-two,account,account:user", ".r:one,.r:-two,account,account:user"},
+		{"TEST_account", "TEST_account"},
+		{".r:*,.r:-specific.host", ".r:*,.r:-specific.host"},
+	}
+
+	for _, tt := range tests {
+		actual, err := CleanACL("X-Container-Read", tt.s)
+		assert.Nil(t, err)
+		if actual != tt.expected {
+			t.Errorf("CleanACL(%v): expected %v, actual %v", tt.s, tt.expected, actual)
+		}
+	}
+	var errortests = []struct {
+		s        string // input
+		expected string // expected result
+	}{
+		{".unknown:test", "Unknown designator .unknown in ACL: .unknown:test"},
+		{".r:", "No host/domain value after referrer designation in ACL: .r:"},
+		{".r:*.", "No host/domain value after referrer designation in ACL: .r:*."},
+		{".r : * . ", "No host/domain value after referrer designation in ACL: .r : * ."},
+		{".r:-*.", "No host/domain value after referrer designation in ACL: .r:-*."},
+		{".r : - * . ", "No host/domain value after referrer designation in ACL: .r : - * ."},
+		{" .r : ", "No host/domain value after referrer designation in ACL: .r :"},
+		{"user , .r : ", "No host/domain value after referrer designation in ACL: .r :"},
+		{".r:-", "No host/domain value after referrer designation in ACL: .r:-"},
+		{"user , .r : - ", "No host/domain value after referrer designation in ACL: .r : -"},
+		{" .r : - ", "No host/domain value after referrer designation in ACL: .r : -"},
+	}
+	for _, tt := range errortests {
+		val, err := CleanACL("X-Container-Read", tt.s)
+		assert.Equal(t, val, "")
+		if assert.Error(t, err, "An error was expected") {
+			assert.Equal(t, err.Error(), tt.expected)
+		}
+	}
+	val, err := CleanACL("X-Container-Write", ".r:r")
+	assert.Equal(t, val, "")
+	if assert.Error(t, err, "An error was expected") {
+		assert.Equal(t, err.Error(), "Referrers not allowed in write ACL: .r:r")
+	}
+
+}
+
+func TestParseACL(t *testing.T) {
+	var tests = []struct {
+		s                 string // input
+		expectedRefferers []string
+		expectedGroups    []string
+	}{
+		{"", []string{}, []string{}},
+		{".r:ref1", []string{"ref1"}, []string{}},
+		{".r:-ref1", []string{"-ref1"}, []string{}},
+		{"account:user", []string{}, []string{"account:user"}},
+		{"account", []string{}, []string{"account"}},
+		{"acc1,acc2:usr2,.r:ref3,.r:-ref4", []string{"ref3", "-ref4"}, []string{"acc1", "acc2:usr2"}},
+		{"acc1,acc2:usr2,.r:ref3,acc3,acc4:usr4,.r:ref5,.r:-ref6",
+			[]string{"ref3", "ref5", "-ref6"},
+			[]string{"acc1", "acc2:usr2", "acc3", "acc4:usr4"}},
+	}
+
+	for _, tt := range tests {
+		actualRefferers, actualGroups := ParseACL(tt.s)
+		if !reflect.DeepEqual(actualRefferers, tt.expectedRefferers) {
+			t.Errorf("ParseACL(%v): expected %v, actual %v", tt.s, tt.expectedRefferers, actualRefferers)
+		}
+		if !reflect.DeepEqual(actualGroups, tt.expectedGroups) {
+			t.Errorf("ParseACL(%v): expected %v, actual %v", tt.s, tt.expectedGroups, actualGroups)
+		}
+	}
+}
+
+func TestReferrerAllowed(t *testing.T) {
+	var tests = []struct {
+		referrer    string
+		referrerACL []string
+		expected    bool
+	}{
+		{"host", []string{}, false},
+		{"", []string{"*"}, true},
+		{"", []string{"specific.host"}, false},
+		{"http://www.example.com/index.html", []string{".example.com"}, true},
+		{"http://user@www.example.com/index.html", []string{".example.com"}, true},
+		{"http://user:pass@www.example.com/index.html", []string{".example.com"}, true},
+		{"http://www.example.com:8080/index.html", []string{".example.com"}, true},
+		{"http://user@www.example.com:8080/index.html", []string{".example.com"}, true},
+		{"http://user:pass@www.example.com:8080/index.html", []string{".example.com"}, true},
+		{"http://user:pass@www.example.com:8080", []string{".example.com"}, true},
+		{"http://www.example.com", []string{".example.com"}, true},
+		{"http://thief.example.com", []string{".example.com", "-thief.example.com"}, false},
+		{"http://thief.example.com", []string{"*", "-thief.example.com"}, false},
+		{"http://www.example.com", []string{".other.com", "www.example.com"}, true},
+		{"http://www.example.com", []string{"-.example.com", "www.example.com"}, true},
+		{"www.example.com", []string{".example.com"}, false},
+		{"../index.htm", []string{".example.com"}, false},
+		{"www.example.com", []string{"*"}, true},
+	}
+
+	for _, tt := range tests {
+		actual := ReferrerAllowed(tt.referrer, tt.referrerACL)
+		if actual != tt.expected {
+			t.Errorf("ReferrerAllowed(%v, %v): expected %v, actual %v", tt.referrer, tt.referrerACL, tt.expected, actual)
+		}
+	}
+}

--- a/proxyserver/middleware/authtoken.go
+++ b/proxyserver/middleware/authtoken.go
@@ -1,0 +1,345 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/troubling/hummingbird/common/conf"
+	"go.uber.org/zap"
+)
+
+type identity struct {
+	client          *http.Client
+	authURL         string
+	authPlugin      string
+	projectDomainID string
+	userDomainID    string
+	projectName     string
+	userName        string
+	password        string
+	userAgent       string
+}
+
+type authToken struct {
+	*identity
+	next      http.Handler
+	cacheTime int
+}
+
+var authHeaders = []string{"X-Identity-Status",
+	"X-Service-Identity-Status",
+	"X-Domain-Id",
+	"X-Domain-Name",
+	"X-Project-Id",
+	"X-Project-Name",
+	"X-Project-Domain-Id",
+	"X-Project-Domain-Name",
+	"X-User-Id",
+	"X-User-Name",
+	"X-User-Domain-Id",
+	"X-User-Domain-Name",
+	"X-Roles",
+	"X-Service-Domain-Id",
+	"X-Service-Domain-Name",
+	"X-Service-Project-Id",
+	"X-Service-Project-Name",
+	"X-Service-Project-Domain-Id",
+	"X-Service-Project-Domain-Name",
+	"X-Service-User-Id",
+	"X-Service-User-Name",
+	"X-Service-User-Domain-Id",
+	"X-Service-User-Domain-Name",
+	"X-Service-Roles",
+	"X-Service-Catalog",
+	"X-Is-Admin-Project",
+	//Deprecated Headers
+	"X-Role",
+	"X-User",
+	"X-Tenant-Id",
+	"X-Tenant-Name",
+	"X-Tenant",
+}
+
+type domain struct {
+	ID      string `json:"id"`
+	Name    string `json:"name,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+}
+
+type project struct {
+	ID      string  `json:"id,omitempty"`
+	Name    string  `json:"name,omitempty"`
+	Enabled bool    `json:"enabled,omitempty"`
+	Domain  *domain `json:"domain"`
+}
+
+type token struct {
+	ExpiresAt time.Time `json:"expires_at"`
+	IssuedAt  time.Time `json:"issued_at"`
+	Methods   []string
+	User      struct {
+		ID      string
+		Name    string
+		Email   string
+		Enabled bool
+		Domain  struct {
+			ID   string
+			Name string
+		}
+	}
+	Project *project
+	Domain  *domain
+	Roles   *[]struct {
+		ID   string
+		Name string
+	}
+}
+
+func (t token) Valid() bool {
+	now := time.Now().Unix()
+	return t.IssuedAt.Unix() <= now && now < t.ExpiresAt.Unix()
+}
+
+func (t token) populateReqHeader(r *http.Request, headerPrefix string) {
+	r.Header.Set(fmt.Sprintf("X%s-User-Id", headerPrefix), t.User.ID)
+	r.Header.Set(fmt.Sprintf("X%s-User-Name", headerPrefix), t.User.Name)
+	r.Header.Set(fmt.Sprintf("X%s-User-Domain-Id", headerPrefix), t.User.Domain.ID)
+	r.Header.Set(fmt.Sprintf("X%s-User-Domain-Name", headerPrefix), t.User.Domain.Name)
+
+	if project := t.Project; project != nil {
+		r.Header.Set(fmt.Sprintf("X%s-Project-Name", headerPrefix), project.Name)
+		r.Header.Set(fmt.Sprintf("X%s-Project-Id", headerPrefix), project.ID)
+		r.Header.Set(fmt.Sprintf("X%s-Project-Domain-Name", headerPrefix), project.Domain.Name)
+		r.Header.Set(fmt.Sprintf("X%s-Project-Domain-Id", headerPrefix), project.Domain.ID)
+	}
+
+	if domain := t.Domain; domain != nil {
+		r.Header.Set(fmt.Sprintf("X%s-Domain-Id", headerPrefix), domain.ID)
+		r.Header.Set(fmt.Sprintf("X%s-Domain-Name", headerPrefix), domain.Name)
+	}
+
+	if roles := t.Roles; roles != nil {
+		roleNames := []string{}
+		for _, role := range *t.Roles {
+			roleNames = append(roleNames, role.Name)
+		}
+		r.Header.Set(fmt.Sprintf("X%s-Roles", headerPrefix), strings.Join(roleNames, ","))
+	}
+}
+
+type identityReq struct {
+	Auth struct {
+		Identity struct {
+			Methods  []string `json:"methods"`
+			Password struct {
+				User struct {
+					Domain struct {
+						ID string `json:"id"`
+					} `json:"domain"`
+					Name     string `json:"name"`
+					Password string `json:"password"`
+				} `json:"user"`
+			} `json:"password"`
+		} `json:"identity"`
+
+		Scope struct {
+			Project *project `json:"project"`
+		} `json:"scope"`
+	} `json:"auth"`
+}
+
+type identityResponse struct {
+	Error *struct {
+		Code    int
+		Message string
+		Title   string
+	}
+	Token *token
+}
+
+func (at *authToken) fetchAndValidateToken(ctx *ProxyContext, authToken string) (*token, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	var tok *token
+	tokenValid := false
+	if cachedToken, err := ctx.Cache.Get(authToken); err == nil {
+		ctx.Logger.Debug("Found cache token",
+			zap.String("token", authToken))
+		if t, ok := cachedToken.(token); ok {
+			tok = &t
+			tokenValid = true
+		}
+	}
+
+	if tok == nil {
+		var err error
+		tok, err = at.validate(authToken)
+		if err != nil {
+			ctx.Logger.Debug("Failed to validate token", zap.Error(err))
+			tokenValid = false
+		}
+
+		if tok != nil {
+			tokenValid = true
+			ttl := at.cacheTime
+			if expiresIn := tok.ExpiresAt.Sub(time.Now()); expiresIn < time.Duration(at.cacheTime)*time.Second {
+				ttl = int(expiresIn / time.Second)
+			}
+			ctx.Cache.Set(authToken, *tok, ttl)
+		}
+	}
+	return tok, tokenValid
+}
+
+func (at *authToken) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	removeAuthHeaders(r)
+	r.Header.Set("X-Identity-Status", "Invalid")
+	ctx := GetProxyContext(r)
+	serviceAuthToken := r.Header.Get("X-Service-Token")
+	if serviceAuthToken != "" {
+		serviceToken, serviceTokenValid := at.fetchAndValidateToken(ctx, serviceAuthToken)
+		if serviceToken != nil && serviceTokenValid {
+			r.Header.Set("X-Service-Identity-Status", "Confirmed")
+			serviceToken.populateReqHeader(r, "-Service")
+		} else {
+			r.Header.Set("X-Service-Identity-Status", "Invalid")
+		}
+	}
+
+	userAuthToken := r.Header.Get("X-Auth-Token")
+	if userAuthToken == "" {
+		userAuthToken = r.Header.Get("X-Storage-Token")
+	}
+	if userAuthToken != "" {
+		userToken, userTokenValid := at.fetchAndValidateToken(ctx, userAuthToken)
+		if userToken != nil && userTokenValid {
+			r.Header.Set("X-Identity-Status", "Confirmed")
+			userToken.populateReqHeader(r, "")
+		}
+	}
+	at.next.ServeHTTP(w, r)
+}
+
+func (at *authToken) validate(token string) (*token, error) {
+	if !strings.HasSuffix(at.authURL, "/") {
+		at.authURL += "/"
+	}
+	req, err := http.NewRequest("GET", at.authURL+"v3/auth/tokens?nocatalog", nil)
+	if err != nil {
+		return nil, err
+	}
+	serverAuthToken, err := at.serverAuth()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Auth-Token", serverAuthToken)
+	req.Header.Set("X-Subject-Token", token)
+	req.Header.Set("User-Agent", at.userAgent)
+
+	r, err := at.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	if r.StatusCode >= 400 {
+		return nil, errors.New(r.Status)
+	}
+
+	var resp identityResponse
+	if err = json.NewDecoder(r.Body).Decode(&resp); err != nil {
+		return nil, err
+	}
+
+	if e := resp.Error; e != nil {
+		return nil, fmt.Errorf("%s : %s", r.Status, e.Message)
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s", r.Status)
+	}
+	if resp.Token == nil {
+		return nil, errors.New("Response didn't contain token context")
+	}
+	if !resp.Token.Valid() {
+		return nil, errors.New("Returned token is not valid")
+
+	}
+	return resp.Token, nil
+}
+
+// serverAuth return the X-Auth-Token to use or an error.
+func (at *authToken) serverAuth() (string, error) {
+	authReq := &identityReq{}
+	authReq.Auth.Identity.Methods = []string{at.authPlugin}
+	authReq.Auth.Identity.Password.User.Domain.ID = at.userDomainID
+	authReq.Auth.Identity.Password.User.Name = at.userName
+	authReq.Auth.Identity.Password.User.Password = at.password
+	authReq.Auth.Scope.Project = &project{Domain: &domain{ID: at.projectDomainID}, Name: at.projectName}
+	authReqBody, err := json.Marshal(authReq)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", at.authURL+"v3/auth/tokens", bytes.NewBuffer(authReqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := at.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		return "", fmt.Errorf("server auth token request gave status %d", resp.StatusCode)
+	}
+	rv := resp.Header.Get("X-Subject-Token")
+	return rv, nil
+}
+
+func removeAuthHeaders(r *http.Request) {
+	for _, header := range authHeaders {
+		r.Header.Del(header)
+	}
+}
+
+func NewAuthToken(config conf.Section) (func(http.Handler) http.Handler, error) {
+	return func(next http.Handler) http.Handler {
+		return &authToken{
+			next:      next,
+			cacheTime: int(config.GetInt("token_cache_time", 300)),
+			identity: &identity{authURL: config.GetDefault("auth_uri", "http://127.0.0.1:5000/"),
+				authPlugin:      config.GetDefault("auth_plugin", "password"),
+				projectDomainID: config.GetDefault("project_domain_id", "default"),
+				userDomainID:    config.GetDefault("user_domain_id", "default"),
+				projectName:     config.GetDefault("project_name", "service"),
+				userName:        config.GetDefault("username", "swift"),
+				password:        config.GetDefault("password", "password"),
+				userAgent:       config.GetDefault("user_agent", "hummingbird-keystone-middleware/1.0"),
+				client: &http.Client{
+					Timeout: 5 * time.Second,
+				}},
+		}
+	}, nil
+}

--- a/proxyserver/middleware/authtoken.go
+++ b/proxyserver/middleware/authtoken.go
@@ -117,7 +117,7 @@ type token struct {
 
 func (t token) Valid() bool {
 	now := time.Now().Unix()
-	return t.IssuedAt.Unix() <= now && now < t.ExpiresAt.Unix()
+	return now < t.ExpiresAt.Unix()
 }
 
 func (t token) populateReqHeader(r *http.Request, headerPrefix string) {

--- a/proxyserver/middleware/authtoken_test.go
+++ b/proxyserver/middleware/authtoken_test.go
@@ -1,0 +1,516 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/net/context"
+
+	"github.com/troubling/hummingbird/common/test"
+)
+
+func newFakeProxyContext() *ProxyContext {
+	return &ProxyContext{
+		Logger:                 zap.NewNop(),
+		ProxyContextMiddleware: &ProxyContextMiddleware{Cache: &test.FakeMemcacheRing{}},
+	}
+}
+
+func checkHeaders(t *testing.T, headers map[string]string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for key, expected := range headers {
+			if v := r.Header.Get(key); v != expected {
+				t.Errorf("Expected header %s to be %q, got %q", key, expected, v)
+			}
+		}
+		w.Write([]byte("stuff"))
+	})
+}
+
+func fakeIdentityServer(statusPost int, statusGet int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			w.WriteHeader(statusPost)
+		} else if r.Method == "GET" {
+			w.WriteHeader(statusGet)
+		}
+		io.WriteString(w, body)
+	}))
+}
+
+func TestSpoofBlock(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fakeContext := newFakeProxyContext()
+	req, err := http.NewRequest("GET", "/someurl", nil)
+	require.Nil(t, err)
+	req.Header.Add("X-Identity-Status", "Confirmed")
+	req.Header.Add("X-Project-Id", "134")
+	req.Header.Add("X-Project-Name", "value")
+	req.Header.Add("X-Domain-Id", "142")
+
+	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", fakeContext))
+
+	passthrough := checkHeaders(t, map[string]string{
+		"X-Identity-Status": "Invalid",
+		"X-Project-Name":    "",
+		"X-Project-Id":      "",
+		"X-Domain-Id":       "",
+	})
+	at := &authToken{
+		next: passthrough,
+	}
+	at.ServeHTTP(rec, req)
+	if body := rec.Body.String(); body != "stuff" {
+		t.Errorf("Wrong body, got %q want %q", body, "stuff")
+	}
+}
+
+func TestNoToken(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fakeContext := newFakeProxyContext()
+	req, err := http.NewRequest("GET", "/someurl", nil)
+	require.Nil(t, err)
+
+	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", fakeContext))
+
+	passthrough := checkHeaders(t, map[string]string{
+		"X-Identity-Status": "Invalid",
+	})
+	at := &authToken{
+		next: passthrough,
+	}
+	at.ServeHTTP(rec, req)
+	if body := rec.Body.String(); body != "stuff" {
+		t.Errorf("Wrong body, got %q want %q", body, "stuff")
+	}
+
+}
+
+type mockTokenMemacacheRing struct {
+	MockValues map[string]interface{}
+}
+
+func (mr *mockTokenMemacacheRing) Decr(key string, delta int64, timeout int) (int64, error) {
+	return int64(0), nil
+}
+
+func (mr *mockTokenMemacacheRing) Delete(key string) error {
+	return nil
+}
+
+func (mr *mockTokenMemacacheRing) Get(key string) (interface{}, error) {
+	if val, ok := mr.MockValues[key]; ok {
+		return val, nil
+	}
+	return nil, errors.New("Some error")
+}
+
+func (mr *mockTokenMemacacheRing) GetStructured(key string, val interface{}) error {
+	return nil
+}
+
+func (mr *mockTokenMemacacheRing) GetMulti(serverKey string, keys []string) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (mr *mockTokenMemacacheRing) Incr(key string, delta int64, timeout int) (int64, error) {
+	return int64(0), nil
+}
+
+func (mr *mockTokenMemacacheRing) Set(key string, value interface{}, timeout int) error {
+	mr.MockValues[key] = value
+	return nil
+}
+
+func (mr *mockTokenMemacacheRing) SetMulti(serverKey string, values map[string]interface{}, timeout int) error {
+	return nil
+}
+
+func TestExpiredToken(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fakeCache := mockTokenMemacacheRing{MockValues: make(map[string]interface{})}
+	fakeContext := &ProxyContext{
+		Logger:                 zap.NewNop(),
+		ProxyContextMiddleware: &ProxyContextMiddleware{Cache: &fakeCache},
+	}
+	obs, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(obs)
+	fakeContext.Logger = logger
+	req, err := http.NewRequest("GET", "/someurl", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Auth-Token", "abcd")
+	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", fakeContext))
+	identityServ := fakeIdentityServer(201, 200, `
+	{
+    "token": {
+        "audit_ids": [
+            "_qJlMw8hSB2mBb5pAQn38w"
+        ],
+        "expires_at": "2015-05-21T08:52:02.283669Z",
+        "issued_at": "2015-05-21T07:52:02.283716Z",
+        "methods": [
+            "password"
+        ],
+        "project": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "12f1b2e6285f4c0c8ee01f3a7d5c1bf1",
+            "name": "test"
+        },
+        "roles": [
+            {
+                "id": "c5f9f21624c444bcaed7a4713b0e3003",
+                "name": "admin"
+            }
+        ],
+        "user": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "9ca318a4fdf244e19da9d1574b452bb1",
+            "name": "tester"
+        }
+    }
+}`)
+	defer identityServ.Close()
+	passthrough := checkHeaders(t, map[string]string{
+		"X-Identity-Status": "Invalid",
+		"X-Project-Name":    "",
+		"X-Project-Id":      "",
+		"X-Domain-Id":       "",
+	})
+	at := &authToken{
+		next: passthrough,
+		identity: &identity{authURL: identityServ.URL,
+			client: &http.Client{
+				Timeout: 5 * time.Second,
+			}},
+	}
+	at.ServeHTTP(rec, req)
+	require.Equal(t, 0, len(fakeCache.MockValues))
+	require.Equal(t, 1, logs.Len())
+	want := []observer.LoggedEntry{{
+		Entry:   zapcore.Entry{Level: zap.DebugLevel, Message: "Failed to validate token"},
+		Context: []zapcore.Field{zap.Error(errors.New("Returned token is not valid"))}}}
+	require.Equal(t, want[0], logs.AllUntimed()[0])
+	if rec.Code != 200 {
+		t.Fatalf("wrong code, got %d want %d", rec.Code, 200)
+	}
+	if body := rec.Body.String(); body != "stuff" {
+		t.Errorf("Wrong body, got %q want %q", body, "stuff")
+	}
+}
+
+func TestUnscopedToken(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fakeCache := mockTokenMemacacheRing{MockValues: make(map[string]interface{})}
+	fakeContext := &ProxyContext{
+		Logger:                 zap.NewNop(),
+		ProxyContextMiddleware: &ProxyContextMiddleware{Cache: &fakeCache},
+	}
+	req, err := http.NewRequest("GET", "/someurl", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Auth-Token", "abcd")
+	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", fakeContext))
+	identityServ := fakeIdentityServer(201, 200, `
+	{
+    "token": {
+        "audit_ids": [
+            "vtno99i8R4OLTLN9vByC-g"
+        ],
+        "expires_at": "2100-05-21T10:57:25.392438Z",
+        "issued_at": "2017-05-21T09:57:25.392463Z",
+        "methods": [
+            "password"
+        ],
+        "project": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "37f58fe3bbc1407fa0b5443250ea0f9f",
+            "name": "service"
+        },
+        "roles": [
+            {
+                "id": "c5f9f21624c444bcaed7a4713b0e3003",
+                "name": "admin"
+            }
+        ],
+        "user": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "921880ba817d438c9577c1932b6a169e",
+            "name": "swift"
+        }
+    }
+}`)
+	defer identityServ.Close()
+	passthrough := checkHeaders(t, map[string]string{
+		"X-Identity-Status":  "Confirmed",
+		"X-User-Id":          "921880ba817d438c9577c1932b6a169e",
+		"X-User-Name":        "swift",
+		"X-User-Domain-Id":   "default",
+		"X-User-Domain-Name": "Default",
+		"X-Roles":            "admin",
+	})
+	at := &authToken{
+		next: passthrough,
+		identity: &identity{authURL: identityServ.URL,
+			client: &http.Client{
+				Timeout: 5 * time.Second,
+			}},
+	}
+	at.ServeHTTP(rec, req)
+	require.Equal(t, 1, len(fakeCache.MockValues))
+	if rec.Code != 200 {
+		t.Fatalf("wrong code, got %d want %d", rec.Code, 200)
+	}
+	if body := rec.Body.String(); body != "stuff" {
+		t.Errorf("Wrong body, got %q want %q", body, "stuff")
+	}
+}
+
+func TestProjectScopedToken(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fakeCache := mockTokenMemacacheRing{MockValues: make(map[string]interface{})}
+	fakeContext := &ProxyContext{
+		Logger:                 zap.NewNop(),
+		ProxyContextMiddleware: &ProxyContextMiddleware{Cache: &fakeCache},
+	}
+	req, err := http.NewRequest("GET", "/someurl", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Auth-Token", "abcd")
+	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", fakeContext))
+	identityServ := fakeIdentityServer(201, 200, `
+	{
+    "token": {
+        "audit_ids": [
+            "1JlsU26ZThSxeILfNWUZ6Q"
+        ],
+        "expires_at": "2100-05-21T11:08:19.270008Z",
+        "issued_at": "2017-05-21T10:08:19.270034Z",
+        "methods": [
+            "password"
+        ],
+        "project": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "37f58fe3bbc1407fa0b5443250ea0f9f",
+            "name": "service"
+        },
+        "roles": [
+            {
+                "id": "c5f9f21624c444bcaed7a4713b0e3003",
+                "name": "admin"
+            }
+        ],
+        "user": {
+            "domain": {
+                "id": "default",
+                "name": "Default"
+            },
+            "id": "921880ba817d438c9577c1932b6a169e",
+            "name": "swift"
+        }
+    }
+}`)
+	defer identityServ.Close()
+	passthrough := checkHeaders(t, map[string]string{
+		"X-Identity-Status":     "Confirmed",
+		"X-Domain-Id":           "",
+		"X-Domain-Name":         "",
+		"X-Project-Name":        "service",
+		"X-Project-Id":          "37f58fe3bbc1407fa0b5443250ea0f9f",
+		"X-Project-Domain-Name": "Default",
+		"X-Project-Domain-Id":   "default",
+		"X-Roles":               "admin",
+	})
+	at := &authToken{
+		next: passthrough,
+		identity: &identity{authURL: identityServ.URL,
+			client: &http.Client{
+				Timeout: 5 * time.Second,
+			}},
+	}
+	at.ServeHTTP(rec, req)
+	require.Equal(t, 1, len(fakeCache.MockValues))
+	if rec.Code != 200 {
+		t.Fatalf("wrong code, got %d want %d", rec.Code, 200)
+	}
+	if body := rec.Body.String(); body != "stuff" {
+		t.Errorf("Wrong body, got %q want %q", body, "stuff")
+	}
+}
+
+func TestDomainScopedToken(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fakeCache := mockTokenMemacacheRing{MockValues: make(map[string]interface{})}
+	fakeContext := &ProxyContext{
+		Logger:                 zap.NewNop(),
+		ProxyContextMiddleware: &ProxyContextMiddleware{Cache: &fakeCache},
+	}
+	req, err := http.NewRequest("GET", "/someurl", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Auth-Token", "abcd")
+	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", fakeContext))
+	identityServ := fakeIdentityServer(201, 200, `
+	{
+  "token": {
+    "domain": {
+      "id": "default",
+      "name": "Default"
+    },
+    "methods": ["password"],
+    "roles": [{
+      "id": "c703057be878458588961ce9a0ce686b",
+      "name": "admin"
+    }],
+    "expires_at": "2100-06-10T21:52:58.852167Z",
+    "extras": {},
+    "user": {
+      "domain": {
+        "id": "default",
+        "name": "Default"
+      },
+      "id": "3ec3164f750146be97f21559ee4d9c51",
+      "name": "admin"
+    },
+    "audit_ids": ["Xpa6Uyn-T9S6mTREudUH3w"],
+    "issued_at": "2014-06-10T20:52:58.852194Z"
+  }
+}`)
+	defer identityServ.Close()
+	passthrough := checkHeaders(t, map[string]string{
+		"X-Identity-Status": "Confirmed",
+		"X-Project-Id":      "",
+		"X-Domain-Id":       "default",
+		"X-Domain-Name":     "Default",
+		"X-Roles":           "admin",
+	})
+	at := &authToken{
+		next: passthrough,
+		identity: &identity{authURL: identityServ.URL,
+			client: &http.Client{
+				Timeout: 5 * time.Second,
+			}},
+	}
+	at.ServeHTTP(rec, req)
+	require.Equal(t, 1, len(fakeCache.MockValues))
+	if rec.Code != 200 {
+		t.Fatalf("wrong code, got %d want %d", rec.Code, 200)
+	}
+	if body := rec.Body.String(); body != "stuff" {
+		t.Errorf("Wrong body, got %q want %q", body, "stuff")
+	}
+}
+
+func TestGetCachedToken(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/someurl", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Auth-Token", "abcd")
+	val := token{ExpiresAt: time.Now().Add(5 * time.Second), IssuedAt: time.Now()}
+	fakeCache := mockTokenMemacacheRing{MockValues: map[string]interface{}{"abcd": val}}
+	fakeContext := &ProxyContext{
+		Logger:                 zap.NewNop(),
+		ProxyContextMiddleware: &ProxyContextMiddleware{Cache: &fakeCache},
+	}
+
+	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", fakeContext))
+
+	passthrough := checkHeaders(t, map[string]string{
+		"X-Identity-Status": "Confirmed",
+	})
+	at := &authToken{
+		next: passthrough,
+	}
+	at.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("wrong code, got %d want %d", rec.Code, 200)
+	}
+	if body := rec.Body.String(); body != "stuff" {
+		t.Errorf("Wrong body, got %q want %q", body, "stuff")
+	}
+}
+
+func TestWriteCachedToken(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/someurl", nil)
+	require.Nil(t, err)
+	req.Header.Set("X-Auth-Token", "abcd")
+	fakeCache := mockTokenMemacacheRing{MockValues: make(map[string]interface{})}
+	fakeContext := &ProxyContext{
+		Logger:                 zap.NewNop(),
+		ProxyContextMiddleware: &ProxyContextMiddleware{Cache: &fakeCache},
+	}
+	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", fakeContext))
+	expectedExpiry := time.Now().Add(5 * time.Second).Round(time.Second)
+	identityServ := fakeIdentityServer(201, 200, fmt.Sprintf(`
+{
+  "token": {
+    "expires_at": "%s",
+    "issued_at": "2015-10-08T15:09:11Z"
+  }
+}
+	`, expectedExpiry.Format(time.RFC3339)))
+	defer identityServ.Close()
+	passthrough := checkHeaders(t, map[string]string{
+		"X-Identity-Status": "Confirmed",
+	})
+	at := &authToken{
+		next: passthrough,
+		identity: &identity{authURL: identityServ.URL,
+			client: &http.Client{
+				Timeout: 5 * time.Second,
+			}},
+	}
+	at.ServeHTTP(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("wrong code, got %d want %d", rec.Code, 200)
+	}
+	var tok token
+	var tokint interface{}
+	var ok bool
+	if tokint, ok = fakeCache.MockValues["abcd"]; !ok {
+		t.Fatal("token was not cached")
+	}
+	if tok, ok = tokint.(token); !ok {
+		t.Fatal("token corrupt")
+	}
+	if !tok.ExpiresAt.Equal(expectedExpiry) {
+		t.Fatalf("cached element has incorrect value. expected %q, got %q", expectedExpiry, tok.ExpiresAt)
+	}
+
+}

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -174,6 +174,7 @@ func (ctx *ProxyContext) Subrequest(writer http.ResponseWriter, req *http.Reques
 		ProxyContextMiddleware: ctx.ProxyContextMiddleware,
 		Authorize:              authorize,
 		AuthorizeOverride:      authorizeOverride,
+		RemoteUser:             ctx.RemoteUser,
 		Logger:                 ctx.Logger.With(zap.String("src", source)),
 		C:                      ctx.C,
 		TxId:                   ctx.TxId,
@@ -261,8 +262,8 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 	newWriter := srv.NewCustomWriter(writer, func(w http.ResponseWriter, status int) int {
 		// strip out any bad headers before calling real WriteHeader
 		for k := range w.Header() {
-			if k == "X-Account-Sysmeta-Project-Domain-ID" {
-				w.Header().Set("X-Account-Project-Domain-ID", w.Header().Get(k))
+			if k == "X-Account-Sysmeta-Project-Domain-Id" {
+				w.Header().Set("X-Account-Project-Domain-Id", w.Header().Get(k))
 			}
 			for _, ex := range excludeHeaders {
 				if strings.HasPrefix(k, ex) {

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -163,11 +163,17 @@ func (ctx *ProxyContext) InvalidateAccountInfo(account string) {
 	ctx.Cache.Delete(key)
 }
 
-func (ctx *ProxyContext) Subrequest(writer http.ResponseWriter, req *http.Request, source string) {
+func (ctx *ProxyContext) Subrequest(writer http.ResponseWriter, req *http.Request, source string, skipAuth bool) {
+	authorize := ctx.Authorize
+	authorizeOverride := ctx.AuthorizeOverride
+	if skipAuth {
+		authorize = nil
+		authorizeOverride = true
+	}
 	newctx := &ProxyContext{
 		ProxyContextMiddleware: ctx.ProxyContextMiddleware,
-		Authorize:              ctx.Authorize,
-		AuthorizeOverride:      ctx.AuthorizeOverride,
+		Authorize:              authorize,
+		AuthorizeOverride:      authorizeOverride,
 		Logger:                 ctx.Logger.With(zap.String("src", source)),
 		C:                      ctx.C,
 		TxId:                   ctx.TxId,

--- a/proxyserver/middleware/copy.go
+++ b/proxyserver/middleware/copy.go
@@ -147,9 +147,7 @@ func (c *copyMiddleware) getSourceObject(object string, request *http.Request) (
 	done := make(chan bool)
 	writer := NewPipeResponseWriter(pipeWriter, done, ctx.Logger)
 	go func() {
-		ctx.Authorize = nil
-		ctx.AuthorizeOverride = true
-		ctx.Subrequest(writer, subRequest, "copy")
+		ctx.Subrequest(writer, subRequest, "copy", true)
 		writer.Close()
 	}()
 	<-done

--- a/proxyserver/middleware/copy.go
+++ b/proxyserver/middleware/copy.go
@@ -147,6 +147,8 @@ func (c *copyMiddleware) getSourceObject(object string, request *http.Request) (
 	done := make(chan bool)
 	writer := NewPipeResponseWriter(pipeWriter, done, ctx.Logger)
 	go func() {
+		ctx.Authorize = nil
+		ctx.AuthorizeOverride = true
 		ctx.Subrequest(writer, subRequest, "copy")
 		writer.Close()
 	}()

--- a/proxyserver/middleware/copy.go
+++ b/proxyserver/middleware/copy.go
@@ -131,7 +131,7 @@ func NewPipeResponseWriter(writer *io.PipeWriter, done chan bool, logger srv.Low
 	}
 }
 
-func (c *copyMiddleware) getSourceObject(object string, request *http.Request) (io.ReadCloser, http.Header, int) {
+func (c *copyMiddleware) getSourceObject(object string, request *http.Request, postAsCopy bool) (io.ReadCloser, http.Header, int) {
 	ctx := GetProxyContext(request)
 	subRequest, err := http.NewRequest("GET", object, nil)
 	if err != nil {
@@ -147,7 +147,11 @@ func (c *copyMiddleware) getSourceObject(object string, request *http.Request) (
 	done := make(chan bool)
 	writer := NewPipeResponseWriter(pipeWriter, done, ctx.Logger)
 	go func() {
-		ctx.Subrequest(writer, subRequest, "copy", true)
+		if c.postAsCopy && postAsCopy {
+			ctx.Subrequest(writer, subRequest, "copy", true)
+		} else {
+			ctx.Subrequest(writer, subRequest, "copy", false)
+		}
 		writer.Close()
 	}()
 	<-done
@@ -274,7 +278,7 @@ func (c *copyMiddleware) handlePut(writer *CopyWriter, request *http.Request) {
 		writer.Logger.Info(fmt.Sprintf("Copying object from %s to %s", srcPath, request.URL.Path))
 	}
 
-	srcBody, srcHeader, srcStatus := c.getSourceObject(common.Urlencode(srcPath), request)
+	srcBody, srcHeader, srcStatus := c.getSourceObject(common.Urlencode(srcPath), request, writer.postAsCopy)
 	if srcBody != nil {
 		defer srcBody.Close()
 	}

--- a/proxyserver/middleware/copy_test.go
+++ b/proxyserver/middleware/copy_test.go
@@ -40,7 +40,7 @@ func TestGetSourceObject(t *testing.T) {
 		next: passthrough,
 	}
 
-	body, header, code := c.getSourceObject("/ver/a/c/o", dummy)
+	body, header, code := c.getSourceObject("/ver/a/c/o", dummy, false)
 	require.Equal(t, 200, code)
 	buf := make([]byte, 1024)
 	num, err := body.Read(buf)

--- a/proxyserver/middleware/formpost.go
+++ b/proxyserver/middleware/formpost.go
@@ -238,7 +238,7 @@ func formpost(next http.Handler) http.Handler {
 				} else {
 					newreq.Header.Set("Content-Type", "application/octet-stream")
 				}
-				ctx.Subrequest(neww, newreq, "formpost")
+				ctx.Subrequest(neww, newreq, "formpost", false)
 				if flr.overRead() {
 					formpostRespond(writer, 400, "max_file_size exceeded", attrs["redirect"])
 					return

--- a/proxyserver/middleware/formpost.go
+++ b/proxyserver/middleware/formpost.go
@@ -208,6 +208,7 @@ func formpost(next http.Handler) http.Handler {
 						formpostRespond(writer, 400, "invalid request", attrs["redirect"])
 						return
 					default:
+						ctx.AuthorizeOverride = true
 						ctx.Authorize = formpostAuthorizer(scope, account, container)
 						validated = true
 					}

--- a/proxyserver/middleware/keystoneauth.go
+++ b/proxyserver/middleware/keystoneauth.go
@@ -1,0 +1,326 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
+	"go.uber.org/zap"
+)
+
+type keystoneAuth struct {
+	resellerPrefixes  []string
+	accountRules      map[string]map[string][]string
+	resellerAdminRole string
+	next              http.Handler
+}
+
+func (ka *keystoneAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	identityMap := extractIdentity(r)
+	defer ka.next.ServeHTTP(w, r)
+	ctx := GetProxyContext(r)
+	if ctx.AuthorizeOverride {
+		ctx.Logger.Debug("Authorizing from an overriding middleware")
+		return
+	}
+	if len(identityMap) == 0 {
+		if ctx.Authorize == nil {
+			ctx.Authorize = ka.authorizeAnonymous
+		}
+	} else {
+		if ctx.Authorize == nil {
+			ctx.RemoteUser = identityMap["tenantName"]
+			ctx.Authorize = ka.authorize
+		}
+		userRoles := common.SliceFromCSV(identityMap["roles"])
+		for _, r := range userRoles {
+			if ka.resellerAdminRole == strings.ToLower(r) {
+				ctx.ResellerRequest = true
+				break
+			}
+		}
+	}
+}
+
+func (ka *keystoneAuth) accountMatchesTenant(account string, tenantID string) bool {
+	for _, prefix := range ka.resellerPrefixes {
+		if fmt.Sprintf("%s%s", prefix, tenantID) == account {
+			return true
+		}
+	}
+	return false
+}
+
+func (ka *keystoneAuth) getProjectDomainID(r *http.Request, account string) string {
+	ctx := GetProxyContext(r)
+	return ctx.GetAccountInfo(account).SysMetadata["Project-Domain-ID"]
+}
+
+func (ka *keystoneAuth) setProjectDomainID(r *http.Request, pathParts map[string]string, identityMap map[string]string) {
+	for k := range r.Header {
+		if k == "X-Account-Sysmeta-Project-Domain-ID" {
+			return
+		}
+	}
+	if pathParts["object"] != "" || (pathParts["container"] != "" && r.Method != "PUT") ||
+		common.StringInSlice(r.Method, []string{"PUT", "POST"}) {
+		return
+	}
+	tenantID := identityMap["tenantID"]
+	sysmetaID := ka.getProjectDomainID(r, pathParts["account"])
+	reqID, newID := "", ""
+	if ka.accountMatchesTenant(pathParts["account"], tenantID) {
+		reqID = identityMap["projectDomainID"]
+		newID = reqID
+	}
+	if sysmetaID == "" && reqID == "default" {
+		newID = reqID
+	}
+	if newID != "" {
+		r.Header.Set("X-Account-Sysmeta-Project-Domain-ID", newID)
+	}
+}
+
+func (ka *keystoneAuth) isNameAllowedinACL(r *http.Request, account string, identityMap map[string]string) bool {
+	userDomainID := identityMap["userDomainID"]
+	if userDomainID != "" && userDomainID != "default" {
+		return false
+	}
+	projectDomainID := identityMap["projectDomainID"]
+	if projectDomainID != "" && projectDomainID != "default" {
+		return false
+	}
+	tenantID := identityMap["tenantID"]
+	allow := false
+	if ka.accountMatchesTenant(account, tenantID) {
+		allow = true
+	} else if ka.getProjectDomainID(r, account) == "default" {
+		allow = true
+	}
+	return allow
+}
+
+func (ka *keystoneAuth) authorizeCrossTenant(userID string, userName string,
+	tenantID string, tenantName string, roles []string, allowNames bool) string {
+	tenantMatch := []string{tenantID, "*"}
+	userMatch := []string{userID, "*"}
+	if allowNames {
+		tenantMatch = append(tenantMatch, tenantName)
+		userMatch = append(userMatch, userName)
+	}
+	for _, tenant := range tenantMatch {
+		for _, user := range userMatch {
+			s := fmt.Sprintf("%s:%s", tenant, user)
+			if common.StringInSlice(s, roles) {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func (ka *keystoneAuth) authorize(r *http.Request) bool {
+	identityMap := extractIdentity(r)
+	ctx := GetProxyContext(r)
+
+	tenantID := identityMap["tenantID"]
+	tenantName := identityMap["tenantName"]
+	userID := identityMap["userID"]
+	userName := identityMap["userName"]
+
+	referrers, roles := ParseACL(ctx.ACL)
+
+	// allow OPTIONS requests to proceed as normal
+	if r.Method == "OPTIONS" {
+		return true
+	}
+	pathParts, err := common.ParseProxyPath(r.URL.Path)
+	if err != nil {
+		ctx.Logger.Error("Unable to parse URL", zap.Error(err))
+		return false
+	}
+
+	ka.setProjectDomainID(r, pathParts, identityMap)
+	userRoles := []string{}
+	for _, userRole := range common.SliceFromCSV(identityMap["roles"]) {
+		userRoles = append(userRoles, strings.ToLower(userRole))
+	}
+	if common.StringInSlice(ka.resellerAdminRole, userRoles) {
+		ctx.Logger.Debug("User has reseller admin authorization", zap.String("userid", tenantID))
+		return true
+	}
+
+	if pathParts["container"] == "" && pathParts["object"] == "" &&
+		r.Method == "DELETE" {
+		ctx.Logger.Debug("User is not allowed to delete its own account",
+			zap.String("tenantName", tenantName),
+			zap.String("userName", userName))
+		return false
+	}
+	matchedACL := ""
+	if len(roles) > 0 {
+		allowNames := ka.isNameAllowedinACL(r, pathParts["account"], identityMap)
+		matchedACL = ka.authorizeCrossTenant(userID, userName, tenantID, tenantName, roles, allowNames)
+	}
+	if matchedACL != "" {
+		ctx.Logger.Debug("user allowed in ACL authorizing", zap.String("user", matchedACL))
+		return true
+	}
+
+	isAuthorized, authErr := ka.authorizeUnconfirmedIdentity(r, pathParts["object"], referrers, roles)
+
+	if isAuthorized {
+		return true
+	}
+
+	if !ka.accountMatchesTenant(pathParts["account"], tenantID) {
+		return false
+	}
+	accountPrefix, _ := ka.getAccountPrefix(pathParts["account"])
+	operatorRoles := ka.accountRules[accountPrefix]["operator_roles"]
+	haveOperatorRole := false
+	for _, or := range operatorRoles {
+		if common.StringInSlice(or, userRoles) {
+			haveOperatorRole = true
+			break
+		}
+	}
+	serviceRoles := ka.accountRules[accountPrefix]["service_roles"]
+	haveServiceRole := false
+	for _, or := range serviceRoles {
+		if common.StringInSlice(or, userRoles) {
+			haveServiceRole = true
+			break
+		}
+	}
+	allowed := false
+	if haveOperatorRole && (len(serviceRoles) > 0 && haveServiceRole) {
+		allowed = true
+	} else if haveOperatorRole && !haveServiceRole {
+		allowed = true
+	}
+	if allowed {
+		return true
+	}
+	if !isAuthorized && authErr == nil {
+		return false
+	}
+
+	for _, role := range roles {
+		if common.StringInSlice(role, userRoles) {
+			return true
+		}
+
+	}
+	return false
+}
+
+func (ka *keystoneAuth) getAccountPrefix(account string) (string, bool) {
+	// Empty prefix matches everything, so try to match others first
+	for _, prefix := range ka.resellerPrefixes {
+		if prefix != "" && strings.HasPrefix(account, prefix) {
+			return prefix, true
+		}
+	}
+	for _, prefix := range ka.resellerPrefixes {
+		if prefix == "" {
+			return "", true
+		}
+	}
+	return "", false
+}
+
+func (ka *keystoneAuth) authorizeAnonymous(r *http.Request) bool {
+	ctx := GetProxyContext(r)
+	pathParts, err := common.ParseProxyPath(r.URL.Path)
+	if err != nil {
+		ctx.Logger.Error("Unable to parse URL", zap.Error(err))
+		return false
+	}
+	// allow OPTIONS requests to proceed as normal
+	if r.Method == "OPTIONS" {
+		return true
+	}
+	isAuthorized := false
+	if pathParts["account"] != "" {
+		if prefix, ok := ka.getAccountPrefix(pathParts["account"]); ok {
+			if common.StringInSlice(prefix, ka.resellerPrefixes) {
+				isAuthorized = true
+			}
+		}
+	}
+	if !isAuthorized {
+		return false
+	}
+
+	referrers, roles := ParseACL(ctx.ACL)
+	isAuthorized, _ = ka.authorizeUnconfirmedIdentity(r, pathParts["object"], referrers, roles)
+
+	if !isAuthorized {
+		return false
+	}
+	return true
+}
+
+func (ka *keystoneAuth) authorizeUnconfirmedIdentity(r *http.Request, obj string, referrers []string, roles []string) (bool, error) {
+	if ReferrerAllowed(r.Referer(), referrers) {
+		if obj != "" || common.StringInSlice(".rlistings", roles) {
+			return true, nil
+		}
+		return false, nil
+	}
+	return false, errors.New("unable to confirm identity")
+}
+
+func extractIdentity(r *http.Request) map[string]string {
+	identity := make(map[string]string)
+	if r.Header.Get("X-Identity-Status") != "Confirmed" ||
+		!common.StringInSlice(r.Header.Get("X-Service-Identity-Status"), []string{"Confirmed", ""}) {
+		return identity
+	}
+
+	identity["userID"] = r.Header.Get("X-User-Id")
+	identity["userName"] = r.Header.Get("X-User-Name")
+	identity["tenantID"] = r.Header.Get("X-Project-Id")
+	identity["tenantName"] = r.Header.Get("X-Project-Name")
+	identity["roles"] = r.Header.Get("X-Roles")
+	identity["serviceRoles"] = r.Header.Get("X-Service-Roles")
+	identity["userDomainID"] = r.Header.Get("X-User-Domain-Id")
+	identity["userDomainName"] = r.Header.Get("X-User-Domain-Name")
+	identity["projectDomainID"] = r.Header.Get("X-Project-Domain-Id")
+	identity["projectDomainName"] = r.Header.Get("X-Project-Domain-Name")
+
+	return identity
+}
+
+func NewKeystoneAuth(config conf.Section) (func(http.Handler) http.Handler, error) {
+	defaultRules := map[string][]string{"operator_roles": {"admin", "swiftoperator"},
+		"service_roles": {}}
+	resellerPrefixes, accountRules := conf.ReadResellerOptions(config, defaultRules)
+	return func(next http.Handler) http.Handler {
+		return &keystoneAuth{
+			next:              next,
+			resellerPrefixes:  resellerPrefixes,
+			accountRules:      accountRules,
+			resellerAdminRole: strings.ToLower(config.GetDefault("reseller_admin_role", "ResellerAdmin")),
+		}
+	}, nil
+}

--- a/proxyserver/middleware/largeobject.go
+++ b/proxyserver/middleware/largeobject.go
@@ -230,7 +230,7 @@ func (xlo *xloMiddleware) feedOutSegments(sw *segWriter, request *http.Request, 
 			newReq.Header.Set("Range", rangeHeader)
 			sw := &segWriter{ResponseWriter: sw.ResponseWriter,
 				Status: 500, allowWrite: true, throwAwayHeader: true} // TODO i think i can reuse this
-			ctx.Subrequest(sw, newReq, "slo")
+			ctx.Subrequest(sw, newReq, "slo", false)
 			if sw.Status/100 != 2 {
 				ctx.Logger.Debug(fmt.Sprintf("segment not found: %s", newPath),
 					zap.String("Segment404", "404"))
@@ -261,7 +261,7 @@ func (xlo *xloMiddleware) buildSloManifest(sw *segWriter, request *http.Request,
 	}
 
 	swRefetch := &segWriter{ResponseWriter: sw.ResponseWriter, Status: 500}
-	ctx.Subrequest(swRefetch, newReq, "slo")
+	ctx.Subrequest(swRefetch, newReq, "slo", false)
 	if swRefetch.manifestBytes != nil {
 		manifestBytes = swRefetch.manifestBytes.Bytes()
 	}
@@ -278,7 +278,7 @@ func (xlo *xloMiddleware) buildDloManifest(sw *segWriter, request *http.Request,
 		return manifest, err
 	}
 	swRefetch := &segWriter{ResponseWriter: sw.ResponseWriter, Status: 500, cacheBytes: true}
-	ctx.Subrequest(swRefetch, newReq, "slo")
+	ctx.Subrequest(swRefetch, newReq, "slo", false)
 	if swRefetch.manifestBytes != nil {
 		manifestBytes = swRefetch.manifestBytes.Bytes()
 	}
@@ -522,7 +522,7 @@ func (xlo *xloMiddleware) handleSloPut(writer http.ResponseWriter, request *http
 			return
 		}
 		pw := &segWriter{ResponseWriter: writer, Status: 500}
-		ctx.Subrequest(pw, newReq, "slo")
+		ctx.Subrequest(pw, newReq, "slo", false)
 
 		if pw.Status != 200 {
 			errs = append(errs,
@@ -657,7 +657,7 @@ func (xlo *xloMiddleware) deleteAllSegments(sw *segWriter, request *http.Request
 		}
 		sw := &segWriter{ResponseWriter: sw.ResponseWriter,
 			Status: 500, allowWrite: true} // TODO i think i can reuse this
-		ctx.Subrequest(sw, newReq, "slo")
+		ctx.Subrequest(sw, newReq, "slo", false)
 	}
 	return nil
 }

--- a/proxyserver/middleware/tempurl.go
+++ b/proxyserver/middleware/tempurl.go
@@ -167,7 +167,7 @@ func tempurl(next http.Handler) http.Handler {
 			srv.StandardResponse(writer, 401)
 			return
 		}
-
+		ctx.AuthorizeOverride = true
 		ctx.Authorize = func(r *http.Request) bool {
 			ar, a, c, _ := getPathParts(r)
 			return ar && ((scope == SCOPE_ACCOUNT && a == account) || (scope == SCOPE_CONTAINER && c == container))

--- a/proxyserver/objhandlers.go
+++ b/proxyserver/objhandlers.go
@@ -33,11 +33,16 @@ func (server *ProxyServer) ObjectGetHandler(writer http.ResponseWriter, request 
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if ctx.C.GetContainerInfo(vars["account"], vars["container"]) == nil {
+	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if containerInfo == nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
+	ctx.ACL = containerInfo.ReadACL
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}
@@ -59,11 +64,16 @@ func (server *ProxyServer) ObjectHeadHandler(writer http.ResponseWriter, request
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if ctx.C.GetContainerInfo(vars["account"], vars["container"]) == nil {
+	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if containerInfo == nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
+	ctx.ACL = containerInfo.ReadACL
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}
@@ -81,11 +91,16 @@ func (server *ProxyServer) ObjectDeleteHandler(writer http.ResponseWriter, reque
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if ctx.C.GetContainerInfo(vars["account"], vars["container"]) == nil {
+	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if containerInfo == nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
+	ctx.ACL = containerInfo.WriteACL
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}
@@ -104,11 +119,16 @@ func (server *ProxyServer) ObjectPutHandler(writer http.ResponseWriter, request 
 		srv.SimpleErrorResponse(writer, 400, "If-None-Match only supports *")
 		return
 	}
-	if ctx.C.GetContainerInfo(vars["account"], vars["container"]) == nil {
+	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if containerInfo == nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
+	ctx.ACL = containerInfo.WriteACL
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
+		if ctx.RemoteUser != "" {
+			srv.StandardResponse(writer, 403)
+		}
 		srv.StandardResponse(writer, 401)
 		return
 	}

--- a/proxyserver/objhandlers.go
+++ b/proxyserver/objhandlers.go
@@ -42,6 +42,7 @@ func (server *ProxyServer) ObjectGetHandler(writer http.ResponseWriter, request 
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -73,6 +74,7 @@ func (server *ProxyServer) ObjectHeadHandler(writer http.ResponseWriter, request
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -100,6 +102,7 @@ func (server *ProxyServer) ObjectDeleteHandler(writer http.ResponseWriter, reque
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return
@@ -128,6 +131,7 @@ func (server *ProxyServer) ObjectPutHandler(writer http.ResponseWriter, request 
 	if ctx.Authorize != nil && !ctx.Authorize(request) {
 		if ctx.RemoteUser != "" {
 			srv.StandardResponse(writer, 403)
+			return
 		}
 		srv.StandardResponse(writer, 401)
 		return


### PR DESCRIPTION
In order to test this, I have created a dockerized keystone
https://github.com/nadeemsyed/dockerized-keystone

In order to enable keystoneauth middleware, you would need to add following entry in proxy.conf
tempauth_enabled = false

Some tests are still failing due missing OPTIONS call support in proxy and some issues with other middleware. Also no support for Account ACLs till now.
Hopefully we will fix them one by one.
If we want, may be we can update travis to use keystone for its tests.