### PR TITLE
HUM-224 User client can't retry request on its own

### DIFF
--- a/client/userclient.go
+++ b/client/userclient.go
@@ -40,16 +40,6 @@ func (c *userClient) do(req *http.Request) *http.Response {
 	if err != nil {
 		return ResponseStub(http.StatusBadRequest, err.Error())
 	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		resp.Body.Close()
-		if aResp := c.authenticate(); aResp.StatusCode/100 != 2 {
-			return aResp
-		}
-		resp, err = c.client.Do(req)
-		if err != nil {
-			return ResponseStub(http.StatusBadRequest, err.Error())
-		}
-	}
 	return resp
 }
 


### PR DESCRIPTION
User client can't retry request on its own because the request body may
have been closed and the original caller would need to reset it, if
possible.