### PR TITLE
HUM-666 preallocate temp files in hec

### DIFF
--- a/objectserver/indexdb/ecengine.go
+++ b/objectserver/indexdb/ecengine.go
@@ -76,7 +76,7 @@ func (f *ecEngine) getDB(device string) (*IndexDB, error) {
 	path := filepath.Join(f.driveRoot, device, objectserver.PolicyDir(f.policy), "hec")
 	temppath := filepath.Join(f.driveRoot, device, "tmp")
 	ringPartPower := bits.Len64(f.ring.PartitionCount() - 1)
-	f.idbs[device], err = NewIndexDB(dbpath, path, temppath, ringPartPower, f.dbPartPower, f.numSubDirs, f.logger)
+	f.idbs[device], err = NewIndexDB(dbpath, path, temppath, ringPartPower, f.dbPartPower, f.numSubDirs, f.reserve, f.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/objectserver/indexdb/indexdb_test.go
+++ b/objectserver/indexdb/indexdb_test.go
@@ -26,7 +26,7 @@ func md5hash(data string) string {
 
 func newTestIndexDB(t *testing.T, pth string) *IndexDB {
 	t.Helper()
-	ot, err := NewIndexDB(pth, pth, pth, 2, 1, 1, zap.L())
+	ot, err := NewIndexDB(pth, pth, pth, 2, 1, 1, 0, zap.L())
 	errnil(t, err)
 	return ot
 }
@@ -567,7 +567,7 @@ func TestIndexDB_ListDefaults(t *testing.T) {
 func TestIndexDB_RingPartRange(t *testing.T) {
 	pth := "testdata/tmp/TestIndexDB_partitionRange"
 	defer os.RemoveAll(pth)
-	ot, err := NewIndexDB(pth, pth, pth, 4, 1, 1, zap.L())
+	ot, err := NewIndexDB(pth, pth, pth, 4, 1, 1, 0, zap.L())
 	errnil(t, err)
 	defer ot.Close()
 	startHash, stopHash := ot.RingPartRange(0)
@@ -591,7 +591,7 @@ func TestIndexDB_RingPartRange(t *testing.T) {
 	if stopHash != "ffffffffffffffffffffffffffffffff" {
 		t.Fatal(stopHash)
 	}
-	ot, err = NewIndexDB(pth, pth, pth, 8, 1, 1, zap.L())
+	ot, err = NewIndexDB(pth, pth, pth, 8, 1, 1, 0, zap.L())
 	errnil(t, err)
 	defer ot.Close()
 	startHash, stopHash = ot.RingPartRange(0)

--- a/objectserver/indexdb/indexdbobjeng.go
+++ b/objectserver/indexdb/indexdbobjeng.go
@@ -88,6 +88,7 @@ func indexDBEngineConstructor(config conf.Config, policy *conf.Policy, flags *fl
 				ringPartPower,
 				dbPartPower,
 				subdirs,
+				0,
 				zap.L(),
 			)
 			if err != nil {


### PR DESCRIPTION
Call Preallocate() on shards.

Preallocating space for files reduces fragmentation and lets us
reject requests early when the drive is full.