### PR TITLE
HUM-590 Update HAIO with helpers: hbmount hbswifttests

### DIFF
--- a/cmd/hummingbird/init.go
+++ b/cmd/hummingbird/init.go
@@ -594,6 +594,14 @@ func initCommand(args []string) error {
 		print(`sudo chmod 0755 %s/usr/bin/hbreset`, prefix)
 		print(``)
 
+		print(`sudo tee %s/usr/bin/hbmount >/dev/null << EOF`, prefix)
+		print(`#!/bin/bash`)
+		print(``)
+		print(`sudo mount -o loop /srv/hb-disk /srv/hb`)
+		print(`EOF`)
+		print(`sudo chmod 0755 %s/usr/bin/hbmount`, prefix)
+		print(``)
+
 		print(`sudo tee %s/usr/bin/hblog >/dev/null << EOF`, prefix)
 		print(`#!/bin/bash`)
 		print(``)
@@ -605,6 +613,15 @@ func initCommand(args []string) error {
 		print(`fi`)
 		print(`EOF`)
 		print(`sudo chmod 0755 %s/usr/bin/hblog`, prefix)
+		print(``)
+
+		print(`sudo tee %s/usr/bin/hbswifttests >/dev/null << EOF`, prefix)
+		print(`#!/bin/bash`)
+		print(``)
+		print(`cd ~/swift/test/functional`)
+		print("nosetests --exclude-test-file=`go env GOPATH`/src/github.com/troubling/hummingbird/.swift_func_excludes")
+		print(`EOF`)
+		print(`sudo chmod 0755 %s/usr/bin/hbswifttests`, prefix)
 		print(``)
 	}
 


### PR DESCRIPTION
After a reboot, the loopback device will be unmounted. hbreset will fix this, but will also throw away all data. hbmount will just mount the loopback.

hbswifttests will run the Swift functional tests using the exclusions we've captured.