### PR TITLE
updater crammed into replicator

### DIFF
--- a/objectserver/backend.go
+++ b/objectserver/backend.go
@@ -49,6 +49,13 @@ func PolicyDir(policy int) string {
 	return fmt.Sprintf("objects-%d", policy)
 }
 
+func AsyncDir(policy int) string {
+	if policy == 0 {
+		return "async_pending"
+	}
+	return fmt.Sprintf("async_pending-%d", policy)
+}
+
 func UnPolicyDir(dir string) (int, error) {
 	if dir == "objects" {
 		return 0, nil

--- a/objectserver/update.go
+++ b/objectserver/update.go
@@ -40,16 +40,6 @@ import (
 const zeroByteHash = "d41d8cd98f00b204e9800998ecf8427e"
 const deleteAtAccount = ".expiring_objects"
 
-func headerToMap(headers http.Header) map[string]string {
-	ret := make(map[string]string)
-	for key, value := range headers {
-		if len(value) > 0 {
-			ret[key] = headers.Get(key)
-		}
-	}
-	return ret
-}
-
 func splitHeader(header string) []string {
 	if header == "" {
 		return []string{}
@@ -100,7 +90,7 @@ func (server *ObjectServer) saveAsync(method, account, container, obj, localDevi
 		"account":   account,
 		"container": container,
 		"obj":       obj,
-		"headers":   headerToMap(headers),
+		"headers":   common.Headers2Map(headers),
 	}
 	if os.MkdirAll(filepath.Dir(asyncFile), 0755) == nil {
 		writer, err := fs.NewAtomicFileWriter(tempDir, filepath.Dir(asyncFile))

--- a/objectserver/updater.go
+++ b/objectserver/updater.go
@@ -1,0 +1,176 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package objectserver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/troubling/hummingbird/common"
+	"github.com/troubling/hummingbird/common/fs"
+	"github.com/troubling/hummingbird/common/pickle"
+	"github.com/troubling/hummingbird/common/ring"
+)
+
+const asyncPendingSleep = 10 * time.Millisecond
+
+type asyncPending struct {
+	Headers   map[string]string `pickle:"headers"`
+	Object    string            `pickle:"obj"`
+	Account   string            `pickle:"account"`
+	Container string            `pickle:"container"`
+	Method    string            `pickle:"op"`
+}
+
+type updateDevice struct {
+	r       *Replicator
+	dev     *ring.Device
+	canchan chan struct{}
+	policy  int
+}
+
+func (ud *updateDevice) updateStat(stat string, amount int64) {
+	key := deviceKey(ud.dev, ud.policy)
+	ud.r.updateStat <- statUpdate{"object-updater", key, stat, amount}
+}
+
+func (ud *updateDevice) listAsyncs(c chan string, cancel chan struct{}) {
+	defer close(c)
+	suffixDirs, err := filepath.Glob(filepath.Join(ud.r.deviceRoot, ud.dev.Device, AsyncDir(ud.policy), "[a-f0-9][a-f0-9][a-f0-9]"))
+	if err != nil {
+		return
+	}
+	for i := len(suffixDirs) - 1; i > 0; i-- { // shuffle suffixDirs list
+		j := rand.Intn(i + 1)
+		suffixDirs[j], suffixDirs[i] = suffixDirs[i], suffixDirs[j]
+	}
+	for _, suffDir := range suffixDirs {
+		asyncs, err := fs.ReadDirNames(suffDir)
+		if err != nil {
+			return
+		}
+		for _, async := range asyncs {
+			select {
+			case c <- filepath.Join(suffDir, async):
+			case <-cancel:
+				return
+			}
+		}
+	}
+}
+
+func (ud *updateDevice) updateContainers(ap *asyncPending) bool {
+	allSuccess := true
+	part := ud.r.containerRing.GetPartition(ap.Account, ap.Container, "")
+	header := common.Map2Headers(ap.Headers)
+	for _, node := range ud.r.containerRing.GetNodes(part) {
+		objUrl := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s/%s", node.Ip, node.Port, node.Device, part,
+			common.Urlencode(ap.Account), common.Urlencode(ap.Container), common.Urlencode(ap.Object))
+		req, err := http.NewRequest(ap.Method, objUrl, nil)
+		if err != nil {
+			allSuccess = false
+			ud.r.logger.Error("updateContainers creating new request", zap.Error(err))
+			continue
+		}
+		req.Header = header
+		resp, err := ud.r.client.Do(req)
+		if err != nil {
+			allSuccess = false
+			continue
+		}
+		resp.Body.Close()
+		allSuccess = allSuccess && resp.StatusCode/100 == 2
+	}
+	return allSuccess
+}
+
+func (ud *updateDevice) processAsync(async string) {
+	data, err := ioutil.ReadFile(async)
+	if err != nil {
+		ud.updateStat("Error", 1)
+		ud.r.logger.Error("read async_pending fail", zap.String("file", async), zap.Error(err))
+		return
+	}
+	var ap asyncPending
+	if err := pickle.Unmarshal(data, &ap); err != nil {
+		ud.updateStat("Error", 1)
+		ud.r.logger.Error("unmarshal async_pending fail", zap.String("file", async), zap.Error(err))
+		return
+	}
+	if ud.updateContainers(&ap) {
+		ud.updateStat("Success", 1)
+		os.Remove(async)
+	} else {
+		ud.updateStat("Failure", 1)
+	}
+}
+
+func (ud *updateDevice) update() {
+	ud.updateStat("startRun", 1)
+	c := make(chan string, 100)
+	cancel := make(chan struct{})
+	defer close(cancel)
+	go ud.listAsyncs(c, cancel)
+	for async := range c {
+		ud.updateStat("checkin", 1)
+		func() {
+			ud.r.updateConcurrencySem <- struct{}{}
+			defer func() {
+				<-ud.r.updateConcurrencySem
+			}()
+			ud.processAsync(async)
+		}()
+		select {
+		case <-time.After(asyncPendingSleep):
+		case <-ud.canchan:
+			return
+		}
+	}
+	ud.updateStat("PassComplete", 1)
+}
+
+func (ud *updateDevice) updateLoop() {
+	for {
+		select {
+		case <-ud.canchan:
+			return
+		default:
+			ud.update()
+		}
+		time.Sleep(replicateLoopSleepTime)
+		ud.updateStat("checkin", 1)
+	}
+}
+
+func (ud *updateDevice) cancel() {
+	close(ud.canchan)
+}
+
+func newUpdateDevice(dev *ring.Device, policy int, r *Replicator) *updateDevice {
+	return &updateDevice{
+		policy:  policy,
+		dev:     dev,
+		r:       r,
+		canchan: make(chan struct{}),
+	}
+}

--- a/objectserver/updater.go
+++ b/objectserver/updater.go
@@ -83,6 +83,7 @@ func (ud *updateDevice) updateContainers(ap *asyncPending) bool {
 	allSuccess := true
 	part := ud.r.containerRing.GetPartition(ap.Account, ap.Container, "")
 	header := common.Map2Headers(ap.Headers)
+	header.Set("User-Agent", fmt.Sprintf("object-updater %d", os.Getpid()))
 	for _, node := range ud.r.containerRing.GetNodes(part) {
 		objUrl := fmt.Sprintf("http://%s:%d/%s/%d/%s/%s/%s", node.Ip, node.Port, node.Device, part,
 			common.Urlencode(ap.Account), common.Urlencode(ap.Container), common.Urlencode(ap.Object))

--- a/objectserver/updater.go
+++ b/objectserver/updater.go
@@ -121,6 +121,7 @@ func (ud *updateDevice) processAsync(async string) {
 	if ud.updateContainers(&ap) {
 		ud.updateStat("Success", 1)
 		os.Remove(async)
+		os.Remove(filepath.Dir(async))
 	} else {
 		ud.updateStat("Failure", 1)
 	}

--- a/objectserver/updater_test.go
+++ b/objectserver/updater_test.go
@@ -1,0 +1,103 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package objectserver
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/troubling/hummingbird/common/pickle"
+	"github.com/troubling/hummingbird/common/ring"
+	"github.com/troubling/hummingbird/common/test"
+)
+
+func TestUpdaterListAsyncs(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(dir)
+	for policy := 0; policy < 3; policy++ {
+		require.Nil(t, os.MkdirAll(filepath.Join(dir, "sda", AsyncDir(policy), "abc"), 0755))
+		require.Nil(t, os.MkdirAll(filepath.Join(dir, "sda", AsyncDir(policy), "def"), 0755))
+		f, err := os.Create(filepath.Join(dir, "sda", AsyncDir(policy), "abc", "d41d8cd98f00b204e9800998ecf8427e-1222222222.12345"))
+		require.Nil(t, err)
+		f.Close()
+		f, err = os.Create(filepath.Join(dir, "sda", AsyncDir(policy), "def", "49f68a5c8493ec2c0bf489821c21fc3b-1333333333.12345"))
+		require.Nil(t, err)
+		f.Close()
+	}
+
+	r := &Replicator{deviceRoot: dir}
+	dev := &ring.Device{Device: "sda"}
+	for policy := 0; policy < 3; policy++ {
+		u := newUpdateDevice(dev, 0, r)
+		c := make(chan string)
+		cancel := make(chan struct{})
+		defer close(cancel)
+		go u.listAsyncs(c, cancel)
+		files := make(map[string]bool)
+		for file := range c {
+			files[filepath.Base(file)] = true
+		}
+		require.Equal(t, 2, len(files))
+		require.True(t, files["d41d8cd98f00b204e9800998ecf8427e-1222222222.12345"])
+		require.True(t, files["49f68a5c8493ec2c0bf489821c21fc3b-1333333333.12345"])
+	}
+}
+
+func TestUpdaterProcessAsync(t *testing.T) {
+	// make an async pending file
+	ap := asyncPending{Headers: map[string]string{"Content-Type": "text/plain"}, Object: "o", Account: "a", Container: "c", Method: "PUT"}
+	f, err := ioutil.TempFile("", "")
+	require.Nil(t, err)
+	defer os.RemoveAll(f.Name())
+	f.Write(pickle.PickleDumps(&ap))
+	f.Close()
+
+	// make a container server
+	requestedPaths := make(map[string]bool)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths[r.URL.Path] = true
+		require.Equal(t, "text/plain", r.Header.Get("Content-Type"))
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	require.Nil(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.Nil(t, err)
+
+	fakering := &test.FakeRing{
+		MockDevices: []*ring.Device{
+			{Ip: u.Hostname(), Port: port, Device: "sda"},
+			{Ip: u.Hostname(), Port: port, Device: "sdb"},
+			{Ip: u.Hostname(), Port: port, Device: "sdc"},
+		},
+	}
+	r := &Replicator{updateStat: make(chan statUpdate, 100), client: http.DefaultClient, containerRing: fakering}
+	dev := &ring.Device{Device: "sda"}
+	updater := newUpdateDevice(dev, 0, r)
+
+	updater.processAsync(f.Name())
+	require.True(t, requestedPaths["/sda/0/a/c/o"])
+	require.True(t, requestedPaths["/sdb/0/a/c/o"])
+	require.True(t, requestedPaths["/sdc/0/a/c/o"])
+}

--- a/probe/base.go
+++ b/probe/base.go
@@ -202,8 +202,6 @@ func NewEnvironment(settings ...string) *Environment {
 		if err != nil {
 			log.Fatal(err)
 		}
-		replicator.(*objectserver.Replicator).Rings[0] = env.ring
-		replicator.(*objectserver.Replicator).Rings[1] = env.ring
 		trs.Config.Handler = replicator.(*objectserver.Replicator).GetHandler()
 
 		replicatorServer := &TestReplicatorWebServer{Server: trs, host: host, port: port, root: driveRoot, replicator: replicator.(*objectserver.Replicator)}


### PR DESCRIPTION
I mean, I've tried to make it not too horrible.
The workers are sort of converging on a shared interface.

Also some replicator cleanup.

Remove ms_per_part setting.  Permanently set that to 10 ms.
Make replication_limit only settable per-device, not globally.
People have already screwed around with those two settings without
understanding them.
Get stats out of replication device struct and into the replicator.
Some other cleanup - un-exporting things if they don't need it.