### PR TITLE
Update staticweb to work with X-Service-Token

### DIFF
--- a/proxyserver/middleware/staticweb_test.go
+++ b/proxyserver/middleware/staticweb_test.go
@@ -610,6 +610,7 @@ func TestStaticWebCustomErrorPages(t *testing.T) {
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
 	}))
+	request.Header.Set("X-Web-Mode", "t")
 	rec := httptest.NewRecorder()
 	s.ServeHTTP(rec, request)
 	resp := rec.Result()


### PR DESCRIPTION
This patch helps in passing test_rbac_with_service_prefix functional test.
Now all the functional tests in test_access_control pass with Keystone.