### PR TITLE
buildDloManifest auth fix

### DIFF
--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -166,6 +166,15 @@ func (ctx *ProxyContext) InvalidateAccountInfo(account string) {
 	ctx.Cache.Delete(key)
 }
 
+func (ctx *ProxyContext) copyAuth(dst, src *http.Request) {
+	// Simple copying of X-Auth-Token for now.
+	// Someday maybe expand it so auth middleware can append to a chain of
+	// copyAuth functions that get called by this one. Or whatever.
+	if v := src.Header.Get("X-Auth-Token"); v != "" {
+		dst.Header.Set("X-Auth-Token", v)
+	}
+}
+
 func (ctx *ProxyContext) Subrequest(writer http.ResponseWriter, req *http.Request, source string, skipAuth bool) {
 	authorize := ctx.Authorize
 	authorizeOverride := ctx.AuthorizeOverride

--- a/proxyserver/middleware/largeobject.go
+++ b/proxyserver/middleware/largeobject.go
@@ -243,9 +243,7 @@ func (xlo *xloMiddleware) buildDloManifest(sw *xloIdentifyWriter, request *http.
 	if err != nil {
 		return manifest, err
 	}
-	if v := request.Header.Get("X-Auth-Token"); v != "" {
-		newReq.Header.Set("X-Auth-Token", v)
-	}
+	ctx.copyAuth(newReq, request)
 	swRefetch := &xloCaptureWriter{header: make(http.Header)}
 	ctx.Subrequest(swRefetch, newReq, "slo", false)
 	if swRefetch.status != 200 || swRefetch.body == nil {

--- a/proxyserver/middleware/largeobject.go
+++ b/proxyserver/middleware/largeobject.go
@@ -243,6 +243,9 @@ func (xlo *xloMiddleware) buildDloManifest(sw *xloIdentifyWriter, request *http.
 	if err != nil {
 		return manifest, err
 	}
+	if v := request.Header.Get("X-Auth-Token"); v != "" {
+		newReq.Header.Set("X-Auth-Token", v)
+	}
 	swRefetch := &xloCaptureWriter{header: make(http.Header)}
 	ctx.Subrequest(swRefetch, newReq, "slo", false)
 	if swRefetch.status != 200 || swRefetch.body == nil {

--- a/proxyserver/middleware/staticweb.go
+++ b/proxyserver/middleware/staticweb.go
@@ -104,7 +104,7 @@ func (s *staticWebHandler) handleObject(writer http.ResponseWriter, request *htt
 		s.handleError(writer, request, http.StatusInternalServerError, err)
 		return
 	}
-	subreq.Header.Set("X-Auth-Token", request.Header.Get("X-Auth-Token"))
+	GetProxyContext(request).copyAuth(subreq, request)
 	subrec := httptest.NewRecorder()
 	s.ctx.Subrequest(subrec, subreq, "staticweb", false)
 	subresp := subrec.Result()
@@ -135,7 +135,7 @@ func (s *staticWebHandler) handleDirectory(writer http.ResponseWriter, request *
 				s.handleError(writer, request, http.StatusInternalServerError, err)
 				return
 			}
-			subreq.Header.Set("X-Auth-Token", request.Header.Get("X-Auth-Token"))
+			GetProxyContext(request).copyAuth(subreq, request)
 			subrec := httptest.NewRecorder()
 			s.ctx.Subrequest(subrec, subreq, "staticweb", false)
 			subresp := subrec.Result()
@@ -156,7 +156,7 @@ func (s *staticWebHandler) handleDirectory(writer http.ResponseWriter, request *
 				s.handleError(writer, request, http.StatusInternalServerError, err)
 				return
 			}
-			subreq.Header.Set("X-Auth-Token", request.Header.Get("X-Auth-Token"))
+			GetProxyContext(request).copyAuth(subreq, request)
 			subrec := httptest.NewRecorder()
 			s.ctx.Subrequest(subrec, subreq, "staticweb", false)
 			subresp := subrec.Result()
@@ -190,7 +190,7 @@ func (s *staticWebHandler) handleDirectory(writer http.ResponseWriter, request *
 			s.handleError(writer, request, http.StatusInternalServerError, err)
 			return
 		}
-		subreq.Header.Set("X-Auth-Token", request.Header.Get("X-Auth-Token"))
+		GetProxyContext(request).copyAuth(subreq, request)
 		subrec := httptest.NewRecorder()
 		s.ctx.Subrequest(subrec, subreq, "staticweb", false)
 		subresp := subrec.Result()
@@ -247,7 +247,7 @@ func (s *staticWebHandler) handleDirectory(writer http.ResponseWriter, request *
 		s.handleError(writer, request, http.StatusInternalServerError, err)
 		return
 	}
-	subreq.Header.Set("X-Auth-Token", request.Header.Get("X-Auth-Token"))
+	GetProxyContext(request).copyAuth(subreq, request)
 	subrec := httptest.NewRecorder()
 	s.ctx.Subrequest(subrec, subreq, "staticweb", false)
 	subresp := subrec.Result()
@@ -376,7 +376,7 @@ func (s *staticWebHandler) handleError(writer http.ResponseWriter, request *http
 		srv.StandardResponse(writer, status)
 		return
 	}
-	subreq.Header.Set("X-Auth-Token", request.Header.Get("X-Auth-Token"))
+	GetProxyContext(request).copyAuth(subreq, request)
 	subrec := httptest.NewRecorder()
 	s.ctx.Subrequest(subrec, subreq, "staticweb", false)
 	subresp := subrec.Result()


### PR DESCRIPTION
This gets another couple of functional tests to pass.

I also added ctx.copyAuth so that we aren't copying X-Auth-Token everywhere and it's more flexible "for the future".