### PR TITLE
HUM-153 Refactor GetAccountInfo GetContainerInfo

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -109,7 +109,7 @@ type ProxyClient interface {
 	PutContainer(account string, container string, headers http.Header) *http.Response
 	PostContainer(account string, container string, headers http.Header) *http.Response
 	GetContainer(account string, container string, options map[string]string, headers http.Header) *http.Response
-	GetContainerInfo(account string, container string) *ContainerInfo
+	GetContainerInfo(account string, container string) (*ContainerInfo, error)
 	HeadContainer(account string, container string, headers http.Header) *http.Response
 	DeleteContainer(account string, container string, headers http.Header) *http.Response
 	PutObject(account string, container string, obj string, headers http.Header, src io.Reader) *http.Response

--- a/proxyserver/containerhandlers.go
+++ b/proxyserver/containerhandlers.go
@@ -43,7 +43,7 @@ func (server *ProxyServer) ContainerGetHandler(writer http.ResponseWriter, reque
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if ctx.GetAccountInfo(vars["account"]) == nil {
+	if _, err := ctx.GetAccountInfo(vars["account"]); err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -78,7 +78,7 @@ func (server *ProxyServer) ContainerHeadHandler(writer http.ResponseWriter, requ
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if ctx.GetAccountInfo(vars["account"]) == nil {
+	if _, err := ctx.GetAccountInfo(vars["account"]); err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -104,7 +104,7 @@ func (server *ProxyServer) ContainerPostHandler(writer http.ResponseWriter, requ
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if ctx.GetAccountInfo(vars["account"]) == nil {
+	if _, err := ctx.GetAccountInfo(vars["account"]); err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -136,7 +136,7 @@ func (server *ProxyServer) ContainerPutHandler(writer http.ResponseWriter, reque
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if ctx.GetAccountInfo(vars["account"]) == nil {
+	if _, err := ctx.GetAccountInfo(vars["account"]); err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -168,7 +168,7 @@ func (server *ProxyServer) ContainerDeleteHandler(writer http.ResponseWriter, re
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if ctx.GetAccountInfo(vars["account"]) == nil {
+	if _, err := ctx.GetAccountInfo(vars["account"]); err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -232,7 +232,7 @@ func (server *ProxyServer) OptionsHandler(writer http.ResponseWriter, request *h
 			return
 		}
 	}
-	if ci := ctx.C.GetContainerInfo(vars["account"], vars["container"]); ci != nil {
+	if ci, err := ctx.C.GetContainerInfo(vars["account"], vars["container"]); err == nil {
 		if common.IsOriginAllowed(ci.Metadata["Access-Control-Allow-Origin"], origin) {
 			writer.Header().Set("Allow", methodString)
 			if ci.Metadata["Access-Control-Allow-Origin"] == "*" {

--- a/proxyserver/middleware/cors.go
+++ b/proxyserver/middleware/cors.go
@@ -80,7 +80,7 @@ func (cm *corsMiddleware) ServeHTTP(writer http.ResponseWriter, request *http.Re
 		cm.next.ServeHTTP(writer, request)
 		return
 	}
-	if ci := ctx.C.GetContainerInfo(pathParts["account"], pathParts["container"]); ci != nil {
+	if ci, err := ctx.C.GetContainerInfo(pathParts["account"], pathParts["container"]); err == nil {
 		cHandler := &cors{origin: origin, ci: ci}
 		w := srv.NewCustomWriter(writer, cHandler.HandleCors)
 		cm.next.ServeHTTP(w, request)

--- a/proxyserver/middleware/formpost.go
+++ b/proxyserver/middleware/formpost.go
@@ -83,12 +83,12 @@ func authenticateFormpost(ctx *ProxyContext, account, container, path string, at
 		return hmac.Equal(sigb, mac.Sum(nil))
 	}
 
-	if ai := ctx.GetAccountInfo(account); ai != nil {
+	if ai, err := ctx.GetAccountInfo(account); err == nil {
 		if key, ok := ai.Metadata["Temp-Url-Key"]; ok && checkhmac([]byte(key)) {
 			return FP_SCOPE_ACCOUNT
 		} else if key, ok := ai.Metadata["Temp-Url-Key-2"]; ok && checkhmac([]byte(key)) {
 			return FP_SCOPE_ACCOUNT
-		} else if ci := ctx.C.GetContainerInfo(account, container); ci != nil {
+		} else if ci, err := ctx.C.GetContainerInfo(account, container); err == nil {
 			if key, ok := ci.Metadata["Temp-Url-Key"]; ok && checkhmac([]byte(key)) {
 				return FP_SCOPE_CONTAINER
 			} else if key, ok := ci.Metadata["Temp-Url-Key-2"]; ok && checkhmac([]byte(key)) {

--- a/proxyserver/middleware/keystoneauth.go
+++ b/proxyserver/middleware/keystoneauth.go
@@ -75,7 +75,11 @@ func (ka *keystoneAuth) accountMatchesTenant(account string, tenantID string) bo
 
 func (ka *keystoneAuth) getProjectDomainID(r *http.Request, account string) string {
 	ctx := GetProxyContext(r)
-	return ctx.GetAccountInfo(account).SysMetadata["Project-Domain-Id"]
+	ai, err := ctx.GetAccountInfo(account)
+	if err != nil {
+		return "" // TODO: I assume this is what we want here
+	}
+	return ai.SysMetadata["Project-Domain-Id"]
 }
 
 func (ka *keystoneAuth) setProjectDomainID(r *http.Request, pathParts map[string]string, identityMap map[string]string) {

--- a/proxyserver/middleware/staticweb.go
+++ b/proxyserver/middleware/staticweb.go
@@ -77,8 +77,8 @@ func (s *staticWebHandler) ServeHTTP(writer http.ResponseWriter, request *http.R
 		s.next.ServeHTTP(writer, request)
 		return
 	}
-	ci := s.ctx.C.GetContainerInfo(s.account, s.container)
-	if ci == nil {
+	ci, err := s.ctx.C.GetContainerInfo(s.account, s.container)
+	if err != nil {
 		s.next.ServeHTTP(writer, request)
 		return
 	}

--- a/proxyserver/middleware/tempurl.go
+++ b/proxyserver/middleware/tempurl.go
@@ -150,12 +150,12 @@ func tempurl(next http.Handler) http.Handler {
 		}
 
 		scope := SCOPE_INVALID
-		if ai := ctx.GetAccountInfo(account); ai != nil {
+		if ai, err := ctx.GetAccountInfo(account); err == nil {
 			if key, ok := ai.Metadata["Temp-Url-Key"]; ok && checkhmac([]byte(key), sigb, request.Method, path, expires) {
 				scope = SCOPE_ACCOUNT
 			} else if key, ok := ai.Metadata["Temp-Url-Key-2"]; ok && checkhmac([]byte(key), sigb, request.Method, path, expires) {
 				scope = SCOPE_ACCOUNT
-			} else if ci := ctx.C.GetContainerInfo(account, container); ci != nil {
+			} else if ci, err := ctx.C.GetContainerInfo(account, container); err == nil {
 				if key, ok := ci.Metadata["Temp-Url-Key"]; ok && checkhmac([]byte(key), sigb, request.Method, path, expires) {
 					scope = SCOPE_CONTAINER
 				} else if key, ok := ci.Metadata["Temp-Url-Key-2"]; ok && checkhmac([]byte(key), sigb, request.Method, path, expires) {

--- a/proxyserver/objhandlers.go
+++ b/proxyserver/objhandlers.go
@@ -33,8 +33,8 @@ func (server *ProxyServer) ObjectGetHandler(writer http.ResponseWriter, request 
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
-	if containerInfo == nil {
+	containerInfo, err := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -61,8 +61,8 @@ func (server *ProxyServer) ObjectHeadHandler(writer http.ResponseWriter, request
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
-	if containerInfo == nil {
+	containerInfo, err := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -88,8 +88,8 @@ func (server *ProxyServer) ObjectDeleteHandler(writer http.ResponseWriter, reque
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
-	if containerInfo == nil {
+	containerInfo, err := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -112,8 +112,8 @@ func (server *ProxyServer) ObjectPostHandler(writer http.ResponseWriter, request
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
-	if containerInfo == nil {
+	containerInfo, err := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}
@@ -141,8 +141,8 @@ func (server *ProxyServer) ObjectPutHandler(writer http.ResponseWriter, request 
 		srv.SimpleErrorResponse(writer, 400, "If-None-Match only supports *")
 		return
 	}
-	containerInfo := ctx.C.GetContainerInfo(vars["account"], vars["container"])
-	if containerInfo == nil {
+	containerInfo, err := ctx.C.GetContainerInfo(vars["account"], vars["container"])
+	if err != nil {
 		srv.StandardResponse(writer, 404)
 		return
 	}


### PR DESCRIPTION
These now return info, err instead of relying on the caller to remember
that they're supposed to check for nils. Of course, they can still
forget to check for err != nil, but that's more of a idiomatic Go thing
so hopefully easier to remember.