### PR TITLE
HUM-390: ec ephemeral port usage and nil crash

### DIFF
--- a/objectserver/ec/obj.go
+++ b/objectserver/ec/obj.go
@@ -112,7 +112,10 @@ func (o *ecObject) Copy(dsts ...io.Writer) (written int64, err error) {
 		if err != nil {
 			continue
 		}
-		defer resp.Body.Close()
+		defer func() {
+			io.Copy(ioutil.Discard, resp.Body)
+			resp.Body.Close()
+		}()
 		if resp.StatusCode != http.StatusOK {
 			continue
 		}


### PR DESCRIPTION
Fix a couple of show stopper bugs in the initial EC code.

Ephemeral ports are being exhausted by runaway time-waits, hopefully
mitigated by increasing the max idle conns setting (like we've had to
do everywhere).  Also fixing one spot where I failed to discard a
response body, so the connection couldn't be reused.

A nil crash cauesd by ecSplit modifying the slice it was given as an
argument and the caller not expecting that.