### PR TITLE
Refactor client code to just return *http.Responses

### DIFF
--- a/proxyserver/accounthandlers.go
+++ b/proxyserver/accounthandlers.go
@@ -46,15 +46,13 @@ func (server *ProxyServer) AccountGetHandler(writer http.ResponseWriter, request
 			}
 		}
 	}
-	r, headers, code := ctx.C.GetAccount(vars["account"], options, request.Header)
-	for k := range headers {
-		writer.Header().Set(k, headers.Get(k))
+	resp := ctx.C.GetAccount(vars["account"], options, request.Header)
+	for k := range resp.Header {
+		writer.Header().Set(k, resp.Header.Get(k))
 	}
-	writer.WriteHeader(code)
-	if r != nil {
-		defer r.Close()
-		common.Copy(r, writer)
-	}
+	writer.WriteHeader(resp.StatusCode)
+	defer resp.Body.Close()
+	common.Copy(resp.Body, writer)
 }
 
 func (server *ProxyServer) AccountHeadHandler(writer http.ResponseWriter, request *http.Request) {
@@ -72,11 +70,12 @@ func (server *ProxyServer) AccountHeadHandler(writer http.ResponseWriter, reques
 		srv.StandardResponse(writer, 401)
 		return
 	}
-	headers, code := ctx.C.HeadAccount(vars["account"], request.Header)
-	for k := range headers {
-		writer.Header().Set(k, headers.Get(k))
+	resp := ctx.C.HeadAccount(vars["account"], request.Header)
+	for k := range resp.Header {
+		writer.Header().Set(k, resp.Header.Get(k))
 	}
-	writer.WriteHeader(code)
+	resp.Body.Close()
+	writer.WriteHeader(resp.StatusCode)
 }
 
 func (server *ProxyServer) AccountPostHandler(writer http.ResponseWriter, request *http.Request) {
@@ -101,7 +100,9 @@ func (server *ProxyServer) AccountPostHandler(writer http.ResponseWriter, reques
 		return
 	}
 	defer ctx.InvalidateAccountInfo(vars["account"])
-	srv.StandardResponse(writer, ctx.C.PostAccount(vars["account"], request.Header))
+	resp := ctx.C.PostAccount(vars["account"], request.Header)
+	resp.Body.Close()
+	srv.StandardResponse(writer, resp.StatusCode)
 }
 
 func (server *ProxyServer) AccountPutHandler(writer http.ResponseWriter, request *http.Request) {
@@ -126,7 +127,9 @@ func (server *ProxyServer) AccountPutHandler(writer http.ResponseWriter, request
 		return
 	}
 	defer ctx.InvalidateAccountInfo(vars["account"])
-	srv.StandardResponse(writer, ctx.C.PutAccount(vars["account"], request.Header))
+	resp := ctx.C.PutAccount(vars["account"], request.Header)
+	resp.Body.Close()
+	srv.StandardResponse(writer, resp.StatusCode)
 }
 
 func (server *ProxyServer) AccountDeleteHandler(writer http.ResponseWriter, request *http.Request) {
@@ -145,5 +148,7 @@ func (server *ProxyServer) AccountDeleteHandler(writer http.ResponseWriter, requ
 		return
 	}
 	defer ctx.InvalidateAccountInfo(vars["account"])
-	srv.StandardResponse(writer, ctx.C.DeleteAccount(vars["account"], request.Header))
+	resp := ctx.C.DeleteAccount(vars["account"], request.Header)
+	resp.Body.Close()
+	srv.StandardResponse(writer, resp.StatusCode)
 }

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -115,7 +115,6 @@ func getPathParts(request *http.Request) (bool, string, string, string) {
 }
 
 func (ctx *ProxyContext) GetAccountInfo(account string) *AccountInfo {
-	var err error
 	key := fmt.Sprintf("account/%s", account)
 	ai := ctx.accountInfoCache[key]
 	if ai == nil {
@@ -124,32 +123,35 @@ func (ctx *ProxyContext) GetAccountInfo(account string) *AccountInfo {
 		}
 	}
 	if ai == nil {
-		headers, code := ctx.C.HeadAccount(account, nil)
-		if code == 404 && autoCreateAccounts {
+		resp := ctx.C.HeadAccount(account, nil)
+		if resp.StatusCode == http.StatusNotFound && autoCreateAccounts {
+			resp.Body.Close()
 			ctx.C.PutAccount(account, http.Header{"X-Timestamp": []string{common.GetTimestamp()}})
-			headers, code = ctx.C.HeadAccount(account, nil)
+			resp = ctx.C.HeadAccount(account, nil)
 		}
-		if code/100 != 2 {
+		resp.Body.Close()
+		if resp.StatusCode/100 != 2 {
 			return nil
 		}
 		ai = &AccountInfo{
 			Metadata:    make(map[string]string),
 			SysMetadata: make(map[string]string),
 		}
-		if ai.ContainerCount, err = strconv.ParseInt(headers.Get("X-Account-Container-Count"), 10, 64); err != nil {
+		var err error
+		if ai.ContainerCount, err = strconv.ParseInt(resp.Header.Get("X-Account-Container-Count"), 10, 64); err != nil {
 			return nil
 		}
-		if ai.ObjectCount, err = strconv.ParseInt(headers.Get("X-Account-Object-Count"), 10, 64); err != nil {
+		if ai.ObjectCount, err = strconv.ParseInt(resp.Header.Get("X-Account-Object-Count"), 10, 64); err != nil {
 			return nil
 		}
-		if ai.ObjectBytes, err = strconv.ParseInt(headers.Get("X-Account-Bytes-Used"), 10, 64); err != nil {
+		if ai.ObjectBytes, err = strconv.ParseInt(resp.Header.Get("X-Account-Bytes-Used"), 10, 64); err != nil {
 			return nil
 		}
-		for k := range headers {
+		for k := range resp.Header {
 			if strings.HasPrefix(k, "X-Account-Meta-") {
-				ai.Metadata[k[15:]] = headers.Get(k)
+				ai.Metadata[k[15:]] = resp.Header.Get(k)
 			} else if strings.HasPrefix(k, "X-Account-Sysmeta-") {
-				ai.SysMetadata[k[18:]] = headers.Get(k)
+				ai.SysMetadata[k[18:]] = resp.Header.Get(k)
 			}
 		}
 		ctx.Cache.Set(key, ai, 30)


### PR DESCRIPTION
The client code was getting a little silly with some functions returning
body, headers, and status and I needed to also return explantory error
bodies for things like "Storage Policy %q is deprecated". Anyway, after
trying different approaches at the problem, I settled on just returning
*http.Response instances. It's not that much harder to check for errors
this way, and is much easier to get at all the information you might
need.

Close #79 