### PR TITLE
pass empty path param on container GET

### DIFF
--- a/client/directclient.go
+++ b/client/directclient.go
@@ -22,9 +22,7 @@ const PostQuorumTimeoutMs = 50
 func mkquery(options map[string]string) string {
 	query := ""
 	for k, v := range options {
-		if v != "" {
-			query += url.QueryEscape(k) + "=" + url.QueryEscape(v) + "&"
-		}
+		query += url.QueryEscape(k) + "=" + url.QueryEscape(v) + "&"
 	}
 	if query != "" {
 		return "?" + strings.TrimRight(query, "&")

--- a/proxyserver/accounthandlers.go
+++ b/proxyserver/accounthandlers.go
@@ -34,14 +34,13 @@ func (server *ProxyServer) AccountGetHandler(writer http.ResponseWriter, request
 		srv.StandardResponse(writer, 401)
 		return
 	}
-	options := map[string]string{
-		"format":     request.FormValue("format"),
-		"limit":      request.FormValue("limit"),
-		"marker":     request.FormValue("marker"),
-		"end_marker": request.FormValue("end_marker"),
-		"prefix":     request.FormValue("prefix"),
-		"delimiter":  request.FormValue("delimiter"),
-		"reverse":    request.FormValue("reverse"),
+	options := make(map[string]string)
+	if request.ParseForm() == nil {
+		for k, v := range request.Form {
+			if listingQueryParms[k] && len(v) > 0 {
+				options[k] = v[0]
+			}
+		}
 	}
 	r, headers, code := ctx.C.GetAccount(vars["account"], options, request.Header)
 	for k := range headers {


### PR DESCRIPTION
Container GETs treat an empty path query param differently than path
not being there.  Ignoring the wisdom of this for the moment, make it
work.