### PR TITLE
proxy client and container info cache

### DIFF
--- a/proxyserver/containerhandlers_test.go
+++ b/proxyserver/containerhandlers_test.go
@@ -37,7 +37,7 @@ func TestOptionsHandler(t *testing.T) {
 
 	r := httptest.NewRequest("OPTIONS", "/v1/a/c/o", nil)
 	ctx := &middleware.ProxyContext{
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{"Access-Control-Allow-Origin": "there.com"}},
 		}),
 	}
@@ -73,7 +73,7 @@ func TestOptionsHandlerStar(t *testing.T) {
 
 	r := httptest.NewRequest("OPTIONS", "/v1/a/c/o", nil)
 	ctx := &middleware.ProxyContext{
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{"Access-Control-Allow-Origin": "*"}},
 		}),
 	}
@@ -96,7 +96,7 @@ func TestOptionsHandlerNotSetup(t *testing.T) {
 
 	r := httptest.NewRequest("OPTIONS", "/v1/a/c/o", nil)
 	ctx := &middleware.ProxyContext{
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{}},
 		}),
 	}

--- a/proxyserver/middleware/formpost_test.go
+++ b/proxyserver/middleware/formpost_test.go
@@ -46,7 +46,7 @@ func makeFormpostRequest(t *testing.T, body, boundary string, next http.Handler)
 	neww := httptest.NewRecorder()
 	ctx := &ProxyContext{
 		Logger: zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/AUTH_test/container": {Metadata: map[string]string{"Temp-Url-Key": "mykey"}},
 		}),
 		accountInfoCache: map[string]*AccountInfo{
@@ -164,7 +164,7 @@ func TestFpLimitReader(t *testing.T) {
 func TestAuthenticateFormpost(t *testing.T) {
 	ctx := &ProxyContext{
 		Logger: zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{
 				"Temp-Url-Key":   "containerkey",
 				"Temp-Url-Key-2": "containerkey2",

--- a/proxyserver/middleware/staticweb_test.go
+++ b/proxyserver/middleware/staticweb_test.go
@@ -104,7 +104,7 @@ func TestStaticWebGetObject(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C:                      client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{"Web-Index": "index.html"}}}),
+		C:                      client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{"Web-Index": "index.html"}}}),
 		accountInfoCache:       map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
 	}))
 	rec := httptest.NewRecorder()
@@ -144,7 +144,7 @@ func TestStaticWebGetObjectNotThere(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -183,7 +183,7 @@ func TestStaticWebGetSubdirRedirect(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -226,7 +226,7 @@ func TestStaticWebGetSubdir(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -277,7 +277,7 @@ func TestStaticWebGetContainerRedirect(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -310,7 +310,7 @@ func TestStaticWebGetContainer(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -355,7 +355,7 @@ func TestStaticWebGetWithWebIndex(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 			"Web-Index":    "index.html",
 		}}}),
@@ -401,7 +401,7 @@ func TestStaticWebGetSubdirWithWebIndex(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 			"Web-Index":    "index.html",
 		}}}),
@@ -451,7 +451,7 @@ func TestStaticWebGetSubdirWithWebIndexRedirect(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 			"Web-Index":    "index.html",
 		}}}),
@@ -489,7 +489,7 @@ func TestStaticWebGetContainerNoListings(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Index": "notfound",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -532,7 +532,7 @@ func TestStaticWebGetContainerCustomCSS(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings":     "true",
 			"Web-Listings-Css": "listings.css",
 		}}}),
@@ -574,7 +574,7 @@ func TestStaticWebGetContainerCustomCSS(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Listings": "true",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -617,7 +617,7 @@ func TestStaticWebCustomErrorPages(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Error": "error.html",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -662,7 +662,7 @@ func TestStaticWebCustomErrorPages(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c": {Metadata: map[string]string{
 			"Web-Error": "error.html",
 		}}}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -707,7 +707,7 @@ func TestStaticWebNoContainerInfo(t *testing.T) {
 	request = request.WithContext(context.WithValue(request.Context(), "proxycontext", &ProxyContext{
 		ProxyContextMiddleware: &ProxyContextMiddleware{next: s},
 		Logger:                 zap.NewNop(),
-		C:                      client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{"container/a/c2": client.NilContainerInfo}),
+		C:                      client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{"container/a/c2": client.NilContainerInfo}),
 		accountInfoCache:       map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
 	}))
 	rec := httptest.NewRecorder()

--- a/proxyserver/middleware/tempurl_test.go
+++ b/proxyserver/middleware/tempurl_test.go
@@ -195,7 +195,7 @@ func TestTempurlMiddleware400PuttingManifest(t *testing.T) {
 func TestTempurlMiddleware401NoKeys(t *testing.T) {
 	r := httptest.NewRequest("PUT", "/v1/a/c/o?temp_url_sig=ABCDEF&temp_url_expires=9999999999", nil)
 	ctx := &ProxyContext{
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{}},
 		}),
 		accountInfoCache: map[string]*AccountInfo{
@@ -213,7 +213,7 @@ func TestTempurlMiddleware401NoKeys(t *testing.T) {
 func TestTempurlMiddleware401WrongKeys(t *testing.T) {
 	r := httptest.NewRequest("PUT", "/v1/a/c/o?temp_url_sig=ABCDEF&temp_url_expires=9999999999", nil)
 	ctx := &ProxyContext{
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{"Temp-Url-Key": "ABCD", "Temp-Url-Key-2": "012345"}},
 		}),
 		accountInfoCache: map[string]*AccountInfo{
@@ -232,7 +232,7 @@ func TestTempurlMiddlewareContainerKey(t *testing.T) {
 	r := httptest.NewRequest("GET", "/v1/a/c/o?temp_url_sig=f2d61be897a27c03ac9a0dac3a8c4f6ce3a3d623&"+
 		"temp_url_expires=9999999999", nil)
 	ctx := &ProxyContext{
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{"Temp-Url-Key": "mykey"}},
 		}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -261,7 +261,7 @@ func TestTempurlMiddlewarePath(t *testing.T) {
 	r := httptest.NewRequest("GET", "/v1/a/c/o123?temp_url_sig=058e0771c69f7e1eb1eacbd68396920fd06ff261&"+
 		"temp_url_expires=9999999999&temp_url_prefix=o", nil)
 	ctx := &ProxyContext{
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{"Temp-Url-Key": "mykey"}},
 		}),
 		accountInfoCache: map[string]*AccountInfo{"account/a": {Metadata: map[string]string{}}},
@@ -284,7 +284,7 @@ func TestTempurlMiddlewareAccountKey(t *testing.T) {
 	r := httptest.NewRequest("GET", "/v1/a/c/o?temp_url_sig=f2d61be897a27c03ac9a0dac3a8c4f6ce3a3d623&"+
 		"temp_url_expires=9999999999", nil)
 	ctx := &ProxyContext{
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {Metadata: map[string]string{}},
 		}),
 		accountInfoCache: map[string]*AccountInfo{

--- a/proxyserver/middleware/versioned_writes_test.go
+++ b/proxyserver/middleware/versioned_writes_test.go
@@ -76,7 +76,7 @@ func TestObjectPutHistory(t *testing.T) {
 			next: next,
 		},
 		Logger: zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {
 				SysMetadata: map[string]string{
 					"Versions-Location": "c_v",
@@ -133,7 +133,7 @@ func TestObjectDeleteHistory(t *testing.T) {
 			next: next,
 		},
 		Logger: zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {
 				SysMetadata: map[string]string{
 					"Versions-Location": "c_v",
@@ -197,7 +197,7 @@ func TestObjectDeleteStack(t *testing.T) {
 			next: next,
 		},
 		Logger: zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {
 				SysMetadata: map[string]string{
 					"Versions-Location": "c_v",
@@ -262,7 +262,7 @@ func TestObjectDeleteStackMarker(t *testing.T) {
 			next: next,
 		},
 		Logger: zap.NewNop(),
-		C: client.NewProxyClient(nil, nil, map[string]*client.ContainerInfo{
+		C: client.NewProxyClient(&client.ProxyDirectClient{}, nil, map[string]*client.ContainerInfo{
 			"container/a/c": {
 				SysMetadata: map[string]string{
 					"Versions-Location": "c_v",


### PR DESCRIPTION
The proxy client never re-uses container info.  There's a place to
cache it, and it's checked, but it's never set.  This means that the
container info can be fetched from memcache 4 or 5 times per request.

I also took the opportunity to rework things so we don't create
new proxy object clients for every operation.  They are created once,
when the proxy client is created.