### PR TITLE
HUM-614 EC range requests

### DIFF
--- a/objectserver/indexdb/ecengine.go
+++ b/objectserver/indexdb/ecengine.go
@@ -151,7 +151,8 @@ func (f *ecEngine) ecFragGetHandler(writer http.ResponseWriter, request *http.Re
 		srv.StandardResponse(writer, http.StatusInternalServerError)
 		return
 	}
-	io.Copy(writer, fl)
+	defer fl.Close()
+	http.ServeContent(writer, request, item.Path, time.Unix(item.Timestamp, 0), fl)
 }
 
 func (f *ecEngine) ecFragPutHandler(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
Serve EC range requests.

We have to grab block-aligned chunks from the fragments, then discard
any bytes we don't need.  I used a proxy Writer to do the discarding,
to keep ecGlue "simple".