### PR TITLE
HUM-638 make sure ec stabilizer closes bodies

### DIFF
--- a/common/expects_test.go
+++ b/common/expects_test.go
@@ -49,7 +49,7 @@ func TestExpectorSuccesses(t *testing.T) {
 	}))
 	defer srv.Close()
 	e := NewExpector(xpectClient)
-	defer e.Cancel()
+	defer e.Close()
 	for i := 0; i < 3; i++ {
 		req, err := http.NewRequest("PUT", srv.URL+"/"+strconv.Itoa(i), strings.NewReader("STUFF"))
 		require.Nil(t, err)
@@ -64,7 +64,7 @@ func TestExpectorReady(t *testing.T) {
 	}))
 	defer srv.Close()
 	e := NewExpector(xpectClient)
-	defer e.Cancel()
+	defer e.Close()
 	for i := 0; i < 3; i++ {
 		req, err := http.NewRequest("PUT", srv.URL+"/"+strconv.Itoa(i), strings.NewReader("STUFF"))
 		require.Nil(t, err)
@@ -87,7 +87,7 @@ func TestExpectorErrorRetry(t *testing.T) {
 	}))
 	defer srv.Close()
 	e := NewExpector(xpectClient)
-	defer e.Cancel()
+	defer e.Close()
 	for i := 0; i < 3; i++ {
 		req, err := http.NewRequest("PUT", srv.URL+"/"+strconv.Itoa(i), strings.NewReader("STUFF"))
 		req.Header.Set("Content-Length", "5")

--- a/objectserver/indexdb/ecobj.go
+++ b/objectserver/indexdb/ecobj.go
@@ -384,7 +384,6 @@ func (o *ecObject) nurseryReplicate(rng ring.Ring, partition uint64, dev *ring.D
 	more := rng.GetMoreNodes(partition)
 	var node *ring.Device
 	e := common.NewExpector(o.client)
-	defer e.Cancel()
 	defer e.Close()
 	wrs := make([]io.WriteCloser, 0)
 	successReadyCount := 0
@@ -471,7 +470,6 @@ func (o *ecObject) Stabilize(rng ring.Ring, dev *ring.Device, policy int) error 
 	}
 	wrs := make([]io.WriteCloser, len(nodes))
 	e := common.NewExpector(o.client)
-	defer e.Cancel()
 	defer e.Close()
 	for i, node := range nodes {
 		rp, wp := io.Pipe()


### PR DESCRIPTION
Consolidate expector Cancel and Close, just because we don't need
both.

Then when it gets a response to a request, go ahead and close the Body
if the expector has been closed/canceled, so it's not left dangling.