### PR TITLE
HUM-412: lock hashdir during db creation

### DIFF
--- a/accountserver/sqlite_backend.go
+++ b/accountserver/sqlite_backend.go
@@ -927,18 +927,26 @@ func sqliteCreateAccount(accountFile string, account string, putTimestamp string
 	var serializedMetadata []byte
 	var err error
 
+	hashDir := filepath.Dir(accountFile)
+	if err := os.MkdirAll(hashDir, 0755); err != nil {
+		return err
+	}
+	lock, err := fs.LockPath(filepath.Dir(hashDir), 10*time.Second)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+
 	if fs.Exists(accountFile) {
 		return errors.New("Account exists!")
 	}
+
 	if metadata == nil {
 		serializedMetadata = []byte("{}")
 	} else if serializedMetadata, err = json.Marshal(metadata); err != nil {
 		return err
 	}
-	hashDir := filepath.Dir(accountFile)
-	if err := os.MkdirAll(hashDir, 0755); err != nil {
-		return err
-	}
+
 	tfp, err := ioutil.TempFile(hashDir, ".newdb")
 	if err != nil {
 		return err

--- a/containerserver/sqlite_backend.go
+++ b/containerserver/sqlite_backend.go
@@ -957,18 +957,26 @@ func sqliteCreateContainer(containerFile string, account string, container strin
 	var serializedMetadata []byte
 	var err error
 
+	hashDir := filepath.Dir(containerFile)
+	if err := os.MkdirAll(hashDir, 0755); err != nil {
+		return err
+	}
+	lock, err := fs.LockPath(filepath.Dir(hashDir), 10*time.Second)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+
 	if fs.Exists(containerFile) {
 		return errors.New("Container exists!")
 	}
+
 	if metadata == nil {
 		serializedMetadata = []byte("{}")
 	} else if serializedMetadata, err = json.Marshal(metadata); err != nil {
 		return err
 	}
-	hashDir := filepath.Dir(containerFile)
-	if err := os.MkdirAll(hashDir, 0755); err != nil {
-		return err
-	}
+
 	tfp, err := ioutil.TempFile(hashDir, ".newdb")
 	if err != nil {
 		return err


### PR DESCRIPTION
That code looked racy and it's kind of the only place we do anything
weird with sqlite, so lock down the whole hashdir during db creation
to see if serializing that fixes it.