### PR TITLE
HUM-497 customWriter should be a hijacker for replicators

### DIFF
--- a/common/srv/server.go
+++ b/common/srv/server.go
@@ -92,6 +92,10 @@ func (w *customWriter) WriteHeader(status int) {
 	w.ResponseWriter.WriteHeader(w.f(w.ResponseWriter, status))
 }
 
+func (w *customWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ResponseWriter.(http.Hijacker).Hijack()
+}
+
 // NewCustomWriter creates an http.ResponseWriter wrapper that calls your function on WriteHeader.
 func NewCustomWriter(w http.ResponseWriter, f func(w http.ResponseWriter, status int) int) http.ResponseWriter {
 	return &customWriter{ResponseWriter: w, f: f}


### PR DESCRIPTION
When debug_x_source_code is enabled, the replicator panics all over the place. Change customWriter to a http hijacker.