### PR TITLE
Refactor of Subrequest and minor auth changes

### DIFF
--- a/proxyserver/middleware/authtoken.go
+++ b/proxyserver/middleware/authtoken.go
@@ -213,9 +213,13 @@ func (at *authToken) fetchAndValidateToken(ctx *ProxyContext, authToken string) 
 }
 
 func (at *authToken) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := GetProxyContext(r)
+	if ctx.Authorize != nil {
+		at.next.ServeHTTP(w, r)
+		return
+	}
 	removeAuthHeaders(r)
 	r.Header.Set("X-Identity-Status", "Invalid")
-	ctx := GetProxyContext(r)
 	serviceAuthToken := r.Header.Get("X-Service-Token")
 	if serviceAuthToken != "" {
 		serviceToken, serviceTokenValid := at.fetchAndValidateToken(ctx, serviceAuthToken)

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -76,19 +77,18 @@ type ProxyContextMiddleware struct {
 
 type ProxyContext struct {
 	*ProxyContextMiddleware
-	C                 client.ProxyClient
-	Authorize         AuthorizeFunc
-	AuthorizeOverride bool
-	RemoteUser        string
-	ResellerRequest   bool
-	ACL               string
-	Logger            srv.LowLevelLogger
-	TxId              string
-	responseSent      bool
-	status            int
-	accountInfoCache  map[string]*AccountInfo
-	depth             int
-	Source            string
+	C                client.ProxyClient
+	Authorize        AuthorizeFunc
+	RemoteUser       string
+	ResellerRequest  bool
+	ACL              string
+	Logger           srv.LowLevelLogger
+	TxId             string
+	responseSent     bool
+	status           int
+	accountInfoCache map[string]*AccountInfo
+	depth            int
+	Source           string
 }
 
 func GetProxyContext(r *http.Request) *ProxyContext {
@@ -166,17 +166,14 @@ func (ctx *ProxyContext) InvalidateAccountInfo(account string) {
 	ctx.Cache.Delete(key)
 }
 
-func (ctx *ProxyContext) Subrequest(writer http.ResponseWriter, req *http.Request, source string, skipAuth bool) {
-	authorize := ctx.Authorize
-	authorizeOverride := ctx.AuthorizeOverride
-	if skipAuth {
-		authorize = nil
-		authorizeOverride = true
+func (ctx *ProxyContext) newSubrequest(method, urlStr string, body io.Reader, req *http.Request, source string) (*http.Request, error) {
+	subreq, err := http.NewRequest(method, urlStr, body)
+	if err != nil {
+		return nil, err
 	}
-	newctx := &ProxyContext{
+	subctx := &ProxyContext{
 		ProxyContextMiddleware: ctx.ProxyContextMiddleware,
-		Authorize:              authorize,
-		AuthorizeOverride:      authorizeOverride,
+		Authorize:              ctx.Authorize,
 		RemoteUser:             ctx.RemoteUser,
 		Logger:                 ctx.Logger.With(zap.String("src", source)),
 		C:                      ctx.C,
@@ -187,17 +184,22 @@ func (ctx *ProxyContext) Subrequest(writer http.ResponseWriter, req *http.Reques
 		depth:                  ctx.depth + 1,
 		Source:                 source,
 	}
-	// TODO: check depth
-	newWriter := srv.NewCustomWriter(writer, func(w http.ResponseWriter, status int) int {
-		newctx.responseSent = true
-		newctx.status = status
+	subreq = subreq.WithContext(context.WithValue(req.Context(), "proxycontext", subctx))
+	subreq.Header.Set("X-Trans-Id", subctx.TxId)
+	subreq.Header.Set("X-Timestamp", common.GetTimestamp())
+	return subreq, nil
+}
+
+func (ctx *ProxyContext) serveHTTPSubrequest(writer http.ResponseWriter, subreq *http.Request) {
+	subctx := GetProxyContext(subreq)
+	// TODO: check subctx.depth
+	subwriter := srv.NewCustomWriter(writer, func(w http.ResponseWriter, status int) int {
+		subctx.responseSent = true
+		subctx.status = status
 		return status
 	})
-	req.Header.Set("X-Trans-Id", ctx.TxId)
-	req.Header.Set("X-Timestamp", common.GetTimestamp())
-	newWriter.Header().Set("X-Trans-Id", ctx.TxId)
-	req = req.WithContext(context.WithValue(req.Context(), "proxycontext", newctx))
-	ctx.next.ServeHTTP(newWriter, req)
+	subwriter.Header().Set("X-Trans-Id", subctx.TxId)
+	ctx.next.ServeHTTP(subwriter, subreq)
 }
 
 func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *http.Request) {

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -203,6 +203,9 @@ func (ctx *ProxyContext) newSubrequest(method, urlStr string, body io.Reader, re
 	if subctx.subrequestCopy != nil {
 		subctx.subrequestCopy(subreq, req)
 	}
+	if v := req.Header.Get("Referer"); v != "" {
+		subreq.Header.Set("Referer", v)
+	}
 	subreq.Header.Set("X-Trans-Id", subctx.TxId)
 	subreq.Header.Set("X-Timestamp", common.GetTimestamp())
 	return subreq, nil

--- a/proxyserver/middleware/copy.go
+++ b/proxyserver/middleware/copy.go
@@ -132,7 +132,7 @@ func NewPipeResponseWriter(writer *io.PipeWriter, done chan bool, logger srv.Low
 
 func (c *copyMiddleware) getSourceObject(object string, request *http.Request, post bool) (io.ReadCloser, http.Header, int) {
 	ctx := GetProxyContext(request)
-	subRequest, err := http.NewRequest("GET", object, nil)
+	subRequest, err := ctx.newSubrequest("GET", object, nil, request, "copy")
 	if err != nil {
 		ctx.Logger.Error("getSourceObject GET error", zap.Error(err))
 		return nil, nil, 400
@@ -144,15 +144,18 @@ func (c *copyMiddleware) getSourceObject(object string, request *http.Request, p
 	// FIXME. Are we going to do X-Newest?
 	subRequest.Header.Set("X-Newest", "true")
 	subRequest.Header.Del("X-Backend-Storage-Policy-Index")
+	if post {
+		// POST doesn't need to auth the internal GET; if they issued a POST
+		// and it was authorized and we happen to need to do a GET+PUT for our
+		// own reasons, that's fine.
+		GetProxyContext(subRequest).Authorize = func(r *http.Request) bool { return true }
+	}
 
 	pipeReader, pipeWriter := io.Pipe()
 	done := make(chan bool)
 	writer := NewPipeResponseWriter(pipeWriter, done, ctx.Logger)
 	go func() {
-		// POST doesn't need to auth the internal GET; if they issued a POST
-		// and it was authorized and we happen to need to do a GET+PUT for our
-		// own reasons, that's fine.
-		ctx.Subrequest(writer, subRequest, "copy", !post)
+		ctx.serveHTTPSubrequest(writer, subRequest)
 		writer.Close()
 	}()
 	<-done
@@ -225,6 +228,8 @@ func copyItemsWithPrefix(dest, src http.Header, prefix string) {
 	}
 }
 
+// TODO: This seems like it might copy headers it shouldn't.
+// Also, shouldn't it be called copyHeaders instead?
 func copyItems(dest, src http.Header) {
 	for k, v := range src {
 		dest.Del(k)

--- a/proxyserver/middleware/multirange.go
+++ b/proxyserver/middleware/multirange.go
@@ -64,7 +64,7 @@ func multirange(next http.Handler) http.Handler {
 		var contentType string
 		var mw *common.MultiWriter
 
-		subreq, err := http.NewRequest("GET", request.URL.Path, nil)
+		subreq, err := ctx.newSubrequest("GET", request.URL.Path, nil, request, "multirange")
 		if err != nil {
 			srv.StandardResponse(writer, 500)
 			return
@@ -113,12 +113,12 @@ func multirange(next http.Handler) http.Handler {
 			}
 			return status
 		})
-		if ctx.Subrequest(subw, subreq, "multirange", false); uw.err != nil {
+		if ctx.serveHTTPSubrequest(subw, subreq); uw.err != nil {
 			return
 		}
 
 		for _, rng := range ranges[1:] {
-			if subreq, err = http.NewRequest("GET", request.URL.Path, nil); err != nil {
+			if subreq, err = ctx.newSubrequest("GET", request.URL.Path, nil, request, "multirange"); err != nil {
 				srv.StandardResponse(writer, 500)
 				return
 			}
@@ -138,7 +138,7 @@ func multirange(next http.Handler) http.Handler {
 				}
 				return status
 			})
-			if ctx.Subrequest(subw, subreq, "multirange", false); uw.err != nil {
+			if ctx.serveHTTPSubrequest(subw, subreq); uw.err != nil {
 				return
 			}
 		}

--- a/proxyserver/middleware/tempurl.go
+++ b/proxyserver/middleware/tempurl.go
@@ -168,7 +168,6 @@ func tempurl(next http.Handler) http.Handler {
 			return
 		}
 		ctx.RemoteUser = ".tempurl"
-		ctx.AuthorizeOverride = true
 		ctx.Authorize = func(r *http.Request) bool {
 			ar, a, c, _ := getPathParts(r)
 			return ar && ((scope == SCOPE_ACCOUNT && a == account) || (scope == SCOPE_CONTAINER && c == container))


### PR DESCRIPTION
* Dropped AuthorizeOverride. It just served for confusion and can be
  readded if we ever truly understand and can explain why we need it.

* Refactored Subrequest into newSubrequest and serveHTTPSubrequest. This
  means you create the http.Request object with all the proper stuff
  copied over and then can tweak it before processing/serving it.

* Refactored Keystone middleware to only set the Authorize func for its
  configured reseller prefixes. Swift supports the notion of fallback
  auth for unconfigured reseller prefixes and that's why it needed
  AuthorizeOverride (I think) etc. It was kind of a mess we don't really
  need to emulate.

* New subrequestCopy infrastructure gives a hook for any middleware
  to copy over request-level data for a subrequest. Keystone loves it
  some headers and will reject subrequests without this.