### PR TITLE
HUM-451 Dispersion scan support for HEC

### DIFF
--- a/objectserver/ecengine.go
+++ b/objectserver/ecengine.go
@@ -252,9 +252,6 @@ func (f *ecEngine) ecShardPutHandler(writer http.ResponseWriter, request *http.R
 	hash := md5.New()
 	n, err := common.Copy(request.Body, atm, hash)
 	if err == io.ErrUnexpectedEOF || (request.ContentLength >= 0 && n != request.ContentLength) {
-		if request.ContentLength >= 0 && n != request.ContentLength {
-			srv.GetLogger(request).Error(fmt.Sprintf("REMOVE THIS DEBUG ERROR GLH2 %d != %d", n, request.ContentLength))
-		}
 		srv.StandardResponse(writer, 499)
 		return
 	} else if err != nil {
@@ -328,9 +325,6 @@ func (f *ecEngine) ecNurseryPutHandler(writer http.ResponseWriter, request *http
 
 		n, err := common.Copy(request.Body, atm)
 		if err == io.ErrUnexpectedEOF || (request.ContentLength >= 0 && n != request.ContentLength) {
-			if request.ContentLength >= 0 && n != request.ContentLength {
-				srv.GetLogger(request).Error(fmt.Sprintf("REMOVE THIS DEBUG ERROR GLH3 %d != %d", n, request.ContentLength))
-			}
 			srv.StandardResponse(writer, 499)
 			return
 		} else if err != nil {

--- a/objectserver/main.go
+++ b/objectserver/main.go
@@ -304,9 +304,6 @@ func (server *ObjectServer) ObjPutHandler(writer http.ResponseWriter, request *h
 	hash := md5.New()
 	totalSize, err := common.Copy(request.Body, tempFile, hash)
 	if err == io.ErrUnexpectedEOF || (request.ContentLength >= 0 && totalSize != request.ContentLength) {
-		if request.ContentLength >= 0 && totalSize != request.ContentLength {
-			srv.GetLogger(request).Error(fmt.Sprintf("REMOVE THIS DEBUG ERROR GLH1 %d != %d", totalSize, request.ContentLength))
-		}
 		srv.StandardResponse(writer, 499)
 		return
 	} else if err != nil {

--- a/tools/dispersionpopulateobjects.go
+++ b/tools/dispersionpopulateobjects.go
@@ -144,10 +144,9 @@ func (dpo *dispersionPopulateObjects) putDispersionObjects(logger *zap.Logger, p
 			container,
 			object,
 			common.Map2Headers(map[string]string{
-				"Content-Length":         "0",
-				"Content-Type":           "text",
-				"X-Timestamp":            common.CanonicalTimestampFromTime(xtimestamp),
-				"X-Object-Meta-Populate": common.CanonicalTimestampFromTime(xtimestamp), // GLH Just for debugging, remove at some point.
+				"Content-Length": "0",
+				"Content-Type":   "text",
+				"X-Timestamp":    common.CanonicalTimestampFromTime(xtimestamp),
 			}),
 			bytes.NewReader([]byte{}),
 		)
@@ -173,10 +172,9 @@ func (dpo *dispersionPopulateObjects) putDispersionObjects(logger *zap.Logger, p
 			container,
 			"object-init",
 			common.Map2Headers(map[string]string{
-				"Content-Length":         "0",
-				"Content-Type":           "text",
-				"X-Timestamp":            common.CanonicalTimestampFromTime(xtimestamp),
-				"X-Object-Meta-Populate": common.CanonicalTimestampFromTime(xtimestamp), // GLH Just for debugging, remove at some point.
+				"Content-Length": "0",
+				"Content-Type":   "text",
+				"X-Timestamp":    common.CanonicalTimestampFromTime(xtimestamp),
 			}),
 			bytes.NewReader([]byte{}),
 		)

--- a/tools/dispersionscancontainers.go
+++ b/tools/dispersionscancontainers.go
@@ -26,13 +26,6 @@ import (
 
 const queuedPerDevice = 10
 
-type checkInfo struct {
-	deviceID  int
-	device    string
-	partition uint64
-	name      string
-}
-
 type dispersionScanContainers struct {
 	aa *AutoAdmin
 	// delay between each request; adjusted each pass to try to make passes last passTimeTarget


### PR DESCRIPTION
When there's a HEC policy, the shards of the dispersion objects will now
be scanned for and replication jobs queued for missing shards.

Before, it would just query each of the many devices from ring.GetNodes
for the full object, and every single one would respond successfully if
there had been at least data:shards in place. Lots of extra work and
useless in the end.

One side effect on this new change is that before the dispersion objects
get stabilized it will seem to the scanner that all the shards are
missing (since they essentially are) and it will queue up a bunch of
wasted effort replication jobs. In practice this shouldn't be a big deal
as it will only happen right after a dispersion populate and before
stabilization, and the cluster or policy should be brand new with near
zero data so the wasted effort will be low.