### PR TITLE
increase more idle conn limits

### DIFF
--- a/client/directclient.go
+++ b/client/directclient.go
@@ -45,7 +45,10 @@ type ProxyDirectClient struct {
 
 func NewProxyDirectClient(policyList conf.PolicyList) (*ProxyDirectClient, error) {
 	var xport http.RoundTripper = &http.Transport{
-		DisableCompression: true,
+		MaxIdleConnsPerHost: 100,
+		MaxIdleConns:        0,
+		IdleConnTimeout:     5 * time.Second,
+		DisableCompression:  true,
 		Dial: (&net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 5 * time.Second,

--- a/containerserver/server.go
+++ b/containerserver/server.go
@@ -650,8 +650,14 @@ func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bind
 	connTimeout := time.Duration(serverconf.GetFloat("app:container-server", "conn_timeout", 1.0) * float64(time.Second))
 	nodeTimeout := time.Duration(serverconf.GetFloat("app:container-server", "node_timeout", 10.0) * float64(time.Second))
 	server.updateClient = &http.Client{
-		Timeout:   nodeTimeout,
-		Transport: &http.Transport{Dial: (&net.Dialer{Timeout: connTimeout}).Dial},
+		Timeout: nodeTimeout,
+		Transport: &http.Transport{
+			Dial:                (&net.Dialer{Timeout: connTimeout}).Dial,
+			MaxIdleConnsPerHost: 100,
+			MaxIdleConns:        0,
+			IdleConnTimeout:     5 * time.Second,
+			DisableCompression:  true,
+		},
 	}
 	return bindIP, bindPort, server, server.logger, nil
 }

--- a/objectserver/main.go
+++ b/objectserver/main.go
@@ -687,8 +687,14 @@ func GetServer(serverconf conf.Config, flags *flag.FlagSet) (bindIP string, bind
 	connTimeout := time.Duration(serverconf.GetFloat("app:object-server", "conn_timeout", 1.0) * float64(time.Second))
 	nodeTimeout := time.Duration(serverconf.GetFloat("app:object-server", "node_timeout", 10.0) * float64(time.Second))
 	server.updateClient = &http.Client{
-		Timeout:   nodeTimeout,
-		Transport: &http.Transport{Dial: (&net.Dialer{Timeout: connTimeout}).Dial},
+		Timeout: nodeTimeout,
+		Transport: &http.Transport{
+			Dial:                (&net.Dialer{Timeout: connTimeout}).Dial,
+			MaxIdleConnsPerHost: 100,
+			MaxIdleConns:        0,
+			IdleConnTimeout:     5 * time.Second,
+			DisableCompression:  true,
+		},
 	}
 
 	deviceLockUpdateSeconds := serverconf.GetInt("app:object-server", "device_lock_update_seconds", 0)


### PR DESCRIPTION
Bump MaxIdleConnsPerHost in some clients that get a lot of use.
Make sure MaxIdleConns is 0 everywhere.
Make the idle connection timeout more aggressive (5 seconds).

This should make us put fewer proxy->object and object->container
connections into time_wait when doing a lot of concurrency, but
idle conns will also be reaped more quickly once they're unused.