### PR TITLE
Refactor Subrequest

### DIFF
--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -77,19 +77,18 @@ type ProxyContextMiddleware struct {
 
 type ProxyContext struct {
 	*ProxyContextMiddleware
-	C                 client.ProxyClient
-	Authorize         AuthorizeFunc
-	AuthorizeOverride bool
-	RemoteUser        string
-	ResellerRequest   bool
-	ACL               string
-	Logger            srv.LowLevelLogger
-	TxId              string
-	responseSent      bool
-	status            int
-	accountInfoCache  map[string]*AccountInfo
-	depth             int
-	Source            string
+	C                client.ProxyClient
+	Authorize        AuthorizeFunc
+	RemoteUser       string
+	ResellerRequest  bool
+	ACL              string
+	Logger           srv.LowLevelLogger
+	TxId             string
+	responseSent     bool
+	status           int
+	accountInfoCache map[string]*AccountInfo
+	depth            int
+	Source           string
 }
 
 func GetProxyContext(r *http.Request) *ProxyContext {
@@ -183,6 +182,8 @@ func (ctx *ProxyContext) newSubrequest(method, urlStr string, body io.Reader, re
 	}
 	subctx := &ProxyContext{
 		ProxyContextMiddleware: ctx.ProxyContextMiddleware,
+		Authorize:              ctx.Authorize,
+		RemoteUser:             ctx.RemoteUser,
 		Logger:                 ctx.Logger.With(zap.String("src", source)),
 		C:                      ctx.C,
 		TxId:                   ctx.TxId,

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -166,15 +166,6 @@ func (ctx *ProxyContext) InvalidateAccountInfo(account string) {
 	ctx.Cache.Delete(key)
 }
 
-func (ctx *ProxyContext) copyAuth(dst, src *http.Request) {
-	// Simple copying of X-Auth-Token for now.
-	// Someday maybe expand it so auth middleware can append to a chain of
-	// copyAuth functions that get called by this one. Or whatever.
-	if v := src.Header.Get("X-Auth-Token"); v != "" {
-		dst.Header.Set("X-Auth-Token", v)
-	}
-}
-
 func (ctx *ProxyContext) newSubrequest(method, urlStr string, body io.Reader, req *http.Request, source string) (*http.Request, error) {
 	subreq, err := http.NewRequest(method, urlStr, body)
 	if err != nil {
@@ -194,7 +185,6 @@ func (ctx *ProxyContext) newSubrequest(method, urlStr string, body io.Reader, re
 		Source:                 source,
 	}
 	subreq = subreq.WithContext(context.WithValue(req.Context(), "proxycontext", subctx))
-	ctx.copyAuth(subreq, req)
 	subreq.Header.Set("X-Trans-Id", subctx.TxId)
 	subreq.Header.Set("X-Timestamp", common.GetTimestamp())
 	return subreq, nil

--- a/proxyserver/middleware/copy.go
+++ b/proxyserver/middleware/copy.go
@@ -132,7 +132,7 @@ func NewPipeResponseWriter(writer *io.PipeWriter, done chan bool, logger srv.Low
 
 func (c *copyMiddleware) getSourceObject(object string, request *http.Request, post bool) (io.ReadCloser, http.Header, int) {
 	ctx := GetProxyContext(request)
-	subRequest, err := http.NewRequest("GET", object, nil)
+	subRequest, err := ctx.newSubrequest("GET", object, nil, request, "copy")
 	if err != nil {
 		ctx.Logger.Error("getSourceObject GET error", zap.Error(err))
 		return nil, nil, 400
@@ -144,15 +144,18 @@ func (c *copyMiddleware) getSourceObject(object string, request *http.Request, p
 	// FIXME. Are we going to do X-Newest?
 	subRequest.Header.Set("X-Newest", "true")
 	subRequest.Header.Del("X-Backend-Storage-Policy-Index")
+	if post {
+		// POST doesn't need to auth the internal GET; if they issued a POST
+		// and it was authorized and we happen to need to do a GET+PUT for our
+		// own reasons, that's fine.
+		GetProxyContext(subRequest).Authorize = func(r *http.Request) bool { return true }
+	}
 
 	pipeReader, pipeWriter := io.Pipe()
 	done := make(chan bool)
 	writer := NewPipeResponseWriter(pipeWriter, done, ctx.Logger)
 	go func() {
-		// POST doesn't need to auth the internal GET; if they issued a POST
-		// and it was authorized and we happen to need to do a GET+PUT for our
-		// own reasons, that's fine.
-		ctx.Subrequest(writer, subRequest, "copy", !post)
+		ctx.serveHTTPSubrequest(writer, subRequest)
 		writer.Close()
 	}()
 	<-done
@@ -225,6 +228,8 @@ func copyItemsWithPrefix(dest, src http.Header, prefix string) {
 	}
 }
 
+// TODO: This seems like it might copy headers it shouldn't.
+// Also, shouldn't it be called copyHeaders instead?
 func copyItems(dest, src http.Header) {
 	for k, v := range src {
 		dest.Del(k)

--- a/proxyserver/middleware/formpost.go
+++ b/proxyserver/middleware/formpost.go
@@ -209,7 +209,6 @@ func formpost(next http.Handler) http.Handler {
 						return
 					default:
 						ctx.RemoteUser = ".formpost"
-						ctx.AuthorizeOverride = true
 						ctx.Authorize = formpostAuthorizer(scope, account, container)
 						validated = true
 					}

--- a/proxyserver/middleware/formpost.go
+++ b/proxyserver/middleware/formpost.go
@@ -228,7 +228,7 @@ func formpost(next http.Handler) http.Handler {
 				path += fn
 				neww := httptest.NewRecorder()
 				flr := &fpLimitReader{Reader: p, l: maxFileSize}
-				newreq, err := http.NewRequest("PUT", path, flr)
+				newreq, err := ctx.newSubrequest("PUT", path, flr, request, "formpost")
 				if err != nil {
 					formpostRespond(writer, 500, "internal server error", attrs["redirect"])
 					return
@@ -240,7 +240,7 @@ func formpost(next http.Handler) http.Handler {
 				} else {
 					newreq.Header.Set("Content-Type", "application/octet-stream")
 				}
-				ctx.Subrequest(neww, newreq, "formpost", false)
+				ctx.serveHTTPSubrequest(neww, newreq)
 				if flr.overRead() {
 					formpostRespond(writer, 400, "max_file_size exceeded", attrs["redirect"])
 					return

--- a/proxyserver/middleware/multirange.go
+++ b/proxyserver/middleware/multirange.go
@@ -64,7 +64,7 @@ func multirange(next http.Handler) http.Handler {
 		var contentType string
 		var mw *common.MultiWriter
 
-		subreq, err := http.NewRequest("GET", request.URL.Path, nil)
+		subreq, err := ctx.newSubrequest("GET", request.URL.Path, nil, request, "multirange")
 		if err != nil {
 			srv.StandardResponse(writer, 500)
 			return
@@ -113,12 +113,12 @@ func multirange(next http.Handler) http.Handler {
 			}
 			return status
 		})
-		if ctx.Subrequest(subw, subreq, "multirange", false); uw.err != nil {
+		if ctx.serveHTTPSubrequest(subw, subreq); uw.err != nil {
 			return
 		}
 
 		for _, rng := range ranges[1:] {
-			if subreq, err = http.NewRequest("GET", request.URL.Path, nil); err != nil {
+			if subreq, err = ctx.newSubrequest("GET", request.URL.Path, nil, request, "multirange"); err != nil {
 				srv.StandardResponse(writer, 500)
 				return
 			}
@@ -138,7 +138,7 @@ func multirange(next http.Handler) http.Handler {
 				}
 				return status
 			})
-			if ctx.Subrequest(subw, subreq, "multirange", false); uw.err != nil {
+			if ctx.serveHTTPSubrequest(subw, subreq); uw.err != nil {
 				return
 			}
 		}

--- a/proxyserver/middleware/tempurl.go
+++ b/proxyserver/middleware/tempurl.go
@@ -168,7 +168,6 @@ func tempurl(next http.Handler) http.Handler {
 			return
 		}
 		ctx.RemoteUser = ".tempurl"
-		ctx.AuthorizeOverride = true
 		ctx.Authorize = func(r *http.Request) bool {
 			ar, a, c, _ := getPathParts(r)
 			return ar && ((scope == SCOPE_ACCOUNT && a == account) || (scope == SCOPE_CONTAINER && c == container))


### PR DESCRIPTION
Now subrequesting will always copy the auth details over. Had to split
into newSubrequest and serveHTTPSubrequest, but it's pretty much the
same for code that uses it because they all did two steps anyway.