### PR TITLE
HUM-288 debugging stack traces in headers

### DIFF
--- a/accountserver/server.go
+++ b/accountserver/server.go
@@ -505,7 +505,13 @@ func (server *AccountServer) GetHandler(config conf.Config, metricsPrefix string
 		CachedReporter: promreporter.NewReporter(promreporter.Options{}),
 		Separator:      promreporter.DefaultSeparator,
 	}, time.Second)
-	commonHandlers := alice.New(server.LogRequest, middleware.RecoverHandler, middleware.ValidateRequest, server.AcquireDevice)
+	commonHandlers := alice.New(
+		middleware.NewDebugResponses(config.GetBool("debug", "debug_x_source_code", false)),
+		server.LogRequest,
+		middleware.RecoverHandler,
+		middleware.ValidateRequest,
+		server.AcquireDevice,
+	)
 	router := srv.NewRouter()
 	router.Get("/metrics", prometheus.Handler())
 	router.Get("/loglevel", server.logLevel)

--- a/containerserver/server.go
+++ b/containerserver/server.go
@@ -586,7 +586,13 @@ func (server *ContainerServer) GetHandler(config conf.Config, metricsPrefix stri
 		CachedReporter: promreporter.NewReporter(promreporter.Options{}),
 		Separator:      promreporter.DefaultSeparator,
 	}, time.Second)
-	commonHandlers := alice.New(server.LogRequest, middleware.RecoverHandler, middleware.ValidateRequest, server.AcquireDevice)
+	commonHandlers := alice.New(
+		middleware.NewDebugResponses(config.GetBool("debug", "debug_x_source_code", false)),
+		server.LogRequest,
+		middleware.RecoverHandler,
+		middleware.ValidateRequest,
+		server.AcquireDevice,
+	)
 	router := srv.NewRouter()
 	router.Get("/metrics", prometheus.Handler())
 	router.Get("/loglevel", server.logLevel)

--- a/middleware/dbgheader.go
+++ b/middleware/dbgheader.go
@@ -1,0 +1,39 @@
+//  Copyright (c) 2017 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"runtime"
+
+	"github.com/troubling/hummingbird/common/srv"
+)
+
+func NewDebugResponses(debugHeader bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if debugHeader {
+			return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				next.ServeHTTP(srv.NewCustomWriter(writer, func(w http.ResponseWriter, status int) int {
+					buf := make([]byte, 1024)
+					runtime.Stack(buf, false)
+					w.Header().Set("X-Source-Code", string(buf))
+					return status
+				}), request)
+			})
+		}
+		return next
+	}
+}

--- a/objectserver/main.go
+++ b/objectserver/main.go
@@ -607,7 +607,13 @@ func (server *ObjectServer) GetHandler(config conf.Config, metricsPrefix string)
 		CachedReporter: promreporter.NewReporter(promreporter.Options{}),
 		Separator:      promreporter.DefaultSeparator,
 	}, time.Second)
-	commonHandlers := alice.New(server.LogRequest, middleware.RecoverHandler, middleware.ValidateRequest, server.AcquireDevice)
+	commonHandlers := alice.New(
+		middleware.NewDebugResponses(config.GetBool("debug", "debug_x_source_code", false)),
+		server.LogRequest,
+		middleware.RecoverHandler,
+		middleware.ValidateRequest,
+		server.AcquireDevice,
+	)
 	router := srv.NewRouter()
 	router.Get("/metrics", prometheus.Handler())
 	router.Get("/loglevel", server.logLevel)

--- a/proxyserver/main.go
+++ b/proxyserver/main.go
@@ -149,7 +149,8 @@ func (server *ProxyServer) GetHandler(config conf.Config, metricsPrefix string) 
 			{middleware.NewXlo, "filter:slo"},
 		}
 	}
-	pipeline := alice.New(middleware.NewContext(server.mc, server.logger, server.proxyDirectClient))
+	pipeline := alice.New(middleware.NewContext(config.GetBool("debug", "debug_x_source_code", false),
+		server.mc, server.logger, server.proxyDirectClient))
 	for _, m := range middlewares {
 		mid, err := m.construct(config.GetSection(m.section), metricsScope)
 		if err != nil {

--- a/proxyserver/middleware/context.go
+++ b/proxyserver/middleware/context.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -74,6 +75,7 @@ type ProxyContextMiddleware struct {
 	log               srv.LowLevelLogger
 	Cache             ring.MemcacheRing
 	proxyDirectClient *client.ProxyDirectClient
+	debugResponses    bool
 }
 
 type ProxyContext struct {
@@ -345,6 +347,13 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 				w.Header().Set("Www-Authenticate", "Swift realm=\"unknown\"")
 			}
 		}
+
+		if m.debugResponses {
+			buf := make([]byte, 1024)
+			runtime.Stack(buf, false)
+			w.Header().Set("X-Source-Code", string(buf))
+		}
+
 		ctx.responseSent = true
 		ctx.status = status
 		return status
@@ -353,13 +362,14 @@ func (m *ProxyContextMiddleware) ServeHTTP(writer http.ResponseWriter, request *
 	m.next.ServeHTTP(newWriter, request)
 }
 
-func NewContext(mc ring.MemcacheRing, log srv.LowLevelLogger, proxyDirectClient *client.ProxyDirectClient) func(http.Handler) http.Handler {
+func NewContext(debugResponses bool, mc ring.MemcacheRing, log srv.LowLevelLogger, proxyDirectClient *client.ProxyDirectClient) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return &ProxyContextMiddleware{
 			Cache:             mc,
 			log:               log,
 			next:              next,
 			proxyDirectClient: proxyDirectClient,
+			debugResponses:    debugResponses,
 		}
 	}
 }


### PR DESCRIPTION
Support for a new config option in proxy, object, container and
account servers,

    [debug]
    debug_x_source_code = true

This causes the server to add an X-Source-Code header to the
response, containing the stack trace at the point where
WriteHeader was called.  This should be useful in tracking down
which code generates an unexpected response.