### PR TITLE
Added an X-Source-Code header capability

### DIFF
--- a/accountserver/server.go
+++ b/accountserver/server.go
@@ -526,7 +526,7 @@ func (server *AccountServer) GetHandler(config conf.Config, metricsPrefix string
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Invalid path: %s", r.URL.Path), http.StatusBadRequest)
 	})
-	return alice.New(middleware.Metrics(metricsScope)).Append(middleware.GrepObject).Then(router)
+	return alice.New(middleware.Metrics(&config, metricsScope)).Append(middleware.GrepObject).Then(router)
 }
 
 // GetServer parses configs and command-line flags, returning a configured server object and the ip and port it should bind on.

--- a/client/debug.go
+++ b/client/debug.go
@@ -10,11 +10,12 @@ import (
 
 type autoCloseResponses struct {
 	http.RoundTripper
+	autoCloseAfter time.Duration
 }
 
 func (a *autoCloseResponses) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := a.RoundTripper.RoundTrip(req)
-	resp.Body = &autoClosingBody{ReadCloser: resp.Body, timer: time.AfterFunc(time.Minute, func() { autoCloseReport(req, resp) })}
+	resp.Body = &autoClosingBody{ReadCloser: resp.Body, timer: time.AfterFunc(a.autoCloseAfter, func() { autoCloseReport(req, resp) })}
 	return resp, err
 }
 

--- a/client/directclient.go
+++ b/client/directclient.go
@@ -163,16 +163,17 @@ func (c *ProxyDirectClient) firstResponse(reqs ...*http.Request) (resp *http.Res
 
 		select {
 		case resp = <-success:
-			if resp == nil || resp.StatusCode/100 == 5 {
-				internalErrors++
-			} else if resp.StatusCode/100 == 2 || resp.StatusCode == http.StatusPreconditionFailed || resp.StatusCode == http.StatusNotModified || resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
-				resp = StubResponse(resp)
+			if resp != nil && (resp.StatusCode/100 == 2 || resp.StatusCode == http.StatusPreconditionFailed || resp.StatusCode == http.StatusNotModified || resp.StatusCode == http.StatusRequestedRangeNotSatisfiable) {
 				resp.Header.Set("Accept-Ranges", "bytes")
 				if etag := resp.Header.Get("Etag"); etag != "" {
 					resp.Header.Set("Etag", strings.Trim(etag, "\""))
 				}
 				return resp
-			} else if resp != nil {
+			}
+			if resp == nil || resp.StatusCode/100 == 5 {
+				internalErrors++
+			}
+			if resp != nil {
 				resp.Body.Close()
 			}
 		case <-time.After(time.Second):

--- a/client/directclient.go
+++ b/client/directclient.go
@@ -16,6 +16,8 @@ import (
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/conf"
 	"github.com/troubling/hummingbird/common/ring"
+	"github.com/troubling/hummingbird/common/srv"
+	"go.uber.org/zap"
 )
 
 const PostQuorumTimeoutMs = 100
@@ -51,7 +53,7 @@ type ProxyDirectClient struct {
 	ContainerRing ring.Ring
 }
 
-func NewProxyDirectClient(policyList conf.PolicyList) (*ProxyDirectClient, error) {
+func NewProxyDirectClient(config *conf.Config, policyList conf.PolicyList, logger srv.LowLevelLogger) (*ProxyDirectClient, error) {
 	var xport http.RoundTripper = &http.Transport{
 		DisableCompression: true,
 		Dial: (&net.Dialer{
@@ -59,8 +61,15 @@ func NewProxyDirectClient(policyList conf.PolicyList) (*ProxyDirectClient, error
 			KeepAlive: 5 * time.Second,
 		}).Dial,
 	}
-	// Debug hook to auto-close responses and report on it. See debug.go
-	// xport = &autoCloseResponses{transport: xport}
+	if config != nil {
+		autoCloseSeconds := config.GetInt("debug", "debug_http_close", 0)
+		if autoCloseSeconds != 0 {
+			xport = &autoCloseResponses{RoundTripper: xport, autoCloseAfter: time.Duration(autoCloseSeconds) * time.Second}
+			if logger != nil {
+				logger.Info("AUTO CLOSING HTTP RESPONSES IS TURNED ON", zap.Int64("debug_http_close", autoCloseSeconds))
+			}
+		}
+	}
 	c := &ProxyDirectClient{
 		policyList: policyList,
 		client: &http.Client{
@@ -897,7 +906,7 @@ func (c *directClient) DeleteObject(container string, obj string, headers map[st
 
 // NewDirectClient creates a new direct client with the given account name.
 func NewDirectClient(account string) (Client, error) {
-	pdc, err := NewProxyDirectClient(nil)
+	pdc, err := NewProxyDirectClient(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nectar/main.go
+++ b/cmd/nectar/main.go
@@ -212,7 +212,7 @@ func delet(c client.Client, args []string) {
 	if resp.StatusCode/100 != 2 {
 		bodyBytes, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
-		fatalf("%d %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+		fatalf("%d %s - %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 	}
 	resp.Body.Close()
 }
@@ -234,7 +234,7 @@ func get(c client.Client, args []string) {
 		if resp.StatusCode/100 != 2 {
 			bodyBytes, _ := ioutil.ReadAll(resp.Body)
 			resp.Body.Close()
-			fatalf("%d %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+			fatalf("%d %s - %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 		}
 		if *getFlagRaw || object == "" {
 			data := [][]string{}
@@ -262,7 +262,7 @@ func get(c client.Client, args []string) {
 		if resp.StatusCode/100 != 2 {
 			bodyBytes, _ := ioutil.ReadAll(resp.Body)
 			resp.Body.Close()
-			fatalf("%d %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+			fatalf("%d %s - %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 		}
 		if *getFlagNameOnly {
 			for _, entry := range entries {
@@ -290,7 +290,7 @@ func get(c client.Client, args []string) {
 	if resp.StatusCode/100 != 2 {
 		bodyBytes, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
-		fatalf("%d %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+		fatalf("%d %s - %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 	}
 	if *getFlagNameOnly {
 		for _, entry := range entries {
@@ -334,7 +334,7 @@ func head(c client.Client, args []string) {
 	bodyBytes, _ := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
-		fatalf("%d %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+		fatalf("%d %s - %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 	}
 	data := [][]string{}
 	ks := []string{}
@@ -385,7 +385,7 @@ func put(c client.Client, args []string) {
 	if resp.StatusCode/100 != 2 {
 		bodyBytes, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
-		fatalf("%d %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+		fatalf("%d %s - %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 	}
 	resp.Body.Close()
 }
@@ -403,7 +403,7 @@ func post(c client.Client, args []string) {
 	if resp.StatusCode/100 != 2 {
 		bodyBytes, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
-		fatalf("%d %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+		fatalf("%d %s - %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 	}
 	resp.Body.Close()
 }
@@ -426,7 +426,7 @@ func upload(c client.Client, args []string) {
 	if resp.StatusCode/100 != 2 {
 		bodyBytes, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
-		fatalf("PUT %s - %d %s - %s\n", container, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+		fatalf("PUT %s - %d %s - %s - %s\n", container, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 	}
 	resp.Body.Close()
 	concurrency := *globalFlagConcurrency
@@ -459,10 +459,10 @@ func upload(c client.Client, args []string) {
 					resp.Body.Close()
 					f.Close()
 					if *globalFlagContinueOnError {
-						fmt.Fprintf(os.Stderr, "PUT %s/%s - %d %s - %s\n", container, object+path, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+						fmt.Fprintf(os.Stderr, "PUT %s/%s - %d %s - %s - %s\n", container, object+path, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 						continue
 					} else {
-						fatalf("PUT %s/%s - %d %s - %s\n", container, object+path, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+						fatalf("PUT %s/%s - %d %s - %s - %s\n", container, object+path, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 					}
 				}
 				resp.Body.Close()
@@ -535,10 +535,10 @@ func download(c client.Client, args []string) {
 						resp.Body.Close()
 						containerWG.Done()
 						if *globalFlagContinueOnError {
-							fmt.Fprintf(os.Stderr, "GET %s - %d %s - %s\n", task.container, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+							fmt.Fprintf(os.Stderr, "GET %s - %d %s - %s - %s\n", task.container, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 							continue
 						} else {
-							fatalf("GET %s - %d %s - %s\n", task.container, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+							fatalf("GET %s - %d %s - %s - %s\n", task.container, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 						}
 					}
 					resp.Body.Close()
@@ -580,10 +580,10 @@ func download(c client.Client, args []string) {
 					resp.Body.Close()
 					f.Close()
 					if *globalFlagContinueOnError {
-						fmt.Fprintf(os.Stderr, "GET %s/%s - %d %s - %s\n", task.container, task.object, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+						fmt.Fprintf(os.Stderr, "GET %s/%s - %d %s - %s - %s\n", task.container, task.object, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 						continue
 					} else {
-						fatalf("GET %s/%s - %d %s - %s\n", task.container, task.object, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+						fatalf("GET %s/%s - %d %s - %s - %s\n", task.container, task.object, resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 					}
 				}
 				if _, err = io.Copy(f, resp.Body); err != nil {
@@ -638,7 +638,7 @@ func download(c client.Client, args []string) {
 		if resp.StatusCode/100 != 2 {
 			bodyBytes, _ := ioutil.ReadAll(resp.Body)
 			resp.Body.Close()
-			fatalf("GET - %d %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes))
+			fatalf("GET - %d %s - %s - %s\n", resp.StatusCode, http.StatusText(resp.StatusCode), string(bodyBytes), resp.Header.Get("X-Source-Code"))
 		}
 		resp.Body.Close()
 		for _, entry := range entries {

--- a/common/pickle/pickle.go
+++ b/common/pickle/pickle.go
@@ -167,6 +167,9 @@ func pickleobj(o interface{}, buf *bytes.Buffer, scratch []byte) error {
 			}
 			buf.WriteByte('(') // MARK
 			for i := 0; i < v.Type().NumField(); i++ {
+				if !v.Field(i).CanInterface() {
+					continue
+				}
 				field := v.Type().Field(i)
 				if tag := field.Tag.Get("pickle"); tag != "" {
 					picklestring(tag, buf, scratch)

--- a/common/pickle/pickle_test.go
+++ b/common/pickle/pickle_test.go
@@ -440,13 +440,15 @@ func TestLoadArrayDifferentProtocol(t *testing.T) {
 type arbitraryStruct struct {
 	Val1 string
 	Val2 int
+	valH int
 }
 
 func TestArbitraryStruct(t *testing.T) {
-	x := arbitraryStruct{Val1: "hello", Val2: 311}
+	x := arbitraryStruct{Val1: "hello", Val2: 311, valH: 411}
 	rt := PickleRoundTrip(t, x)
 	v2, valid := rt.(map[interface{}]interface{})
 	require.True(t, valid)
 	require.Equal(t, "hello", v2["Val1"])
 	require.Equal(t, int64(311), v2["Val2"])
+	require.Equal(t, nil, v2["valH"])
 }

--- a/common/srv/server.go
+++ b/common/srv/server.go
@@ -114,11 +114,7 @@ func (w *customWriter) WriteHeader(status int) {
 }
 
 // NewCustomWriter creates an http.ResponseWriter wrapper that calls your function on WriteHeader.
-func NewCustomWriter(config *conf.Config, w http.ResponseWriter, f func(w http.ResponseWriter, status int) int) http.ResponseWriter {
-	xSourceCode := false
-	if config != nil {
-		xSourceCode = config.GetBool("debug", "debug_x_source_code", false)
-	}
+func NewCustomWriter(xSourceCode bool, w http.ResponseWriter, f func(w http.ResponseWriter, status int) int) http.ResponseWriter {
 	return &customWriter{ResponseWriter: w, xSourceCode: xSourceCode, f: f}
 }
 

--- a/common/srv/server.go
+++ b/common/srv/server.go
@@ -81,18 +81,45 @@ var responseBodies = map[int]string{
 	504: fmt.Sprintf(responseTemplate, "Gateway Timeout", "A timeout has occurred speaking to a backend server."),
 }
 
+type XSourceCodeRecorder interface {
+	AddXSourceCode(skip int)
+}
+
 type customWriter struct {
 	http.ResponseWriter
-	f func(w http.ResponseWriter, status int) int
+	xSourceCode bool
+	f           func(w http.ResponseWriter, status int) int
+}
+
+func (w *customWriter) AddXSourceCode(skip int) {
+	if w.xSourceCode {
+		if _, f, n, ok := runtime.Caller(skip + 1); ok {
+			v := w.Header().Get("X-Source-Code")
+			if v != "" {
+				v += fmt.Sprintf(" %s:%d", f, n)
+			} else {
+				v = fmt.Sprintf("%s:%d", f, n)
+			}
+			w.Header().Set("X-Source-Code", v)
+		}
+	}
 }
 
 func (w *customWriter) WriteHeader(status int) {
+	if w.xSourceCode {
+		w.AddXSourceCode(1)
+		w.Header().Set("X-Source-Code", w.Header().Get("X-Source-Code")+" - ")
+	}
 	w.ResponseWriter.WriteHeader(w.f(w.ResponseWriter, status))
 }
 
 // NewCustomWriter creates an http.ResponseWriter wrapper that calls your function on WriteHeader.
-func NewCustomWriter(w http.ResponseWriter, f func(w http.ResponseWriter, status int) int) http.ResponseWriter {
-	return &customWriter{ResponseWriter: w, f: f}
+func NewCustomWriter(config *conf.Config, w http.ResponseWriter, f func(w http.ResponseWriter, status int) int) http.ResponseWriter {
+	xSourceCode := false
+	if config != nil {
+		xSourceCode = config.GetBool("debug", "debug_x_source_code", false)
+	}
+	return &customWriter{ResponseWriter: w, xSourceCode: xSourceCode, f: f}
 }
 
 // ResponseWriter that saves its status - used for logging.
@@ -106,6 +133,9 @@ type WebWriter struct {
 func (w *WebWriter) WriteHeader(status int) {
 	w.Status = status
 	w.ResponseStarted = true
+	if r, ok := w.ResponseWriter.(XSourceCodeRecorder); ok {
+		r.AddXSourceCode(1)
+	}
 	w.ResponseWriter.WriteHeader(status)
 }
 
@@ -127,6 +157,9 @@ func StandardResponse(w http.ResponseWriter, statusCode int) {
 	body := responseBodies[statusCode]
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(body)), 10))
+	if r, ok := w.(XSourceCodeRecorder); ok {
+		r.AddXSourceCode(1)
+	}
 	w.WriteHeader(statusCode)
 	w.Write([]byte(body))
 }
@@ -134,6 +167,9 @@ func StandardResponse(w http.ResponseWriter, statusCode int) {
 func SimpleErrorResponse(w http.ResponseWriter, statusCode int, body string) {
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(body)), 10))
+	if r, ok := w.(XSourceCodeRecorder); ok {
+		r.AddXSourceCode(1)
+	}
 	w.WriteHeader(statusCode)
 	w.Write([]byte(body))
 }
@@ -148,6 +184,9 @@ func CustomErrorResponse(w http.ResponseWriter, statusCode int, vars map[string]
 		}
 	}
 	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(body)), 10))
+	if r, ok := w.(XSourceCodeRecorder); ok {
+		r.AddXSourceCode(1)
+	}
 	w.WriteHeader(statusCode)
 	w.Write([]byte(body))
 }

--- a/containerserver/server.go
+++ b/containerserver/server.go
@@ -610,7 +610,7 @@ func (server *ContainerServer) GetHandler(config conf.Config, metricsPrefix stri
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Invalid path: %s", r.URL.Path), http.StatusBadRequest)
 	})
-	return alice.New(middleware.Metrics(metricsScope)).Append(middleware.GrepObject).Then(router)
+	return alice.New(middleware.Metrics(&config, metricsScope)).Append(middleware.GrepObject).Then(router)
 }
 
 // GetServer parses configs and command-line flags, returning a configured server object and the ip and port it should bind on.

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -11,10 +11,14 @@ import (
 
 func Metrics(config *conf.Config, metricsScope tally.Scope) func(http.Handler) http.Handler {
 	requestsMetric := metricsScope.Counter("requests")
+	xSourceCode := false
+	if config != nil {
+		xSourceCode = config.GetBool("debug", "debug_x_source_code", false)
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			var status int
-			w := srv.NewCustomWriter(config, writer, func(w http.ResponseWriter, s int) int {
+			w := srv.NewCustomWriter(xSourceCode, writer, func(w http.ResponseWriter, s int) int {
 				status = s
 				return s
 			})

--- a/middleware/metrics.go
+++ b/middleware/metrics.go
@@ -4,28 +4,24 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/srv"
 	"github.com/uber-go/tally"
 )
 
-type recordStatusWriter struct {
-	http.ResponseWriter
-	status int
-}
-
-func (mw *recordStatusWriter) WriteHeader(status int) {
-	mw.status = status
-	mw.ResponseWriter.WriteHeader(status)
-}
-
-func Metrics(metricsScope tally.Scope) func(http.Handler) http.Handler {
+func Metrics(config *conf.Config, metricsScope tally.Scope) func(http.Handler) http.Handler {
 	requestsMetric := metricsScope.Counter("requests")
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			w := &recordStatusWriter{ResponseWriter: writer}
+			var status int
+			w := srv.NewCustomWriter(config, writer, func(w http.ResponseWriter, s int) int {
+				status = s
+				return s
+			})
 			next.ServeHTTP(w, request)
 			requestsMetric.Inc(1)
 			metricsScope.Counter(request.Method + "_requests").Inc(1)
-			metricsScope.Counter(fmt.Sprintf("%d_responses", w.status)).Inc(1)
+			metricsScope.Counter(fmt.Sprintf("%d_responses", status)).Inc(1)
 		})
 	}
 }

--- a/objectserver/main.go
+++ b/objectserver/main.go
@@ -627,7 +627,7 @@ func (server *ObjectServer) GetHandler(config conf.Config, metricsPrefix string)
 	router.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Invalid path: %s", r.URL.Path), http.StatusBadRequest)
 	})
-	return alice.New(middleware.Metrics(metricsScope)).Append(middleware.GrepObject).Then(router)
+	return alice.New(middleware.Metrics(&config, metricsScope)).Append(middleware.GrepObject).Then(router)
 }
 
 func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bindPort int, serv srv.Server, logger srv.LowLevelLogger, err error) {

--- a/proxyserver/main.go
+++ b/proxyserver/main.go
@@ -145,7 +145,7 @@ func (server *ProxyServer) GetHandler(config conf.Config, metricsPrefix string) 
 			{middleware.NewXlo, "filter:slo"},
 		}
 	}
-	pipeline := alice.New(middleware.NewContext(server.mc, server.logger, server.proxyDirectClient))
+	pipeline := alice.New(middleware.NewContext(&config, server.mc, server.logger, server.proxyDirectClient))
 	for _, m := range middlewares {
 		mid, err := m.construct(config.GetSection(m.section), metricsScope)
 		if err != nil {
@@ -176,7 +176,7 @@ func GetServer(serverconf conf.Config, flags *flag.FlagSet) (string, int, srv.Se
 		return "", 0, nil, nil, fmt.Errorf("Error setting up logger: %v", err)
 	}
 	policies := conf.LoadPolicies()
-	server.proxyDirectClient, err = client.NewProxyDirectClient(policies)
+	server.proxyDirectClient, err = client.NewProxyDirectClient(&serverconf, policies, server.logger)
 	if err != nil {
 		return "", 0, nil, nil, fmt.Errorf("Error setting up proxyDirectClient: %v", err)
 	}

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -74,7 +74,7 @@ type ProxyContextMiddleware struct {
 	log               srv.LowLevelLogger
 	Cache             ring.MemcacheRing
 	proxyDirectClient *client.ProxyDirectClient
-	config            *conf.Config
+	xSourceCode       bool
 }
 
 type ProxyContext struct {
@@ -230,7 +230,7 @@ func (ctx *ProxyContext) newSubrequest(method, urlStr string, body io.Reader, re
 func (ctx *ProxyContext) serveHTTPSubrequest(writer http.ResponseWriter, subreq *http.Request) {
 	subctx := GetProxyContext(subreq)
 	// TODO: check subctx.depth
-	subwriter := srv.NewCustomWriter(ctx.config, writer, func(w http.ResponseWriter, status int) int {
+	subwriter := srv.NewCustomWriter(ctx.xSourceCode, writer, func(w http.ResponseWriter, status int) int {
 		subctx.responseSent = true
 		subctx.status = status
 		return status
@@ -310,7 +310,7 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 		}
 		wg.Wait()
 	}
-	newWriter := srv.NewCustomWriter(ctx.config, writer, func(w http.ResponseWriter, status int) int {
+	newWriter := srv.NewCustomWriter(ctx.xSourceCode, writer, func(w http.ResponseWriter, status int) int {
 		// strip out any bad headers before calling real WriteHeader
 		for k := range w.Header() {
 			if k == "X-Account-Sysmeta-Project-Domain-Id" {
@@ -338,13 +338,17 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 }
 
 func NewContext(config *conf.Config, mc ring.MemcacheRing, log srv.LowLevelLogger, proxyDirectClient *client.ProxyDirectClient) func(http.Handler) http.Handler {
+	xSourceCode := false
+	if config != nil {
+		xSourceCode = config.GetBool("debug", "debug_x_source_code", false)
+	}
 	return func(next http.Handler) http.Handler {
 		return &ProxyContextMiddleware{
 			Cache:             mc,
 			log:               log,
 			next:              next,
 			proxyDirectClient: proxyDirectClient,
-			config:            config,
+			xSourceCode:       xSourceCode,
 		}
 	}
 }

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/troubling/hummingbird/client"
 	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/conf"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/srv"
 	"go.uber.org/zap"
@@ -73,6 +74,7 @@ type ProxyContextMiddleware struct {
 	log               srv.LowLevelLogger
 	Cache             ring.MemcacheRing
 	proxyDirectClient *client.ProxyDirectClient
+	config            *conf.Config
 }
 
 type ProxyContext struct {
@@ -228,7 +230,7 @@ func (ctx *ProxyContext) newSubrequest(method, urlStr string, body io.Reader, re
 func (ctx *ProxyContext) serveHTTPSubrequest(writer http.ResponseWriter, subreq *http.Request) {
 	subctx := GetProxyContext(subreq)
 	// TODO: check subctx.depth
-	subwriter := srv.NewCustomWriter(writer, func(w http.ResponseWriter, status int) int {
+	subwriter := srv.NewCustomWriter(ctx.config, writer, func(w http.ResponseWriter, status int) int {
 		subctx.responseSent = true
 		subctx.status = status
 		return status
@@ -308,7 +310,7 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 		}
 		wg.Wait()
 	}
-	newWriter := srv.NewCustomWriter(writer, func(w http.ResponseWriter, status int) int {
+	newWriter := srv.NewCustomWriter(ctx.config, writer, func(w http.ResponseWriter, status int) int {
 		// strip out any bad headers before calling real WriteHeader
 		for k := range w.Header() {
 			if k == "X-Account-Sysmeta-Project-Domain-Id" {
@@ -335,13 +337,14 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 	m.next.ServeHTTP(newWriter, request)
 }
 
-func NewContext(mc ring.MemcacheRing, log srv.LowLevelLogger, proxyDirectClient *client.ProxyDirectClient) func(http.Handler) http.Handler {
+func NewContext(config *conf.Config, mc ring.MemcacheRing, log srv.LowLevelLogger, proxyDirectClient *client.ProxyDirectClient) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return &ProxyContextMiddleware{
 			Cache:             mc,
 			log:               log,
 			next:              next,
 			proxyDirectClient: proxyDirectClient,
+			config:            config,
 		}
 	}
 }

--- a/proxyserver/middleware/cors.go
+++ b/proxyserver/middleware/cors.go
@@ -83,7 +83,7 @@ func (cm *corsMiddleware) ServeHTTP(writer http.ResponseWriter, request *http.Re
 	}
 	if ci, err := ctx.C.GetContainerInfo(pathParts["account"], pathParts["container"]); err == nil {
 		cHandler := &cors{origin: origin, ci: ci}
-		w := srv.NewCustomWriter(writer, cHandler.HandleCors)
+		w := srv.NewCustomWriter(ctx.config, writer, cHandler.HandleCors)
 		cm.next.ServeHTTP(w, request)
 		return
 	}

--- a/proxyserver/middleware/cors.go
+++ b/proxyserver/middleware/cors.go
@@ -83,7 +83,7 @@ func (cm *corsMiddleware) ServeHTTP(writer http.ResponseWriter, request *http.Re
 	}
 	if ci, err := ctx.C.GetContainerInfo(pathParts["account"], pathParts["container"]); err == nil {
 		cHandler := &cors{origin: origin, ci: ci}
-		w := srv.NewCustomWriter(ctx.config, writer, cHandler.HandleCors)
+		w := srv.NewCustomWriter(ctx.xSourceCode, writer, cHandler.HandleCors)
 		cm.next.ServeHTTP(w, request)
 		return
 	}

--- a/proxyserver/middleware/largeobject.go
+++ b/proxyserver/middleware/largeobject.go
@@ -103,6 +103,9 @@ func (sw *xloIdentifyWriter) WriteHeader(status int) {
 		sw.isSlo = true
 	}
 	if !sw.isSlo && !sw.isDlo {
+		if r, ok := sw.ResponseWriter.(srv.XSourceCodeRecorder); ok {
+			r.AddXSourceCode(1)
+		}
 		sw.ResponseWriter.WriteHeader(status)
 		return
 	}

--- a/proxyserver/middleware/multirange.go
+++ b/proxyserver/middleware/multirange.go
@@ -73,7 +73,7 @@ func multirange(next http.Handler) http.Handler {
 		subreq.Header.Set("Range", firstRange(rangeHeader))
 
 		uw := &mrw{Writer: ioutil.Discard, header: make(http.Header)}
-		subw := srv.NewCustomWriter(uw, func(w http.ResponseWriter, status int) int {
+		subw := srv.NewCustomWriter(ctx.config, uw, func(w http.ResponseWriter, status int) int {
 			if status != http.StatusPartialContent {
 				uw.err = fmt.Errorf("Bad status code %d", status)
 				uw.Writer = writer
@@ -128,7 +128,7 @@ func multirange(next http.Handler) http.Handler {
 				return // we just can't complete this request
 			}
 			uw := &mrw{Writer: ioutil.Discard, header: make(http.Header)}
-			subw := srv.NewCustomWriter(uw, func(w http.ResponseWriter, status int) int {
+			subw := srv.NewCustomWriter(ctx.config, uw, func(w http.ResponseWriter, status int) int {
 				part, err := mw.CreatePart(rng.Start, rng.End)
 				if err != nil {
 					uw.err = err

--- a/proxyserver/middleware/multirange.go
+++ b/proxyserver/middleware/multirange.go
@@ -73,7 +73,7 @@ func multirange(next http.Handler) http.Handler {
 		subreq.Header.Set("Range", firstRange(rangeHeader))
 
 		uw := &mrw{Writer: ioutil.Discard, header: make(http.Header)}
-		subw := srv.NewCustomWriter(ctx.config, uw, func(w http.ResponseWriter, status int) int {
+		subw := srv.NewCustomWriter(ctx.xSourceCode, uw, func(w http.ResponseWriter, status int) int {
 			if status != http.StatusPartialContent {
 				uw.err = fmt.Errorf("Bad status code %d", status)
 				uw.Writer = writer
@@ -128,7 +128,7 @@ func multirange(next http.Handler) http.Handler {
 				return // we just can't complete this request
 			}
 			uw := &mrw{Writer: ioutil.Discard, header: make(http.Header)}
-			subw := srv.NewCustomWriter(ctx.config, uw, func(w http.ResponseWriter, status int) int {
+			subw := srv.NewCustomWriter(ctx.xSourceCode, uw, func(w http.ResponseWriter, status int) int {
 				part, err := mw.CreatePart(rng.Start, rng.End)
 				if err != nil {
 					uw.err = err


### PR DESCRIPTION
This will log, to an X-Source-Code HTTP header, the file and line number where
the WriteHeader(statusCode) happened, and anywhere else someone thought to make
an AddXSourceCode call, such as StandardResponse, SimpleErrorResponse, and
CustomErrorResponse.

Also updated the HTTP Auto Close feature to use a debug_http_close
config value.

Nectar now dumps the X-Source-Code header on errors as well.