### PR TITLE
HUM-496: fix 404 on missing shard 0

### DIFF
--- a/objectserver/ec/engine.go
+++ b/objectserver/ec/engine.go
@@ -102,7 +102,7 @@ func (f *ecEngine) New(vars map[string]string, needData bool, asyncWG *sync.Wait
 	}
 	if idb, err := f.getDB(vars["device"]); err == nil {
 		obj.idb = idb
-		if item, err := idb.Lookup(hash, 0, false); err == nil && item != nil {
+		if item, err := idb.Lookup(hash, shardAny, false); err == nil && item != nil {
 			obj.IndexDBItem = *item
 			if err = json.Unmarshal(item.Metabytes, &obj.metadata); err != nil {
 				return nil, fmt.Errorf("Error parsing metadata: %v", err)


### PR DESCRIPTION
Have the object server look for any local version when instantiating
existing ec objects.  This should fix several places that we get
unexpected 404s after stabilization.