### PR TITLE
some logging/cmd stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install:
   - sudo mkfs.xfs /tmp/hb-disk
   - sudo mkdir -p /srv
   - sudo mount -o loop /tmp/hb-disk /srv
-  - sudo mkdir -p /var/cache/swift /var/cache/swift2 /var/cache/swift3 /var/cache/swift4 /var/run/swift /srv/1/node/sdb1 /srv/2/node/sdb2 /srv/3/node/sdb3 /srv/4/node/sdb4 /var/run/hummingbird /etc/hummingbird /etc/swift /var/log/swift
-  - sudo chown -R "${USER}" /etc/swift /etc/hummingbird /srv/* /var/cache/swift* /var/run/swift /var/run/hummingbird /var/log/swift
+  - sudo mkdir -p /var/cache/swift /var/cache/swift2 /var/cache/swift3 /var/cache/swift4 /var/run/swift /srv/1/node/sdb1 /srv/2/node/sdb2 /srv/3/node/sdb3 /srv/4/node/sdb4 /var/run/hummingbird /etc/hummingbird /etc/swift /var/log/hummingbird
+  - sudo chown -R "${USER}" /etc/swift /etc/hummingbird /srv/* /var/cache/swift* /var/run/swift /var/run/hummingbird /var/log/hummingbird
   - git clone --depth 1 'https://github.com/openstack/swift.git' ~/swift
   - virtualenv ~/swift-venv
   - ~/swift-venv/bin/pip install -U pip setuptools python-subunit nose-htmloutput

--- a/accountserver/replicator.go
+++ b/accountserver/replicator.go
@@ -579,10 +579,8 @@ func GetReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, srv
 	logLevel := zap.NewAtomicLevel()
 	logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
 
-	logPath := serverconf.GetDefault("account-replicator", "log_path", "/var/log/swift/accountreplicator.log")
-
 	var logger srv.LowLevelLogger
-	if logger, err = srv.SetupLogger("account-replicator", &logLevel, flags, logPath); err != nil {
+	if logger, err = srv.SetupLogger("account-replicator", &logLevel, flags); err != nil {
 		return nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	return &Replicator{

--- a/accountserver/server.go
+++ b/accountserver/server.go
@@ -526,8 +526,7 @@ func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bind
 	logLevelString := serverconf.GetDefault("app:account-server", "log_level", "INFO")
 	server.logLevel = zap.NewAtomicLevel()
 	server.logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
-	logPath := serverconf.GetDefault("app:account-server", "log_path", "/var/log/swift/account.log")
-	if server.logger, err = srv.SetupLogger("account-server", &server.logLevel, flags, logPath); err != nil {
+	if server.logger, err = srv.SetupLogger("account-server", &server.logLevel, flags); err != nil {
 		return "", 0, nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	server.accountEngine = newLRUEngine(server.driveRoot, server.hashPathPrefix, server.hashPathSuffix, 32)

--- a/common/ring/ring.go
+++ b/common/ring/ring.go
@@ -107,13 +107,7 @@ func (r *hashRing) getData() *ringData {
 }
 
 func (r *hashRing) GetNodes(partition uint64) (response []*Device) {
-	d := r.getData()
-	if partition >= uint64(len(d.replica2part2devId[0])) {
-		return nil
-	}
-	for i := 0; i < d.ReplicaCount; i++ {
-		response = append(response, &d.Devs[d.replica2part2devId[i][partition]])
-	}
+	response = r.GetNodesInOrder(partition)
 	for i := range response {
 		j := rand.Intn(i + 1)
 		response[i], response[j] = response[j], response[i]

--- a/common/ring/ring_test.go
+++ b/common/ring/ring_test.go
@@ -81,6 +81,24 @@ func TestLoadRing(t *testing.T) {
 	require.Equal(t, uint64(29), ring.getData().PartShift)
 }
 
+func TestGetNodesInOrder(t *testing.T) {
+	fp, err := ioutil.TempFile("", "")
+	require.Nil(t, err)
+	defer fp.Close()
+	defer os.RemoveAll(fp.Name())
+	require.Nil(t, writeARing(fp, 4, 2, 29))
+	r, err := LoadRing(fp.Name(), "prefix", "suffix")
+	require.Nil(t, err)
+	ring, ok := r.(*hashRing)
+	require.True(t, ok)
+	require.NotNil(t, ring)
+	nodes := ring.GetNodesInOrder(0)
+	require.Equal(t, 2, len(nodes))
+	// some of these values may not be obvious, but they shouldn't change
+	require.Equal(t, 0, nodes[0].Id)
+	require.Equal(t, 1, nodes[1].Id)
+}
+
 func TestGetNodes(t *testing.T) {
 	fp, err := ioutil.TempFile("", "")
 	require.Nil(t, err)
@@ -94,9 +112,9 @@ func TestGetNodes(t *testing.T) {
 	require.NotNil(t, ring)
 	nodes := ring.GetNodes(0)
 	require.Equal(t, 2, len(nodes))
-	// some of these values may not be obvious, but they shouldn't change
-	require.Equal(t, 0, nodes[0].Id)
-	require.Equal(t, 1, nodes[1].Id)
+	// make sure one node is 0 and one node is 1.
+	require.True(t, 0 == nodes[0].Id || 0 == nodes[1].Id)
+	require.True(t, 1 == nodes[0].Id || 1 == nodes[1].Id)
 }
 
 func TestGetJobNodes(t *testing.T) {

--- a/common/utils.go
+++ b/common/utils.go
@@ -27,7 +27,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/cactus/go-statsd-client/statsd"
@@ -205,10 +204,6 @@ func ParseRange(rangeHeader string, fileSize int64) (reqRanges []HttpRange, err 
 		return nil, errors.New("Unsatisfiable range")
 	}
 	return reqRanges, nil
-}
-
-func SetRlimits() {
-	syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Max: 65536, Cur: 65536})
 }
 
 func GetEpochFromTimestamp(timestamp string) (string, error) {

--- a/containerserver/replicator.go
+++ b/containerserver/replicator.go
@@ -582,10 +582,8 @@ func GetReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, srv
 	logLevel := zap.NewAtomicLevel()
 	logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
 
-	logPath := serverconf.GetDefault("container-replicator", "log_path", "/var/log/swift/containerreplicator.log")
-
 	var logger srv.LowLevelLogger
-	if logger, err = srv.SetupLogger("container-replicator", &logLevel, flags, logPath); err != nil {
+	if logger, err = srv.SetupLogger("container-replicator", &logLevel, flags); err != nil {
 		return nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	return &Replicator{

--- a/containerserver/server.go
+++ b/containerserver/server.go
@@ -611,8 +611,7 @@ func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bind
 	server.logLevel = zap.NewAtomicLevel()
 	server.logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
 
-	logPath := serverconf.GetDefault("app:container-server", "log_path", "/var/log/swift/container.log")
-	if server.logger, err = srv.SetupLogger("container-server", &server.logLevel, flags, logPath); err != nil {
+	if server.logger, err = srv.SetupLogger("container-server", &server.logLevel, flags); err != nil {
 		return "", 0, nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 

--- a/objectserver/auditor.go
+++ b/objectserver/auditor.go
@@ -362,8 +362,7 @@ func NewAuditor(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, srv.Lo
 	logLevelString := serverconf.GetDefault("object-auditor", "log_level", "INFO")
 	logLevel := zap.NewAtomicLevel()
 	logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
-	logPath := serverconf.GetDefault("object-auditor", "log_path", "/var/log/swift/objectauditor.log")
-	if d.logger, err = srv.SetupLogger("object-auditor", &logLevel, flags, logPath); err != nil {
+	if d.logger, err = srv.SetupLogger("object-auditor", &logLevel, flags); err != nil {
 		return nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	d.bytesPerSecond = serverconf.GetInt("object-auditor", "bytes_per_second", 10000000)

--- a/objectserver/main.go
+++ b/objectserver/main.go
@@ -581,8 +581,7 @@ func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bind
 	logLevelString := serverconf.GetDefault("app:object-server", "log_level", "INFO")
 	server.logLevel = zap.NewAtomicLevel()
 	server.logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
-	logPath := serverconf.GetDefault("app:object-server", "log_path", "/var/log/swift/storage.log")
-	if server.logger, err = srv.SetupLogger("object-server", &server.logLevel, flags, logPath); err != nil {
+	if server.logger, err = srv.SetupLogger("object-server", &server.logLevel, flags); err != nil {
 		return "", 0, nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 

--- a/objectserver/replicator.go
+++ b/objectserver/replicator.go
@@ -979,8 +979,7 @@ func NewReplicator(serverconf conf.Config, flags *flag.FlagSet) (srv.Daemon, srv
 			return nil, nil, fmt.Errorf("Unable to load ring for Policy %d.", policy.Index)
 		}
 	}
-	logPath := serverconf.GetDefault("object-replicator", "log_path", "/var/log/swift/objectreplicator.log")
-	if replicator.logger, err = srv.SetupLogger("object-replicator", &logLevel, flags, logPath); err != nil {
+	if replicator.logger, err = srv.SetupLogger("object-replicator", &logLevel, flags); err != nil {
 		return nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	devices_flag := flags.Lookup("devices")

--- a/proxyserver/main.go
+++ b/proxyserver/main.go
@@ -138,9 +138,8 @@ func GetServer(serverconf conf.Config, flags *flag.FlagSet) (string, int, srv.Se
 	logLevelString := serverconf.GetDefault("proxy-server", "log_level", "INFO")
 	server.logLevel = zap.NewAtomicLevel()
 	server.logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
-	logPath := serverconf.GetDefault("proxy-server", "log_path", "/var/log/swift/proxy.log")
 
-	if server.logger, err = srv.SetupLogger("proxy-server", &server.logLevel, flags, logPath); err != nil {
+	if server.logger, err = srv.SetupLogger("proxy-server", &server.logLevel, flags); err != nil {
 		return "", 0, nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	server.proxyDirectClient, err = client.NewProxyDirectClient(conf.LoadPolicies())


### PR DESCRIPTION
Use -l [stdout] -e [stderr] to set log destinations, get rid of -v.
Wire up "hummingbird start" to set them to /var/log/hummingbird/*.
Get rid of -d, since apparently nobody does that anymore.
Remark that "hummingbird start" shouldn't be used for production.
Various little cleanups, since I was in the neighborhood.