### PR TITLE
HUM-567 : cant overwrite obj in EC

### DIFF
--- a/objectserver/indexdb/ecengine.go
+++ b/objectserver/indexdb/ecengine.go
@@ -181,6 +181,8 @@ func (f *ecEngine) ecFragPutHandler(writer http.ResponseWriter, request *http.Re
 		if strings.HasPrefix(key, "Meta-") {
 			if key == "Meta-Name" {
 				metadata["name"] = request.Header.Get(key)
+			} else if key == "Meta-Etag" {
+				metadata["ETag"] = request.Header.Get(key)
 			} else {
 				metadata[http.CanonicalHeaderKey(key[5:])] = request.Header.Get(key)
 			}


### PR DESCRIPTION
when the object got stabilized the ETag got sent over as a Meta-Etag
header. I'm special casing it to be saved as ETag in db. this is
basically in line with what is done on whole objects