### PR TITLE
HUM-653 Autocreate success when already created; typos

### DIFF
--- a/accountserver/sqlite_backend.go
+++ b/accountserver/sqlite_backend.go
@@ -948,7 +948,7 @@ func sqliteCreateAccount(accountFile string, account string, putTimestamp string
 	defer lock.Close()
 
 	if fs.Exists(accountFile) {
-		return errors.New("Account exists!")
+		return nil
 	}
 
 	if metadata == nil {

--- a/containerserver/sqlite_backend.go
+++ b/containerserver/sqlite_backend.go
@@ -978,7 +978,7 @@ func sqliteCreateContainer(containerFile string, account string, container strin
 	defer lock.Close()
 
 	if fs.Exists(containerFile) {
-		return errors.New("Container exists!")
+		return nil
 	}
 
 	if metadata == nil {

--- a/objectserver/auditor.go
+++ b/objectserver/auditor.go
@@ -252,7 +252,7 @@ func (a *Auditor) statsReport() {
 		zap.String("Object audit", a.auditorType),
 		zap.String("Since", a.lastLog.Format(time.ANSIC)),
 		zap.Int64("Locally passed", a.passes),
-		zap.Int64("Locally quarantied", a.quarantines),
+		zap.Int64("Locally quarantined", a.quarantines),
 		zap.Int64("Locally errored", a.errors),
 		zap.Float64("files/sec", frate),
 		zap.Float64("bytes/sec", brate),

--- a/objectserver/auditor_test.go
+++ b/objectserver/auditor_test.go
@@ -466,7 +466,7 @@ func TestStatReport(t *testing.T) {
 		Context: []zapcore.Field{zap.String("Object audit", ""),
 			zap.String("Since", "Tue May  2 05:48:19 2017"),
 			zap.Int64("Locally passed", 120),
-			zap.Int64("Locally quarantied", 17),
+			zap.Int64("Locally quarantined", 17),
 			zap.Int64("Locally errored", 41),
 			zap.Float64("files/sec", 1),
 			zap.Float64("bytes/sec", 2),


### PR DESCRIPTION
Pretty much this just cleans up the logs a bit. The error wasn't getting propagated all the way back to the client before, it was just a bit of log spam and didn't seem "correct" to me.