### PR TITLE
HUM-220 Suppress closed pipe errors

### DIFF
--- a/proxyserver/middleware/copy.go
+++ b/proxyserver/middleware/copy.go
@@ -104,7 +104,9 @@ type PipeResponseWriter struct {
 func (w *PipeResponseWriter) Write(stuff []byte) (int, error) {
 	written, err := w.w.Write(stuff)
 	if err != nil {
-		w.Logger.Error("PipeResponseWriter Write() error", zap.Error(err))
+		if !strings.Contains(err.Error(), "closed pipe") {
+			w.Logger.Error("PipeResponseWriter Write() error", zap.Error(err))
+		}
 	}
 	return written, err
 }


### PR DESCRIPTION
No need to log every time a client drops their connection.