### PR TITLE
HUM-264: allow policies to register web handlers

### DIFF
--- a/objectserver/ec/engine.go
+++ b/objectserver/ec/engine.go
@@ -20,10 +20,12 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net/http"
 	"strconv"
 	"sync"
 
 	"github.com/troubling/hummingbird/common/conf"
+	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/objectserver"
 )
 
@@ -112,6 +114,25 @@ func (f *ecEngine) New(vars map[string]string, needData bool, asyncWG *sync.Wait
 	return sor, nil
 }
 
+func (f *ecEngine) ecFragGetHandler(writer http.ResponseWriter, request *http.Request) {
+	// vars := srv.GetVars(request)
+	srv.StandardResponse(writer, http.StatusNotImplemented)
+}
+
+func (f *ecEngine) ecFragPutHandler(writer http.ResponseWriter, request *http.Request) {
+	srv.StandardResponse(writer, http.StatusNotImplemented)
+}
+
+func (f *ecEngine) ecFragDeleteHandler(writer http.ResponseWriter, request *http.Request) {
+	srv.StandardResponse(writer, http.StatusNotImplemented)
+}
+
+func (f *ecEngine) RegisterHandlers(addRoute func(method, path string, handler http.HandlerFunc)) {
+	addRoute("GET", "/ec-frag/:device/:hash", f.ecFragGetHandler)
+	addRoute("PUT", "/ec-frag/:device/:hash", f.ecFragPutHandler)
+	addRoute("DELETE", "/ec-frag/:device/:hash", f.ecFragDeleteHandler)
+}
+
 // ecEngineConstructor creates a ecEngine given the object server configs.
 func ecEngineConstructor(config conf.Config, policy *conf.Policy, flags *flag.FlagSet) (objectserver.ObjectEngine, error) {
 	driveRoot := config.GetDefault("app:object-server", "devices", "/srv/node")
@@ -136,3 +157,4 @@ func init() {
 var _ objectserver.ObjectEngineConstructor = ecEngineConstructor
 var _ objectserver.Object = &ecObject{}
 var _ objectserver.ObjectEngine = &ecEngine{}
+var _ objectserver.PolicyHandlerRegistrator = &ecEngine{}

--- a/objectserver/objengine.go
+++ b/objectserver/objengine.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net/http"
 	"sync"
 
 	"github.com/troubling/hummingbird/common/conf"
@@ -58,6 +59,10 @@ type Object interface {
 type ObjectEngine interface {
 	// New creates a new instance of the Object, for interacting with a single object.
 	New(vars map[string]string, needData bool, asyncWG *sync.WaitGroup) (Object, error)
+}
+
+type PolicyHandlerRegistrator interface {
+	RegisterHandlers(addRoute func(method, path string, handler http.HandlerFunc))
 }
 
 // ObjectEngineConstructor> is a function that, given configs and flags, returns an ObjectEngine


### PR DESCRIPTION
Policies might need to handle requests aside from the pre-allowed ones
(e.g. EC chunk GETs).  This lets obj engines optionally register http
handlers and creates some dummy ones for EC.