### PR TITLE
HUM-575 Couple of small EC GET optimization

### DIFF
--- a/objectserver/indexdb/utils.go
+++ b/objectserver/indexdb/utils.go
@@ -81,12 +81,12 @@ func ecGlue(dataChunks, parityChunks int, bodies []io.Reader, chunkSize int, con
 		for i := range bodies {
 			if bodies[i] != nil && !failed[i] {
 				if _, err := io.ReadFull(bodies[i], data[i]); err != nil {
-					data[i] = nil
+					data[i] = data[i][:0]
 					failed[i] = true
 				}
 			}
 		}
-		if err := enc.Reconstruct(data); err != nil {
+		if err := enc.ReconstructData(data); err != nil {
 			return err
 		}
 		for i := 0; i < dataChunks; i++ {


### PR DESCRIPTION
While doing GET call for EC objects, we might get better performance if we use
ReconstructData instead of Reconstruct.
https://github.com/klauspost/reedsolomon#performance

Also while doing Reconstruct/ReconstructData we could shave off one allocation
if we use zero-length buffer with adequate capacity instead of passing nil.