### PR TITLE
make http pprof accessible in replicator

### DIFF
--- a/objectserver/repsrv.go
+++ b/objectserver/repsrv.go
@@ -313,7 +313,7 @@ func (r *Replicator) GetHandler() http.Handler {
 		router.HandlePolicy("REPLICATE", "/:device/:partition/:suffixes", policy.Index, commonHandlers.ThenFunc(r.objReplicateHandler))
 		router.HandlePolicy("REPLICATE", "/:device/:partition", policy.Index, commonHandlers.ThenFunc(r.objReplicateHandler))
 	}
-	router.Get("/debug", http.DefaultServeMux)
+	router.Get("/debug/*_", http.DefaultServeMux)
 	return router
 }
 


### PR DESCRIPTION
There wasn't a route that could be used to access it.