### PR TITLE
HUM-246 Fix a bug in authtoken middleware

### DIFF
--- a/proxyserver/middleware/authtoken.go
+++ b/proxyserver/middleware/authtoken.go
@@ -183,14 +183,13 @@ func (at *authToken) fetchAndValidateToken(ctx *ProxyContext, authToken string) 
 		return nil, false
 	}
 	var tok *token
+	var cachedToken token
 	tokenValid := false
-	if cachedToken, err := ctx.Cache.Get(authToken); err == nil {
+	if err := ctx.Cache.GetStructured(authToken, &cachedToken); err == nil {
 		ctx.Logger.Debug("Found cache token",
 			zap.String("token", authToken))
-		if t, ok := cachedToken.(token); ok {
-			tok = &t
-			tokenValid = true
-		}
+		tokenValid = true
+		tok = &cachedToken
 	}
 
 	if tok == nil {

--- a/proxyserver/middleware/keystoneauth.go
+++ b/proxyserver/middleware/keystoneauth.go
@@ -224,16 +224,16 @@ func (ka *keystoneAuth) authorize(r *http.Request) (bool, int) {
 		}
 	}
 	/* Copying this truth table from swift.
-        # Compare roles from tokens against the configuration options:
-        #
-        # X-Auth-Token role  Has specified  X-Service-Token role  Grant
-        # in operator_roles? service_roles? in service_roles?     swift_owner?
-        # ------------------ -------------- --------------------  ------------
-        # yes                yes            yes                   yes
-        # yes                yes            no                    no
-        # yes                no             don't care            yes
-        # no                 don't care     don't care            no
-        # ------------------ -------------- --------------------  ------------
+	   # Compare roles from tokens against the configuration options:
+	   #
+	   # X-Auth-Token role  Has specified  X-Service-Token role  Grant
+	   # in operator_roles? service_roles? in service_roles?     swift_owner?
+	   # ------------------ -------------- --------------------  ------------
+	   # yes                yes            yes                   yes
+	   # yes                yes            no                    no
+	   # yes                no             don't care            yes
+	   # no                 don't care     don't care            no
+	   # ------------------ -------------- --------------------  ------------
 	*/
 	allowed := false
 	if haveOperatorRole && (len(serviceRoles) > 0 && haveServiceRole) {


### PR DESCRIPTION
Use memcache GetStructured instead of Get in authtoken.
Now Keystone test is quite fast.