### PR TITLE
HUM-577 : get rid of rescuepartition command

### DIFF
--- a/cmd/hummingbird/main.go
+++ b/cmd/hummingbird/main.go
@@ -424,9 +424,6 @@ func main() {
 		fmt.Fprintln(os.Stderr, "hummingbird restoredevice [ip] [device-name]")
 		fmt.Fprintln(os.Stderr, "  Reconstruct a device from its peers")
 		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "hummingbird rescueparts [partnum1,partnum2,...]")
-		fmt.Fprintln(os.Stderr, "  Will send requests to all the object nodes to try to fully replicate given partitions if they have them.")
-		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "hummingbird bench CONFIG")
 		fmt.Fprintln(os.Stderr, "  Run bench tool")
 		fmt.Fprintln(os.Stderr)
@@ -515,8 +512,6 @@ func main() {
 		objectserver.MoveParts(flag.Args()[1:], srv.DefaultConfigLoader{})
 	case "restoredevice":
 		objectserver.RestoreDevice(flag.Args()[1:], srv.DefaultConfigLoader{})
-	case "rescueparts":
-		objectserver.RescueParts(flag.Args()[1:], srv.DefaultConfigLoader{})
 	case "ring":
 		ringBuilderFlags.Parse(flag.Args()[1:])
 		tools.RingBuildCmd(ringBuilderFlags)

--- a/docs/replication-tools.md
+++ b/docs/replication-tools.md
@@ -125,22 +125,3 @@ If you are using storage policies, use *-p policy_id* so it can find the correct
 current ring.
 
 This can be run after every device replacement to heal your cluster asap.
-
-## rescueparts
-
-If, for whatever reason, you notice that there is a partition that is in need of
-replication (say it is the only copy left) you can run **rescueparts** to send
-a priority replication call to all devices in the cluster to replicate the
-partition if they have it. Most of the calls will 404 but this will make copies
-of the partition and clean up handoffs for the partition on any nodes that have
-them. You run it like:
-
-```
-hummingbird rescueparts 18,12
-```
-
-the current ring must be in the *normal* spot. (i.e. */etc/hummingbird/object.ring.gz*)
-and it is important that that is the deployed ring in the cluster.
-
-If you are using storage policies, use *-p policy_id* so it can find the correct
-current ring.

--- a/objectserver/replicator.go
+++ b/objectserver/replicator.go
@@ -56,11 +56,11 @@ const (
 )
 
 type PriorityRepJob struct {
-	Partition  uint64         `json:"partition"`
-	FromDevice *ring.Device   `json:"from_device"`
-	ToDevices  []*ring.Device `json:"to_devices"`
-	Policy     int            `json:"policy"`
-	Version    string         `json:"version"`
+	Partition  uint64       `json:"partition"`
+	FromDevice *ring.Device `json:"from_device"`
+	ToDevice   *ring.Device `json:"to_device"`
+	Policy     int          `json:"policy"`
+	Version    string       `json:"version"`
 }
 
 type quarantineFileError struct {
@@ -716,10 +716,6 @@ func (rd *replicationDevice) processPriorityJobs() {
 				}()
 				partition := strconv.FormatUint(pri.Partition, 10)
 				_, handoff := rd.r.objectRings[rd.policy].GetJobNodes(pri.Partition, pri.FromDevice.Id)
-				toDevicesArr := make([]string, len(pri.ToDevices))
-				for i, s := range pri.ToDevices {
-					toDevicesArr[i] = fmt.Sprintf("%s:%d/%s", s.Ip, s.Port, s.Device)
-				}
 				jobType := "local"
 				if handoff {
 					jobType = "handoff"
@@ -732,9 +728,9 @@ func (rd *replicationDevice) processPriorityJobs() {
 					zap.Uint64("partition", pri.Partition),
 					zap.String("jobType", jobType),
 					zap.String("From Device", pri.FromDevice.Device),
-					zap.String("To Device", strings.Join(toDevicesArr, ",")))
+					zap.String("To Device", pri.ToDevice.Device))
 				rjob := replJob{
-					partition: partition, nodes: pri.ToDevices,
+					partition: partition, nodes: []*ring.Device{pri.ToDevice},
 					headers: map[string]string{"X-Force-Acquire": "true"}}
 				if handoff || (policy.Type == "replication-nursery" &&
 					!common.LooksTrue(policy.Config["cache_hash_dirs"])) {

--- a/objectserver/replicator_test.go
+++ b/objectserver/replicator_test.go
@@ -487,9 +487,7 @@ func TestPriorityRepHandler404(t *testing.T) {
 	job := &PriorityRepJob{
 		Partition:  0,
 		FromDevice: &ring.Device{Id: 1, Device: "sda", Ip: "127.0.0.1", Port: 5000, ReplicationIp: "127.0.0.1", ReplicationPort: 5000},
-		ToDevices: []*ring.Device{
-			{Id: 2, Device: "sdb"},
-		},
+		ToDevice:   &ring.Device{Id: 2, Device: "sdb"},
 	}
 	jsonned, _ := json.Marshal(job)
 	req, _ := http.NewRequest("POST", "/priorityrep", bytes.NewBuffer(jsonned))
@@ -828,7 +826,7 @@ func TestProcessPriorityJobs(t *testing.T) {
 	rd.priRep <- PriorityRepJob{
 		Partition:  1,
 		FromDevice: &ring.Device{},
-		ToDevices:  []*ring.Device{{}},
+		ToDevice:   &ring.Device{},
 		Policy:     0,
 	}
 	replicateUsingHashesCalled := false
@@ -847,7 +845,7 @@ func TestProcessPriorityJobs(t *testing.T) {
 	rd.priRep <- PriorityRepJob{
 		Partition:  1,
 		FromDevice: &ring.Device{},
-		ToDevices:  []*ring.Device{{}},
+		ToDevice:   &ring.Device{},
 		Policy:     0,
 	}
 	testRing.MockGetJobNodesHandoff = true
@@ -1030,7 +1028,7 @@ func TestPriorityReplicate(t *testing.T) {
 	replicator.priorityReplicate(&httptest.ResponseRecorder{}, PriorityRepJob{
 		Partition:  1,
 		FromDevice: &ring.Device{Device: "sda"},
-		ToDevices:  []*ring.Device{},
+		ToDevice:   nil,
 		Policy:     0,
 	})
 	require.True(t, priorityReplicateCalled)

--- a/tools/drivewatch_test.go
+++ b/tools/drivewatch_test.go
@@ -562,8 +562,7 @@ func TestCheckMissingDispersionObjects(t *testing.T) {
 			require.Nil(t, err)
 			require.Equal(t, uint64(100), prj.Partition)
 			require.Equal(t, "sdb", prj.FromDevice.Device)
-			require.Equal(t, 1, len(prj.ToDevices))
-			require.Equal(t, "sda", prj.ToDevices[0].Device)
+			require.Equal(t, "sda", prj.ToDevice.Device)
 		}
 		srv.SimpleErrorResponse(w, 200, "")
 	}))


### PR DESCRIPTION
this cmd isn't really used and this allows changes priorityrepl jobs
to just have a single todevice- which simplifies handling them.
the only things to use multiple ToDevices is rescuepartitions
and RescueLonelyPartitions. first removed, second refactored