### PR TITLE
HUM-613 Suppress dispersion request logging

### DIFF
--- a/tools/dispersionscancontainers.go
+++ b/tools/dispersionscancontainers.go
@@ -206,6 +206,7 @@ func (dsc *dispersionScanContainers) handleChecks(ctx *dispersionScanContainersC
 			}
 			continue
 		}
+		req.Header.Set("X-Backend-Suppress-2xx-Logging", "t")
 		resp, err := dsc.aa.client.Do(req)
 		if err != nil {
 			atomic.AddInt64(&ctx.errored, 1)

--- a/tools/dispersionscanobjects.go
+++ b/tools/dispersionscanobjects.go
@@ -238,6 +238,7 @@ func (dso *dispersionScanObjects) handleChecks(ctx *dispersionScanObjectsContext
 			}
 			continue
 		}
+		req.Header.Set("X-Backend-Suppress-2xx-Logging", "t")
 		req.Header.Set("X-Backend-Storage-Policy-Index", fmt.Sprintf("%d", ctx.policy))
 		resp, err := dso.aa.client.Do(req)
 		if err != nil {


### PR DESCRIPTION
Can't suppress 100% of it since some checks are done via a proxy-client,
such as the populations and the HEADs for the -init markers and GETs for
container listings. But it suppresses most of the scans.