### PR TITLE
HUM-518 Andrewd Quarantine Repairman

### DIFF
--- a/common/ring/ring.go
+++ b/common/ring/ring.go
@@ -43,6 +43,7 @@ type Ring interface {
 	GetMoreNodes(partition uint64) MoreNodes
 	ReplicaCount() (cnt uint64)
 	PartitionCount() (cnt uint64)
+	PartitionForHash(hsh uint64) uint64
 }
 
 type MoreNodes interface {
@@ -149,6 +150,10 @@ func (r *hashRing) GetPartition(account string, container string, object string)
 	// treat as big endian unsigned int
 	val := uint64(digest[0])<<24 | uint64(digest[1])<<16 | uint64(digest[2])<<8 | uint64(digest[3])
 	return val >> d.PartShift
+}
+
+func (r *hashRing) PartitionForHash(hsh uint64) uint64 {
+	return hsh >> r.getData().PartShift
 }
 
 func (r *hashRing) LocalDevices(localPort int) (devs []*Device, err error) {

--- a/common/test/test.go
+++ b/common/test/test.go
@@ -98,6 +98,10 @@ func (r *FakeRing) GetPartition(account string, container string, object string)
 	return 0
 }
 
+func (r *FakeRing) PartitionForHash(hsh uint64) uint64 {
+	return 0
+}
+
 func (r *FakeRing) LocalDevices(localPort int) (devs []*ring.Device, err error) {
 	if len(r.MockDevices) > 0 {
 		for _, d := range r.MockDevices {

--- a/middleware/recon_test.go
+++ b/middleware/recon_test.go
@@ -203,12 +203,16 @@ func TestQuarantineDetail(t *testing.T) {
 		t.Fatal(len(jsonMap))
 	}
 
-	accounts := jsonMap["accounts"].([]interface{})
-	if len(accounts) != 2 {
+	accounts := jsonMap["accounts"].(map[string]interface{})
+	if len(accounts) != 1 {
 		t.Fatal(len(accounts))
 	}
+	devAccounts := accounts["sdb4"].([]interface{})
+	if len(devAccounts) != 2 {
+		t.Fatal(len(devAccounts))
+	}
 	pathToItem := map[string]string{}
-	for _, account := range accounts {
+	for _, account := range devAccounts {
 		accountMap := account.(map[string]interface{})
 		pathToItem[accountMap["NameOnDevice"].(string)] = accountMap["NameInURL"].(string)
 	}
@@ -219,12 +223,16 @@ func TestQuarantineDetail(t *testing.T) {
 		t.Fatal(ok, v)
 	}
 
-	containers := jsonMap["containers"].([]interface{})
-	if len(containers) != 2 {
+	containers := jsonMap["containers"].(map[string]interface{})
+	if len(containers) != 1 {
 		t.Fatal(len(containers))
 	}
+	devContainers := containers["sdb4"].([]interface{})
+	if len(devContainers) != 2 {
+		t.Fatal(len(devContainers))
+	}
 	pathToItem = map[string]string{}
-	for _, container := range containers {
+	for _, container := range devContainers {
 		containerMap := container.(map[string]interface{})
 		pathToItem[containerMap["NameOnDevice"].(string)] = containerMap["NameInURL"].(string)
 	}
@@ -235,12 +243,16 @@ func TestQuarantineDetail(t *testing.T) {
 		t.Fatal(ok, v)
 	}
 
-	objects := jsonMap["objects"].([]interface{})
-	if len(objects) != 2 {
+	objects := jsonMap["objects"].(map[string]interface{})
+	if len(objects) != 1 {
 		t.Fatal(len(objects))
 	}
+	devObjects := objects["sdb4"].([]interface{})
+	if len(devObjects) != 2 {
+		t.Fatal(len(devObjects))
+	}
 	pathToItem = map[string]string{}
-	for _, object := range objects {
+	for _, object := range devObjects {
 		objectMap := object.(map[string]interface{})
 		pathToItem[objectMap["NameOnDevice"].(string)] = objectMap["NameInURL"].(string)
 	}

--- a/objectserver/priorityrep_test.go
+++ b/objectserver/priorityrep_test.go
@@ -52,6 +52,8 @@ func (p *priFakeRing) GetJobNodes(partition uint64, localDevice int) (response [
 
 func (p *priFakeRing) GetPartition(account string, container string, object string) uint64 { return 0 }
 
+func (p *priFakeRing) PartitionForHash(hsh uint64) uint64 { return 0 }
+
 func (p *priFakeRing) LocalDevices(localPort int) (devs []*ring.Device, err error) {
 	return nil, nil
 }

--- a/tools/dispersion_test.go
+++ b/tools/dispersion_test.go
@@ -97,6 +97,10 @@ func (r *FakeRing) GetPartition(account string, container string, object string)
 	return 0
 }
 
+func (r *FakeRing) PartitionForHash(hsh uint64) uint64 {
+	return 0
+}
+
 func (r *FakeRing) LocalDevices(localPort int) (devs []*ring.Device, err error) {
 	return nil, nil
 }

--- a/tools/quarantinerepairman.go
+++ b/tools/quarantinerepairman.go
@@ -332,7 +332,7 @@ func (qr *quarantineRepairman) queuePartitionReplication(logger *zap.Logger, typ
           AND policy = ?
           AND partition = ?
           AND reason = "quarantine"
-          AND toDevice = ?
+          AND to_device = ?
     `, typ, policy, partition, deviceID)
 	if err != nil {
 		tx.Rollback()
@@ -346,7 +346,7 @@ func (qr *quarantineRepairman) queuePartitionReplication(logger *zap.Logger, typ
 	}
 	_, err = tx.Exec(`
         INSERT INTO replication_queue
-        (rtype, policy, partition, reason, toDevice)
+        (rtype, policy, partition, reason, to_device)
         VALUES (?, ?, ?, "quarantine", ?)
     `, typ, policy, partition, deviceID)
 	if err != nil {

--- a/tools/quarantinerepairman.go
+++ b/tools/quarantinerepairman.go
@@ -1,0 +1,394 @@
+package tools
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/troubling/hummingbird/common/ring"
+	"go.uber.org/zap"
+)
+
+type quarantineRepairman struct {
+	aa *AutoAdmin
+	// delay between each request; adjusted each pass to try to make passes an hour
+	delay time.Duration
+}
+
+func newQuarantineRepairman(aa *AutoAdmin) *quarantineRepairman {
+	return &quarantineRepairman{aa: aa, delay: time.Second}
+}
+
+func (qr *quarantineRepairman) runForever() {
+	for {
+		qr.runOnce()
+	}
+}
+
+func (qr *quarantineRepairman) runOnce() {
+	start := time.Now()
+	logger := qr.aa.logger.With(zap.String("process", "quarantine repairman"))
+	delays := 0
+	for url, ipp := range qr.quarantineDetailURLs() {
+		getLogger := logger.With(zap.String("method", "GET"), zap.String("url", url))
+		for typ, deviceToEntries := range qr.retrieveTypeToDeviceToEntries(getLogger, url) {
+			for device, entries := range deviceToEntries {
+				policy := 0
+				if typ == "accounts" {
+					typ = "account"
+				} else if typ == "containers" {
+					typ = "container"
+				} else if typ == "objects" {
+					typ = "object"
+				} else if strings.HasPrefix(typ, "objects-") {
+					var err error
+					policy, err = strconv.Atoi(typ[len("objects-"):])
+					if err != nil {
+						getLogger.Debug("Weird type in entries", zap.String("type", typ), zap.Error(err))
+						continue
+					}
+					typ = "object"
+				} else {
+					getLogger.Debug("Weird type in entries", zap.String("type", typ))
+					continue
+				}
+				ringg, _ := getRing("", typ, policy)
+				deviceID := -1
+				for _, dev := range ringg.AllDevices() {
+					if dev.Ip == ipp.ip && dev.Port == ipp.port && dev.Device == device {
+						deviceID = dev.Id
+						break
+					}
+				}
+				deviceLogger := logger.With(zap.String("type", typ), zap.Int("policy", policy), zap.String("ip", ipp.ip), zap.Int("port", ipp.port), zap.String("device", device), zap.Int("deviceID", deviceID))
+				for _, entry := range entries {
+					if entry.NameInURL != "" {
+						if !qr.repairItem(deviceLogger, typ, policy, ringg, entry.NameInURL) {
+							continue
+						}
+					} else { // entry.NameOnDevice
+						if !qr.queuePartitionReplication(deviceLogger, typ, policy, ringg, deviceID, entry.NameOnDevice) {
+							continue
+						}
+					}
+					qr.clearQuarantine(deviceLogger, ipp, device, typ, policy, entry.NameOnDevice)
+				}
+			}
+		}
+		delays++
+		time.Sleep(qr.delay)
+	}
+	sleepTo := time.Until(start.Add(time.Hour))
+	if sleepTo > 0 {
+		time.Sleep(sleepTo)
+	}
+	qr.delay = time.Hour / time.Duration(delays)
+}
+
+// quarantineDetailURLs returns a map of urls to ip-port structures based on
+// all the servers in all the rings for the hummingbird configuration.
+func (qr *quarantineRepairman) quarantineDetailURLs() map[string]*ippInstance {
+	urls := map[string]*ippInstance{}
+	for _, typ := range []string{"account", "container", "object"} {
+		if typ == "object" {
+			for _, policy := range qr.aa.policies {
+				ringg, _ := getRing("", typ, policy.Index)
+				for _, dev := range ringg.AllDevices() {
+					urls[fmt.Sprintf("%s://%s:%d/recon/quarantineddetail", dev.Scheme, dev.Ip, dev.Port)] = &ippInstance{scheme: dev.Scheme, ip: dev.Ip, port: dev.Port}
+				}
+			}
+		} else {
+			ringg, _ := getRing("", typ, 0)
+			for _, dev := range ringg.AllDevices() {
+				urls[fmt.Sprintf("%s://%s:%d/recon/quarantineddetail", dev.Scheme, dev.Ip, dev.Port)] = &ippInstance{scheme: dev.Scheme, ip: dev.Ip, port: dev.Port}
+			}
+		}
+	}
+	return urls
+}
+
+// retrieveTypeToDeviceToEntries performs an HTTP GET request to the url and
+// translates the response into a map[string]map[string][]*entryInstance giving
+// the types-to-devices-to-entries of quarantined items that server has; any
+// errors will be logged and an empty map returned.
+func (qr *quarantineRepairman) retrieveTypeToDeviceToEntries(logger *zap.Logger, url string) map[string]map[string][]*entryInstance {
+	// type is accounts, containers, objects, objects-1, etc.
+	typeToDeviceToEntries := map[string]map[string][]*entryInstance{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		logger.Error("http.NewRequest", zap.Error(err))
+		return typeToDeviceToEntries
+	}
+	resp, err := qr.aa.client.Do(req)
+	if err != nil {
+		logger.Debug("Do", zap.Error(err))
+		return typeToDeviceToEntries
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		logger.Debug("Body", zap.Int("StatusCode", resp.StatusCode), zap.Error(err))
+		return typeToDeviceToEntries
+	}
+	if resp.StatusCode/100 != 2 {
+		logger.Debug("StatusCode", zap.Int("StatusCode", resp.StatusCode), zap.Error(err))
+		return typeToDeviceToEntries
+	}
+	if err := json.Unmarshal(body, &typeToDeviceToEntries); err != nil {
+		logger.Debug("JSON", zap.String("JSON", string(body)), zap.Error(err))
+		return typeToDeviceToEntries
+	}
+	return typeToDeviceToEntries
+}
+
+// repairItem tries to ensure all replicas are in place for the quarantined
+// entry and returns true if the entry should be deleted as it has been handled
+// as best as is possible.
+func (qr *quarantineRepairman) repairItem(logger *zap.Logger, typ string, policy int, ringg ring.Ring, entryNameInURL string) bool {
+	logger = logger.With(zap.String("name in URL", entryNameInURL))
+	parts := strings.SplitN(entryNameInURL, "/", 4)
+	var account, container, object string
+	switch len(parts) {
+	case 2:
+		account = parts[1]
+	case 3:
+		account = parts[1]
+		container = parts[2]
+	case 4:
+		account = parts[1]
+		container = parts[2]
+		object = parts[3]
+	default:
+		logger.Debug("oddball quarantined item")
+		return true
+	}
+	if account == "" || (container == "" && object != "") {
+		logger.Debug("oddball quarantined item")
+		return true
+	}
+	switch typ {
+	case "account":
+		if container != "" || object != "" {
+			logger.Debug("skipping item since it doesn't match type 'account'")
+			return false
+		}
+	case "container":
+		if container == "" || object != "" {
+			logger.Debug("skipping item since it doesn't match type 'container'")
+			return false
+		}
+	case "object":
+		if container == "" || object == "" {
+			logger.Debug("skipping item since it doesn't match type 'object'")
+			return false
+		}
+	}
+	partition := ringg.GetPartition(account, container, object)
+	logger = logger.With(zap.Uint64("partition", partition))
+	var have, notfound, unsure []*ring.Device
+	for _, device := range ringg.GetNodes(partition) {
+		url := fmt.Sprintf("%s://%s:%d/%s/%d/%s", device.Scheme, device.Ip, device.Port, device.Device, partition, account)
+		if container != "" {
+			url += "/" + container
+			if object != "" {
+				url += "/" + object
+			}
+		}
+		logger = logger.With(zap.String("method", "HEAD"), zap.String("url", url))
+		req, err := http.NewRequest("HEAD", url, nil)
+		if err != nil {
+			logger.Error("http.NewRequest", zap.Error(err))
+			return false
+		}
+		resp, err := qr.aa.client.Do(req)
+		if err != nil {
+			logger.Debug("Do", zap.Error(err))
+			return false
+		}
+		resp.Body.Close()
+		if resp.StatusCode/100 == 2 {
+			have = append(have, device)
+		} else if resp.StatusCode == 404 {
+			notfound = append(notfound, device)
+		} else {
+			logger.Debug("StatusCode", zap.Int("StatusCode", resp.StatusCode), zap.Error(err))
+			unsure = append(unsure, device)
+		}
+	}
+	if uint64(len(notfound)) == ringg.ReplicaCount() {
+		logger.Debug("none of the primary devices had the item so we'll just assume it was deleted after it got quarantined")
+		return true
+	}
+	if len(have) == 0 {
+		logger.Debug("couldn't find anyone with the item yet, but not everyone reported in, so just skip for now")
+		return false
+	}
+	fromURL := fmt.Sprintf("%s://%s:%d/%s/%d/%s", have[0].Scheme, have[0].Ip, have[0].Port, have[0].Device, partition, account)
+	if container != "" {
+		fromURL += "/" + container
+		if object != "" {
+			fromURL += "/" + object
+		}
+	}
+	logger = logger.With(zap.String("fromURL", fromURL))
+	putCopy := func(device *ring.Device) bool {
+		fromReq, err := http.NewRequest("GET", fromURL, nil)
+		if err != nil {
+			logger.Error("http.NewRequest", zap.Error(err))
+			return false
+		}
+		fromResp, err := qr.aa.client.Do(fromReq)
+		if err != nil {
+			logger.Debug("Do", zap.Error(err))
+			return false
+		}
+		defer fromResp.Body.Close()
+		if fromResp.StatusCode/100 != 2 {
+			logger.Debug("StatusCode", zap.Int("StatusCode", fromResp.StatusCode), zap.Error(err))
+			return false
+		}
+		toURL := fmt.Sprintf("%s://%s:%d/%s/%d/%s", device.Scheme, device.Ip, device.Port, device.Device, partition, account)
+		if container != "" {
+			toURL += "/" + container
+			if object != "" {
+				toURL += "/" + object
+			}
+		}
+		logger = logger.With(zap.String("toURL", toURL))
+		toReq, err := http.NewRequest("PUT", toURL, fromResp.Body)
+		if err != nil {
+			logger.Error("http.NewRequest", zap.Error(err))
+			return false
+		}
+		toReq.Header = fromResp.Header
+		toResp, err := qr.aa.client.Do(toReq)
+		if err != nil {
+			logger.Debug("Do", zap.Error(err))
+			return false
+		}
+		toResp.Body.Close()
+		if toResp.StatusCode/100 != 2 {
+			logger.Debug("StatusCode", zap.Int("StatusCode", toResp.StatusCode), zap.Error(err))
+			return false
+		}
+		return true
+	}
+	for _, device := range notfound {
+		if !putCopy(device) {
+			return false
+		}
+	}
+	for _, device := range unsure {
+		if !putCopy(device) {
+			return false
+		}
+	}
+	return true
+}
+
+// queuePartitionReplication tries to figure out the partition for the
+// quarantined entry and queue replication of that partition; returns true if
+// the entry should be deleted as it has been handled as best as is possible.
+func (qr *quarantineRepairman) queuePartitionReplication(logger *zap.Logger, typ string, policy int, ringg ring.Ring, deviceID int, entryNameOnDevice string) bool {
+	logger = logger.With(zap.String("name on device", entryNameOnDevice))
+	if deviceID < 0 {
+		logger.Debug("skipping since deviceID could not be resolved; likely the service we got the report from isn't actually in charge of the device and it's instead another service on the same server using the same device root")
+		return false
+	}
+	if len(entryNameOnDevice) < 8 {
+		logger.Debug("oddball quarantined item")
+		return true
+	}
+	hsh, err := strconv.ParseUint(entryNameOnDevice[:8], 16, 64)
+	if err != nil {
+		logger.Debug("oddball quarantined item")
+		return true
+	}
+	partition := ringg.PartitionForHash(hsh)
+	db, err := qr.aa.getDB()
+	if err != nil {
+		logger.Error("cannot get database", zap.Error(err))
+		return false
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		logger.Error("db.Begin", zap.Error(err))
+		return false
+	}
+	rows, err := tx.Query(`
+        SELECT rtype FROM replication_queue
+        WHERE rtype = ?
+          AND policy = ?
+          AND partition = ?
+          AND reason = "quarantine"
+          AND toDevice = ?
+    `, typ, policy, partition, deviceID)
+	if err != nil {
+		tx.Rollback()
+		logger.Error("tx.Query", zap.Error(err))
+		return false
+	}
+	if rows.Next() { // entry already
+		rows.Close()
+		tx.Rollback()
+		return true
+	}
+	_, err = tx.Exec(`
+        INSERT INTO replication_queue
+        (rtype, policy, partition, reason, toDevice)
+        VALUES (?, ?, ?, "quarantine", ?)
+    `, typ, policy, partition, deviceID)
+	if err != nil {
+		tx.Rollback()
+		logger.Error("tx.Exec", zap.Error(err))
+		return false
+	}
+	err = tx.Commit()
+	if err != nil {
+		logger.Error("tx.Commit", zap.Error(err))
+		return false
+	}
+	return true
+}
+
+type ippInstance struct {
+	scheme string
+	ip     string
+	port   int
+}
+
+type entryInstance struct {
+	NameOnDevice string
+	NameInURL    string
+}
+
+func (qr *quarantineRepairman) clearQuarantine(logger *zap.Logger, ipp *ippInstance, device, typ string, policy int, nameOnDevice string) error {
+	reconType := typ + "s"
+	if policy != 0 {
+		reconType += fmt.Sprintf("-%d", policy)
+	}
+	url := fmt.Sprintf("%s://%s:%d/", ipp.scheme, ipp.ip, ipp.port) + path.Join("recon", device, "quarantined", reconType, nameOnDevice)
+	logger = logger.With(zap.String("method", "DELETE"), zap.String("url", url))
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		logger.Error("http.NewRequest", zap.Error(err))
+		return err
+	}
+	resp, err := qr.aa.client.Do(req)
+	if err != nil {
+		logger.Debug("Do", zap.Error(err))
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		logger.Debug("StatusCode", zap.Int("StatusCode", resp.StatusCode), zap.Error(err))
+		return fmt.Errorf("bad response status code %d", resp.StatusCode)
+	}
+	logger.Debug("cleared")
+	return nil
+}

--- a/tools/reconcli_test.go
+++ b/tools/reconcli_test.go
@@ -215,36 +215,42 @@ func TestReconQuarantineDetailReport(t *testing.T) {
 		w.WriteHeader(200)
 		w.Write([]byte(`
 {
-  "accounts": [
-    {
-      "NameOnDevice": "52f9146296db1c31308103a83a7667ed-8848222",
-      "NameInURL": ""
-    },
-    {
-      "NameOnDevice": "a2d288042a86975c5e000e0e4b8d5a2b-12343444",
-      "NameInURL": "/.admin"
-    }
-  ],
-  "containers": [
-    {
-      "NameOnDevice": "330db13d1978d2eaca43612c433bb1be-234234234",
-      "NameInURL": "/.admin/disp-conts-204-270"
-    },
-    {
-      "NameOnDevice": "ff2d04f90fe4099ce8ecc514bbf514b2-413332114",
-      "NameInURL": ""
-    }
-  ],
-  "objects": [
-    {
-      "NameOnDevice": "197ce7d697904ffaada1a16ee3f7a8c0-8585858",
-      "NameInURL": ""
-    },
-    {
-      "NameOnDevice": "a4f4d624d9a18c20addf439bcb7192e8-2399494",
-      "NameInURL": "/AUTH_test/test-container/.git/objects/ea/0192ee16fc8ee99f594c42c6804012732d9153"
-    }
-  ]
+  "accounts": {
+    "sdb4": [
+      {
+        "NameOnDevice": "52f9146296db1c31308103a83a7667ed-8848222",
+        "NameInURL": ""
+      },
+      {
+        "NameOnDevice": "a2d288042a86975c5e000e0e4b8d5a2b-12343444",
+        "NameInURL": "/.admin"
+      }
+    ]
+  },
+  "containers": {
+    "sdb4": [
+      {
+        "NameOnDevice": "330db13d1978d2eaca43612c433bb1be-234234234",
+        "NameInURL": "/.admin/disp-conts-204-270"
+      },
+      {
+        "NameOnDevice": "ff2d04f90fe4099ce8ecc514bbf514b2-413332114",
+        "NameInURL": ""
+      }
+    ]
+  },
+  "objects": {
+    "sdb4": [
+      {
+        "NameOnDevice": "197ce7d697904ffaada1a16ee3f7a8c0-8585858",
+        "NameInURL": ""
+      },
+      {
+        "NameOnDevice": "a4f4d624d9a18c20addf439bcb7192e8-2399494",
+        "NameInURL": "/AUTH_test/test-container/.git/objects/ea/0192ee16fc8ee99f594c42c6804012732d9153"
+      }
+    ]
+  }
 }
 		`))
 	}))
@@ -260,22 +266,26 @@ func TestReconQuarantineDetailReport(t *testing.T) {
 		w.WriteHeader(200)
 		w.Write([]byte(`
 {
-  "objects": [
-    {
-      "NameOnDevice": "893848384384aadaada1a16ee3f7a8c0-9293238",
-      "NameInURL": "/AUTH_test/test-container/haha"
-    }
-  ],
-  "objects-1": [
-    {
-      "NameOnDevice": "ef34e7d697904ffaada1a16ee3f7a8c0-9388223",
-      "NameInURL": ""
-    },
-    {
-      "NameOnDevice": "8383a624d9a18c20addf439bcb7192e8-2988930",
-      "NameInURL": "/AUTH_something/test2/blah/blah/blah"
-    }
-  ]
+  "objects": {
+    "sdb4": [
+      {
+        "NameOnDevice": "893848384384aadaada1a16ee3f7a8c0-9293238",
+        "NameInURL": "/AUTH_test/test-container/haha"
+      }
+    ]
+  },
+  "objects-1": {
+    "sdb4": [
+      {
+        "NameOnDevice": "ef34e7d697904ffaada1a16ee3f7a8c0-9388223",
+        "NameInURL": ""
+      },
+      {
+        "NameOnDevice": "8383a624d9a18c20addf439bcb7192e8-2988930",
+        "NameInURL": "/AUTH_something/test2/blah/blah/blah"
+      }
+    ]
+  }
 }
 		`))
 	}))
@@ -296,23 +306,24 @@ func TestReconQuarantineDetailReport(t *testing.T) {
 	out := report.String()
 	require.True(t, strings.Contains(out, "2/2 hosts matched, 0 error[s] while checking hosts."), out)
 	look := fmt.Sprintf(`  %s:%d
-    197ce7d697904ffaada1a16ee3f7a8c0-8585858 
-    a4f4d624d9a18c20addf439bcb7192e8-2399494 /AUTH_test/test-container/.git/objects/ea/0192ee16fc8ee99f594c42c6804012732d9153
+    sdb4
+      197ce7d697904ffaada1a16ee3f7a8c0-8585858 
+      a4f4d624d9a18c20addf439bcb7192e8-2399494 /AUTH_test/test-container/.git/objects/ea/0192ee16fc8ee99f594c42c6804012732d9153
 `, host, port)
 	look1 := fmt.Sprintf(`  %s:%d
-    893848384384aadaada1a16ee3f7a8c0-9293238 /AUTH_test/test-container/haha
+      893848384384aadaada1a16ee3f7a8c0-9293238 /AUTH_test/test-container/haha
 `, host1, port1)
 	if port < port1 {
 		look = "\nobjects\n" + look + look1
 	} else {
 		look = "\nobjects\n" + look1 + look
 	}
-	require.True(t, strings.Contains(out, look), fmt.Sprintf("\n%q\n%q", out, look))
 	look = fmt.Sprintf(`
 objects-1
   %s:%d
-    8383a624d9a18c20addf439bcb7192e8-2988930 /AUTH_something/test2/blah/blah/blah
-    ef34e7d697904ffaada1a16ee3f7a8c0-9388223 
+    sdb4
+      8383a624d9a18c20addf439bcb7192e8-2988930 /AUTH_something/test2/blah/blah/blah
+      ef34e7d697904ffaada1a16ee3f7a8c0-9388223 
 `, host1, port1)
 	require.True(t, strings.Contains(out, look), fmt.Sprintf("\n%q\n%q", out, look))
 	require.Equal(t, handlersRun, 2)


### PR DESCRIPTION
This adds a background job to andrewd that will scan the whole cluster
for quarantined items and repair them. For items that it has the name
for, it can repair just that item by pulling from a node that has a
copy. For items that it just knows the hash of, it can queue up a
replication pass for that partition.

There are some ancillary changes in here too:

The recon quarantine detail responses had to start including the device
data as well.

I needed to add PartitionForHash to the ring since sometimes the only
thing we know about a quarantined item is what its ring hash was, so the
best we can do is ask for a full replication cycle for the corresponding
partition.

I added a getDB to AutoAdmin. I'd like to move all the DB instantiation
stuff there, such as out of drivewatch, but I'll leave that for the
future. I also added an HTTP client to AutoAdmin and I'd like to get
everything in andrewd using the same client.

I added a new replication_queue table to the andrewd database, but
nothing actually acts on the entries there, yet.