### PR TITLE
Auto create account

### DIFF
--- a/proxyserver/accounthandlers.go
+++ b/proxyserver/accounthandlers.go
@@ -45,6 +45,11 @@ func (server *ProxyServer) AccountGetHandler(writer http.ResponseWriter, request
 		}
 	}
 	resp := ctx.C.GetAccount(vars["account"], options, request.Header)
+	if resp.StatusCode == http.StatusNotFound && server.accountAutoCreate {
+		resp.Body.Close()
+		ctx.AutoCreateAccount(vars["account"], request.Header)
+		resp = ctx.C.GetAccount(vars["account"], options, request.Header)
+	}
 	for k := range resp.Header {
 		writer.Header().Set(k, resp.Header.Get(k))
 	}
@@ -67,6 +72,11 @@ func (server *ProxyServer) AccountHeadHandler(writer http.ResponseWriter, reques
 		}
 	}
 	resp := ctx.C.HeadAccount(vars["account"], request.Header)
+	if resp.StatusCode == http.StatusNotFound && server.accountAutoCreate {
+		resp.Body.Close()
+		ctx.AutoCreateAccount(vars["account"], request.Header)
+		resp = ctx.C.HeadAccount(vars["account"], request.Header)
+	}
 	for k := range resp.Header {
 		writer.Header().Set(k, resp.Header.Get(k))
 	}
@@ -95,6 +105,11 @@ func (server *ProxyServer) AccountPostHandler(writer http.ResponseWriter, reques
 	}
 	defer ctx.InvalidateAccountInfo(vars["account"])
 	resp := ctx.C.PostAccount(vars["account"], request.Header)
+	if resp.StatusCode == http.StatusNotFound && server.accountAutoCreate {
+		resp.Body.Close()
+		ctx.AutoCreateAccount(vars["account"], request.Header)
+		resp = ctx.C.PostAccount(vars["account"], request.Header)
+	}
 	resp.Body.Close()
 	srv.StandardResponse(writer, resp.StatusCode)
 }

--- a/proxyserver/containerhandlers.go
+++ b/proxyserver/containerhandlers.go
@@ -136,10 +136,6 @@ func (server *ProxyServer) ContainerPutHandler(writer http.ResponseWriter, reque
 		srv.StandardResponse(writer, 500)
 		return
 	}
-	if _, err := ctx.GetAccountInfo(vars["account"]); err != nil {
-		srv.StandardResponse(writer, 404)
-		return
-	}
 	if err := cleanACLs(request); err != nil {
 		srv.SimpleErrorResponse(writer, 400, err.Error())
 		return
@@ -149,6 +145,17 @@ func (server *ProxyServer) ContainerPutHandler(writer http.ResponseWriter, reque
 			srv.StandardResponse(writer, s)
 			return
 		}
+	}
+	_, err := ctx.GetAccountInfo(vars["account"])
+	if err != nil {
+		if server.accountAutoCreate {
+			ctx.AutoCreateAccount(vars["account"], request.Header)
+			_, err = ctx.GetAccountInfo(vars["account"])
+		}
+	}
+	if err != nil {
+		srv.StandardResponse(writer, 404)
+		return
 	}
 	if status, str := CheckContainerPut(request, vars["container"]); status != http.StatusOK {
 		writer.Header().Set("Content-Type", "text/plain")

--- a/proxyserver/middleware/keystoneauth.go
+++ b/proxyserver/middleware/keystoneauth.go
@@ -90,7 +90,7 @@ func (ka *keystoneAuth) setProjectDomainID(r *http.Request, pathParts map[string
 		}
 	}
 	if pathParts["object"] != "" || (pathParts["container"] != "" && r.Method != "PUT") ||
-		common.StringInSlice(r.Method, []string{"PUT", "POST"}) {
+		!common.StringInSlice(r.Method, []string{"PUT", "POST"}) {
 		return
 	}
 	tenantID := identityMap["tenantID"]

--- a/proxyserver/middleware/keystoneauth.go
+++ b/proxyserver/middleware/keystoneauth.go
@@ -62,7 +62,6 @@ func (ka *keystoneAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	w.Header().Set("X-Account-Project-Domain-Id", identityMap["projectDomainID"])
 }
 
 func (ka *keystoneAuth) accountMatchesTenant(account string, tenantID string) bool {


### PR DESCRIPTION
Now in proxy-server.conf we will need to have account
auto creation set to true. Default is false:
[app:proxy-server]
    account_autocreate = true

Moved the auto account creation logic from GetAccountInfo
to proxy handlers. Now we auto create account on Account GET/HEAD/POST &
Container PUT request.

Also fixed a typo in keystoneauth setProjectDomainID.
Now more functional tests should pass. Yay!

Fixes #52 