### PR TITLE
HUM-607 Removing device from ring sets weight -1

### DIFF
--- a/common/ring/builder.go
+++ b/common/ring/builder.go
@@ -329,7 +329,7 @@ func (b *RingBuilder) SetDevWeight(devId int64, weight float64) error {
 
 // Remove a device from the ring.
 func (b *RingBuilder) RemoveDev(devId int64) {
-	b.Devs[devId].Weight = 0
+	b.Devs[devId].Weight = -1.0
 	b.removedDevs = append(b.removedDevs, b.Devs[devId])
 	b.DevsChanged = true
 	b.Version += 1
@@ -880,6 +880,7 @@ func (b *RingBuilder) gatherPartsFromFailedDevices(assignParts map[uint][]uint) 
 		for _, dev := range b.removedDevs {
 			if dev.Parts > 0 {
 				devsWithParts = append(devsWithParts, uint(dev.Id))
+				b.Devs[dev.Id].Parts = 0
 			}
 		}
 		if len(devsWithParts) > 0 {
@@ -898,10 +899,7 @@ func (b *RingBuilder) gatherPartsFromFailedDevices(assignParts map[uint][]uint) 
 			}
 
 		}
-		for _, dev := range b.removedDevs {
-			b.debug(fmt.Sprintf("Removing dev %d", dev.Id))
-			b.Devs[dev.Id] = nil
-		}
+		// NOTE: At one time, we used to remove the device from the ring, but now we keep it with a weight of -1 so that tools can know that it has been removed
 		removedDevs := len(b.removedDevs)
 		b.removedDevs = b.removedDevs[:0]
 		return removedDevs

--- a/tools/ring.go
+++ b/tools/ring.go
@@ -267,6 +267,7 @@ func RingBuildCmd(flags *flag.FlagSet) {
 		weight := removeFlags.Float64("weight", -1.0, "Device weight.")
 		meta := removeFlags.String("meta", "", "Metadata.")
 		scheme := removeFlags.String("scheme", "", "URI scheme(http/https).")
+		purge := removeFlags.Bool("purge", false, "Purge device from the ring rather than leaving it but with a weight of -1.")
 		yes := removeFlags.Bool("yes", false, "Force yes.")
 		if err := removeFlags.Parse(args[2:]); err != nil {
 			fmt.Println(err)
@@ -296,7 +297,7 @@ func RingBuildCmd(flags *flag.FlagSet) {
 					return
 				}
 			}
-			err := ring.RemoveDevs(pth, devs)
+			err := ring.RemoveDevs(pth, devs, *purge)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)


### PR DESCRIPTION
Removed devices now also stay in the ring with a weight of -1
so that external tools can see that they have been removed.

If the device needs to go back into the ring, it can be done by
changing its weight.