### PR TITLE
HUM-676 Global Clusters

### DIFF
--- a/client/directclient.go
+++ b/client/directclient.go
@@ -755,7 +755,7 @@ func (oc *standardObjectClient) putObject(account, container, obj string, header
 	defer close(cancel)
 	responsec := make(chan *http.Response)
 	devs, more := oc.objectRing.getWriteNodes(objectPartition, oc.deviceLimit)
-	objectReplicaCount := int(oc.objectRing.ReplicaCount())
+	objectReplicaCount := len(devs)
 
 	devToRequest := func(index int, dev *ring.Device) (*http.Request, error) {
 		trp, wp := io.Pipe()

--- a/client/directclient.go
+++ b/client/directclient.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"net"
 	"net/http"
 	"strconv"
@@ -47,14 +46,14 @@ func addUpdateHeaders(prefix string, headers http.Header, devices []*ring.Device
 type ProxyDirectClient struct {
 	policyList    conf.PolicyList
 	client        *http.Client
-	AccountRing   ring.Ring
-	ContainerRing ring.Ring
+	AccountRing   ringFilter
+	ContainerRing ringFilter
 	objectClients map[int]proxyObjectClient
 	lcm           sync.RWMutex
 	Logger        srv.LowLevelLogger
 }
 
-func NewProxyDirectClient(policyList conf.PolicyList, cnf srv.ConfigLoader, logger srv.LowLevelLogger, certFile, keyFile string) (*ProxyDirectClient, error) {
+func NewProxyDirectClient(policyList conf.PolicyList, cnf srv.ConfigLoader, logger srv.LowLevelLogger, certFile, keyFile, readAffinity, writeAffinity, writeAffinityCount string) (*ProxyDirectClient, error) {
 	var xport http.RoundTripper = &http.Transport{
 		MaxIdleConnsPerHost: 100,
 		MaxIdleConns:        0,
@@ -97,14 +96,16 @@ func NewProxyDirectClient(policyList conf.PolicyList, cnf srv.ConfigLoader, logg
 	if err != nil {
 		return nil, err
 	}
-	c.ContainerRing, err = cnf.GetRing("container", hashPathPrefix, hashPathSuffix, 0)
+	containerRing, err := cnf.GetRing("container", hashPathPrefix, hashPathSuffix, 0)
 	if err != nil {
 		return nil, err
 	}
-	c.AccountRing, err = cnf.GetRing("account", hashPathPrefix, hashPathSuffix, 0)
+	c.ContainerRing = newClientRingFilter(containerRing, readAffinity, "", "")
+	accountRing, err := cnf.GetRing("account", hashPathPrefix, hashPathSuffix, 0)
 	if err != nil {
 		return nil, err
 	}
+	c.AccountRing = newClientRingFilter(accountRing, readAffinity, "", "")
 	c.objectClients = make(map[int]proxyObjectClient)
 	for _, policy := range policyList {
 		// TODO: the intention is to (if it becomes necessary) have a policy type to object client
@@ -113,7 +114,24 @@ func NewProxyDirectClient(policyList conf.PolicyList, cnf srv.ConfigLoader, logg
 		if err != nil {
 			return nil, err
 		}
-		client := &standardObjectClient{proxyDirectClient: c, policy: policy.Index, objectRing: ring, Logger: logger}
+		policyReadAffinity := policy.Config["read_affinity"]
+		if policyReadAffinity == "" {
+			policyReadAffinity = readAffinity
+		}
+		policyWriteAffinity := policy.Config["write_affinity"]
+		if policyWriteAffinity == "" {
+			policyWriteAffinity = writeAffinity
+		}
+		policyWriteAffinityCount := policy.Config["write_affinity_node_count"]
+		if policyWriteAffinityCount == "" {
+			policyWriteAffinityCount = writeAffinityCount
+		}
+		client := &standardObjectClient{
+			proxyDirectClient: c,
+			policy:            policy.Index,
+			objectRing:        newClientRingFilter(ring, policyReadAffinity, policyWriteAffinity, policyWriteAffinityCount),
+			Logger:            logger,
+		}
 		if policy.Type == "hec" {
 			if replicas, err := strconv.Atoi(policy.Config["nursery_replicas"]); err == nil && replicas > 0 {
 				client.deviceLimit = replicas
@@ -126,19 +144,14 @@ func NewProxyDirectClient(policyList conf.PolicyList, cnf srv.ConfigLoader, logg
 	return c, nil
 }
 
-func (c *ProxyDirectClient) writeNodes(r ring.Ring, partition uint64) ([]*ring.Device, ring.MoreNodes) {
-	// TODO: if the client has been configured for write affinity, devices will be filtered here.
-	return r.GetNodes(partition), r.GetMoreNodes(partition)
-}
-
 // quorumResponse returns with a response representative of a quorum of nodes.
 //
 // This is analogous to swift's best_response function.
-func (c *ProxyDirectClient) quorumResponse(r ring.Ring, partition uint64, devToRequest func(int, *ring.Device) (*http.Request, error)) *http.Response {
+func (c *ProxyDirectClient) quorumResponse(r ringFilter, partition uint64, devToRequest func(int, *ring.Device) (*http.Request, error)) *http.Response {
 	cancel := make(chan struct{})
 	defer close(cancel)
 	responsec := make(chan *http.Response)
-	devs, more := c.writeNodes(r, partition)
+	devs, more := r.getWriteNodes(partition, 0)
 	for i := 0; i < int(r.ReplicaCount()); i++ {
 		go func(index int) {
 			var resp *http.Response
@@ -196,20 +209,11 @@ func (c *ProxyDirectClient) quorumResponse(r ring.Ring, partition uint64, devToR
 	return nectarutil.ResponseStub(http.StatusServiceUnavailable, "Unknown State")
 }
 
-func (c *ProxyDirectClient) firstResponse(r ring.Ring, partition uint64, deviceLimit int, devToRequest func(*ring.Device) (*http.Request, error)) (resp *http.Response) {
+func (c *ProxyDirectClient) firstResponse(r ringFilter, partition uint64, devToRequest func(*ring.Device) (*http.Request, error)) (resp *http.Response) {
 	success := make(chan *http.Response)
 	returned := make(chan struct{})
 	defer close(returned)
-	primaries := int(r.ReplicaCount())
-	if deviceLimit > 0 {
-		primaries = deviceLimit
-	}
-	devs := r.GetNodes(partition)
-	for i := 0; i < primaries; i++ {
-		j := rand.Intn(i + 1)
-		devs[i], devs[j] = devs[j], devs[i]
-	}
-	more := r.GetMoreNodes(partition)
+	devs, more := r.getReadNodes(partition)
 	internalErrors := 0
 	notFounds := 0
 	interpretResponse := func(resp *http.Response) *http.Response {
@@ -233,7 +237,7 @@ func (c *ProxyDirectClient) firstResponse(r ring.Ring, partition uint64, deviceL
 		}
 		return nil
 	}
-	maxRequests := primaries * 2
+	maxRequests := int(r.ReplicaCount()) * 2
 	requestsPending := 0
 	for requestCount := 0; requestCount < maxRequests; requestCount++ {
 		var dev *ring.Device
@@ -379,7 +383,7 @@ func (c *proxyClient) ObjectRingFor(account string, container string) (ring.Ring
 	return c.pdc.ObjectRingFor(account, container, c.mc, c.lc)
 }
 func (c *proxyClient) ContainerRing() ring.Ring {
-	return c.pdc.ContainerRing
+	return c.pdc.ContainerRing.ring()
 }
 
 func (c *ProxyDirectClient) PutAccount(account string, headers http.Header) *http.Response {
@@ -415,7 +419,7 @@ func (c *ProxyDirectClient) PostAccount(account string, headers http.Header) *ht
 func (c *ProxyDirectClient) GetAccount(account string, options map[string]string, headers http.Header) *http.Response {
 	partition := c.AccountRing.GetPartition(account, "", "")
 	query := nectarutil.Mkquery(options)
-	return c.firstResponse(c.AccountRing, partition, 0, func(dev *ring.Device) (*http.Request, error) {
+	return c.firstResponse(c.AccountRing, partition, func(dev *ring.Device) (*http.Request, error) {
 		url := fmt.Sprintf("%s://%s:%d/%s/%d/%s%s", dev.Scheme, dev.Ip, dev.Port, dev.Device, partition,
 			common.Urlencode(account), query)
 		req, err := http.NewRequest("GET", url, nil)
@@ -431,7 +435,7 @@ func (c *ProxyDirectClient) GetAccount(account string, options map[string]string
 
 func (c *ProxyDirectClient) HeadAccount(account string, headers http.Header) *http.Response {
 	partition := c.AccountRing.GetPartition(account, "", "")
-	return c.firstResponse(c.AccountRing, partition, 0, func(dev *ring.Device) (*http.Request, error) {
+	return c.firstResponse(c.AccountRing, partition, func(dev *ring.Device) (*http.Request, error) {
 		url := fmt.Sprintf("%s://%s:%d/%s/%d/%s", dev.Scheme, dev.Ip, dev.Port, dev.Device, partition,
 			common.Urlencode(account))
 		req, err := http.NewRequest("HEAD", url, nil)
@@ -515,7 +519,7 @@ func (c *ProxyDirectClient) PostContainer(account string, container string, head
 func (c *ProxyDirectClient) GetContainer(account string, container string, options map[string]string, headers http.Header) *http.Response {
 	partition := c.ContainerRing.GetPartition(account, container, "")
 	query := nectarutil.Mkquery(options)
-	return c.firstResponse(c.ContainerRing, partition, 0, func(dev *ring.Device) (*http.Request, error) {
+	return c.firstResponse(c.ContainerRing, partition, func(dev *ring.Device) (*http.Request, error) {
 		url := fmt.Sprintf("%s://%s:%d/%s/%d/%s/%s%s", dev.Scheme, dev.Ip, dev.Port, dev.Device, partition,
 			common.Urlencode(account), common.Urlencode(container), query)
 		req, err := http.NewRequest("GET", url, nil)
@@ -595,7 +599,7 @@ func (c *ProxyDirectClient) GetContainerInfo(account string, container string, m
 
 func (c *ProxyDirectClient) HeadContainer(account string, container string, headers http.Header) *http.Response {
 	partition := c.ContainerRing.GetPartition(account, container, "")
-	return c.firstResponse(c.ContainerRing, partition, 0, func(dev *ring.Device) (*http.Request, error) {
+	return c.firstResponse(c.ContainerRing, partition, func(dev *ring.Device) (*http.Request, error) {
 		url := fmt.Sprintf("%s://%s:%d/%s/%d/%s/%s", dev.Scheme, dev.Ip, dev.Port, dev.Device, partition,
 			common.Urlencode(account), common.Urlencode(container))
 		req, err := http.NewRequest("HEAD", url, nil)
@@ -705,7 +709,7 @@ func (oc *erroringObjectClient) ring() (ring.Ring, *http.Response) {
 type standardObjectClient struct {
 	proxyDirectClient *ProxyDirectClient
 	policy            int
-	objectRing        ring.Ring
+	objectRing        ringFilter
 	deviceLimit       int
 	Logger            srv.LowLevelLogger
 }
@@ -742,36 +746,6 @@ func (p *putReader) Read(b []byte) (int, error) {
 	}
 }
 
-type lessMore struct {
-	mutex sync.Mutex
-	devs  []*ring.Device
-	more  ring.MoreNodes
-	limit int
-}
-
-func (lm *lessMore) Next() *ring.Device {
-	lm.mutex.Lock()
-	defer lm.mutex.Unlock()
-	if lm.limit <= 0 {
-		return nil
-	}
-	lm.limit--
-	if len(lm.devs) > 0 {
-		dev := lm.devs[0]
-		lm.devs = lm.devs[1:]
-		return dev
-	}
-	return lm.more.Next()
-}
-
-func (oc *standardObjectClient) writeNodes(r ring.Ring, partition uint64) ([]*ring.Device, ring.MoreNodes) {
-	devs, more := oc.proxyDirectClient.writeNodes(r, partition)
-	if oc.deviceLimit > 0 && len(devs) > oc.deviceLimit {
-		return devs[0:oc.deviceLimit], &lessMore{devs: devs[oc.deviceLimit:], more: more, limit: oc.deviceLimit}
-	}
-	return devs, &lessMore{more: more, limit: len(devs)}
-}
-
 func (oc *standardObjectClient) putObject(account, container, obj string, headers http.Header, src io.Reader) *http.Response {
 	objectPartition := oc.objectRing.GetPartition(account, container, obj)
 	containerPartition := oc.proxyDirectClient.ContainerRing.GetPartition(account, container, "")
@@ -780,8 +754,8 @@ func (oc *standardObjectClient) putObject(account, container, obj string, header
 	cancel := make(chan struct{})
 	defer close(cancel)
 	responsec := make(chan *http.Response)
-	devs, more := oc.writeNodes(oc.objectRing, objectPartition)
-	objectReplicaCount := len(devs)
+	devs, more := oc.objectRing.getWriteNodes(objectPartition, oc.deviceLimit)
+	objectReplicaCount := int(oc.objectRing.ReplicaCount())
 
 	devToRequest := func(index int, dev *ring.Device) (*http.Request, error) {
 		trp, wp := io.Pipe()
@@ -905,7 +879,7 @@ func (oc *standardObjectClient) postObject(account, container, obj string, heade
 
 func (oc *standardObjectClient) getObject(account, container, obj string, headers http.Header) *http.Response {
 	partition := oc.objectRing.GetPartition(account, container, obj)
-	return oc.proxyDirectClient.firstResponse(oc.objectRing, partition, oc.deviceLimit, func(dev *ring.Device) (*http.Request, error) {
+	return oc.proxyDirectClient.firstResponse(oc.objectRing, partition, func(dev *ring.Device) (*http.Request, error) {
 		url := fmt.Sprintf("%s://%s:%d/%s/%d/%s/%s/%s", dev.Scheme, dev.Ip, dev.Port, dev.Device, partition,
 			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj))
 		req, err := http.NewRequest("GET", url, nil)
@@ -922,7 +896,7 @@ func (oc *standardObjectClient) getObject(account, container, obj string, header
 
 func (oc *standardObjectClient) grepObject(account, container, obj string, search string) *http.Response {
 	partition := oc.objectRing.GetPartition(account, container, obj)
-	return oc.proxyDirectClient.firstResponse(oc.objectRing, partition, oc.deviceLimit, func(dev *ring.Device) (*http.Request, error) {
+	return oc.proxyDirectClient.firstResponse(oc.objectRing, partition, func(dev *ring.Device) (*http.Request, error) {
 		url := fmt.Sprintf("%s://%s:%d/%s/%d/%s/%s/%s?e=%s", dev.Scheme, dev.Ip, dev.Port, dev.Device, partition,
 			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj), common.Urlencode(search))
 		req, err := http.NewRequest("GREP", url, nil)
@@ -936,7 +910,7 @@ func (oc *standardObjectClient) grepObject(account, container, obj string, searc
 
 func (oc *standardObjectClient) headObject(account, container, obj string, headers http.Header) *http.Response {
 	partition := oc.objectRing.GetPartition(account, container, obj)
-	return oc.proxyDirectClient.firstResponse(oc.objectRing, partition, oc.deviceLimit, func(dev *ring.Device) (*http.Request, error) {
+	return oc.proxyDirectClient.firstResponse(oc.objectRing, partition, func(dev *ring.Device) (*http.Request, error) {
 		url := fmt.Sprintf("%s://%s:%d/%s/%d/%s/%s/%s", dev.Scheme, dev.Ip, dev.Port, dev.Device, partition,
 			common.Urlencode(account), common.Urlencode(container), common.Urlencode(obj))
 		req, err := http.NewRequest("HEAD", url, nil)
@@ -977,7 +951,7 @@ func (oc *standardObjectClient) deleteObject(account, container, obj string, hea
 }
 
 func (oc *standardObjectClient) ring() (ring.Ring, *http.Response) {
-	return oc.objectRing, nil
+	return oc.objectRing.ring(), nil
 }
 
 type directClient struct {

--- a/client/nodeiter.go
+++ b/client/nodeiter.go
@@ -1,0 +1,154 @@
+package client
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/troubling/hummingbird/common/ring"
+)
+
+type ringFilter interface {
+	ReplicaCount() (cnt uint64)
+	GetPartition(account string, container string, object string) uint64
+	GetNodes(partition uint64) []*ring.Device
+	getReadNodes(partition uint64) ([]*ring.Device, ring.MoreNodes)
+	getWriteNodes(partition uint64, deviceLimit int) ([]*ring.Device, ring.MoreNodes)
+	ring() ring.Ring
+}
+
+type writeNodeIter struct {
+	mutex      sync.Mutex
+	devs       []*ring.Device
+	more       ring.MoreNodes
+	waffRegion int
+	waffCount  int
+	limit      int
+}
+
+func (wni *writeNodeIter) next() *ring.Device {
+	var dev *ring.Device
+	for {
+		if len(wni.devs) > 0 {
+			dev = wni.devs[0]
+			wni.devs = wni.devs[1:]
+		} else {
+			dev = wni.more.Next()
+		}
+		if dev == nil {
+			return nil
+		}
+		if wni.waffCount <= 0 || wni.waffRegion == -1 || dev.Region == wni.waffRegion {
+			wni.waffCount--
+			return dev
+		}
+	}
+}
+
+func (wni *writeNodeIter) Next() *ring.Device {
+	wni.mutex.Lock()
+	defer wni.mutex.Unlock()
+
+	if wni.limit <= 0 {
+		return nil
+	}
+	wni.limit--
+	return wni.next()
+}
+
+type readAffSection struct {
+	zone   int
+	region int
+	weight float64
+}
+
+type clientRingFilter struct {
+	ring.Ring
+	raffs      []readAffSection
+	waffRegion int
+	waffCount  int
+}
+
+func (a *clientRingFilter) ring() ring.Ring {
+	return a.Ring
+}
+
+func (a *clientRingFilter) getReadNodes(partition uint64) ([]*ring.Device, ring.MoreNodes) {
+	devs := a.GetNodes(partition)
+	d2a := make(map[*ring.Device]int, len(devs))
+	for i := len(a.raffs) - 1; i >= 0; i-- {
+		af := a.raffs[i]
+		for _, dev := range devs {
+			if (af.region == -1 || af.region == dev.Region) && (af.zone == -1 || af.zone == dev.Zone) {
+				d2a[dev] = i
+			}
+		}
+	}
+	rand.Shuffle(len(devs), func(i, j int) { devs[i], devs[j] = devs[j], devs[i] })
+	sort.SliceStable(devs, func(i, j int) bool { return d2a[devs[i]] < d2a[devs[j]] })
+	return devs, a.Ring.GetMoreNodes(partition)
+}
+
+func (a *clientRingFilter) getWriteNodes(partition uint64, deviceLimit int) ([]*ring.Device, ring.MoreNodes) {
+	var ndevs []*ring.Device
+	devs := a.GetNodes(partition)
+	if deviceLimit == 0 {
+		deviceLimit = len(devs)
+	}
+	more := &writeNodeIter{
+		devs:       devs,
+		more:       a.GetMoreNodes(partition),
+		waffRegion: a.waffRegion,
+		waffCount:  a.waffCount,
+		limit:      deviceLimit,
+	}
+	if deviceLimit < len(devs) {
+		ndevs = make([]*ring.Device, deviceLimit)
+	} else {
+		ndevs = make([]*ring.Device, len(devs))
+	}
+	for i := range ndevs {
+		ndevs[i] = more.next()
+	}
+	return ndevs, more
+}
+
+func newClientRingFilter(r ring.Ring, readAff, writeAff, waffCount string) *clientRingFilter {
+	waffRegion := -1
+	fmt.Sscanf(writeAff, "r%d", &waffRegion)
+
+	wc := 0
+	var f float64
+	if v, err := strconv.ParseInt(waffCount, 0, 64); err == nil {
+		wc = int(v)
+	} else if n, err := fmt.Sscanf(waffCount, "%f * replicas", &f); err == nil && n == 1 {
+		wc = int(math.Ceil(f * float64(r.ReplicaCount())))
+	} else {
+		wc = int(2 * r.ReplicaCount())
+	}
+
+	sections := strings.Split(readAff, ",")
+	raffs := make([]readAffSection, 0, len(sections))
+	for i := range sections {
+		var weight float64
+		var zone, region int
+		if n, err := fmt.Sscanf(strings.TrimSpace(sections[i]), "r%dz%d=%f", &region, &zone, &weight); err == nil && n == 3 {
+			raffs = append(raffs, readAffSection{zone: zone, region: region, weight: weight})
+		} else if n, err := fmt.Sscanf(strings.TrimSpace(sections[i]), "r%d=%f", &region, &weight); err == nil && n == 2 {
+			raffs = append(raffs, readAffSection{zone: -1, region: region, weight: weight})
+		}
+	}
+	sort.Slice(raffs, func(i, j int) bool { return raffs[i].weight < raffs[j].weight })
+	raffs = append(raffs, readAffSection{zone: -1, region: -1, weight: -1})
+
+	return &clientRingFilter{
+		Ring:       r,
+		raffs:      raffs,
+		waffRegion: waffRegion,
+		waffCount:  wc,
+	}
+}

--- a/client/nodeiter_test.go
+++ b/client/nodeiter_test.go
@@ -1,0 +1,114 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/troubling/hummingbird/common/ring"
+	"github.com/troubling/hummingbird/common/test"
+)
+
+func TestAffinityReadOrder(t *testing.T) {
+	r := &test.FakeRing{
+		MockDevices: []*ring.Device{
+			{Id: 0, Region: 1, Zone: 2, Device: "sda"},
+			{Id: 1, Region: 2, Zone: 2, Device: "sdc"},
+			{Id: 2, Region: 1, Zone: 1, Device: "sdb"},
+		},
+	}
+
+	a := newClientRingFilter(r, "r1z1=100, r1=200", "", "")
+	devs, _ := a.getReadNodes(1)
+	require.Equal(t, "sdb", devs[0].Device)
+	require.Equal(t, "sda", devs[1].Device)
+	require.Equal(t, "sdc", devs[2].Device)
+
+	a = newClientRingFilter(r, "r1=200, r1z1=100", "", "")
+	devs, _ = a.getReadNodes(1)
+	require.Equal(t, "sdb", devs[0].Device)
+	require.Equal(t, "sda", devs[1].Device)
+	require.Equal(t, "sdc", devs[2].Device)
+}
+
+type fakeRing struct {
+	*test.FakeRing
+	nodes []*ring.Device
+}
+
+func (fr *fakeRing) GetNodes(partition uint64) []*ring.Device {
+	return fr.nodes
+}
+
+func TestWriteAffinityFiltering(t *testing.T) {
+	r := &fakeRing{
+		FakeRing: &test.FakeRing{
+			MockMoreNodes: &ring.Device{Id: 6, Region: 1, Zone: 1, Device: "sdg"},
+		},
+		nodes: []*ring.Device{
+			{Id: 0, Region: 1, Zone: 1, Device: "sda"},
+			{Id: 1, Region: 2, Zone: 1, Device: "sdb"},
+			{Id: 2, Region: 1, Zone: 1, Device: "sdc"},
+			{Id: 3, Region: 2, Zone: 1, Device: "sdd"},
+			{Id: 4, Region: 1, Zone: 1, Device: "sde"},
+			{Id: 5, Region: 2, Zone: 1, Device: "sdf"},
+		},
+	}
+
+	a := newClientRingFilter(r, "", "r1", "")
+	devs, _ := a.getWriteNodes(1, 4)
+	require.Equal(t, 4, len(devs))
+	require.Equal(t, 0, devs[0].Id)
+	require.Equal(t, 2, devs[1].Id)
+	require.Equal(t, 4, devs[2].Id)
+	require.Equal(t, 6, devs[3].Id)
+}
+
+func TestParseWaffCount(t *testing.T) {
+	a := newClientRingFilter(&test.FakeRing{}, "", "r1", "")
+	require.Equal(t, 6, a.waffCount)
+	a = newClientRingFilter(&test.FakeRing{}, "", "r1", "7")
+	require.Equal(t, 7, a.waffCount)
+	a = newClientRingFilter(&test.FakeRing{}, "", "r1", "3 * replicas")
+	require.Equal(t, 9, a.waffCount)
+	a = newClientRingFilter(&test.FakeRing{}, "", "r1", "2.5 * replicas")
+	require.Equal(t, 8, a.waffCount)
+	a = newClientRingFilter(&test.FakeRing{}, "", "r1", "7 * monkeys")
+	require.Equal(t, 6, a.waffCount)
+}
+
+func TestDeviceLimit(t *testing.T) {
+	r := &fakeRing{
+		FakeRing: &test.FakeRing{
+			MockMoreNodes: &ring.Device{Id: 6, Region: 1, Zone: 1, Device: "sdg"},
+		},
+		nodes: []*ring.Device{
+			{Id: 0, Region: 1, Zone: 1, Device: "sda"},
+			{Id: 1, Region: 2, Zone: 1, Device: "sdb"},
+			{Id: 2, Region: 1, Zone: 1, Device: "sdc"},
+			{Id: 3, Region: 2, Zone: 1, Device: "sdd"},
+			{Id: 4, Region: 1, Zone: 1, Device: "sde"},
+			{Id: 5, Region: 2, Zone: 1, Device: "sdf"},
+		},
+	}
+	a := newClientRingFilter(r, "", "", "")
+
+	devs, _ := a.getWriteNodes(1, 0)
+	require.Equal(t, 6, len(devs))
+
+	devs, more := a.getWriteNodes(1, 4)
+	require.Equal(t, 4, len(devs))
+	i := 0
+	for more.Next() != nil {
+		i++
+	}
+	require.Equal(t, 4, i)
+
+	devs, more = a.getWriteNodes(1, 2)
+	require.Equal(t, 2, len(devs))
+
+	i = 0
+	for more.Next() != nil {
+		i++
+	}
+	require.Equal(t, 2, i)
+}

--- a/proxyserver/main.go
+++ b/proxyserver/main.go
@@ -189,6 +189,9 @@ func NewServer(serverconf conf.Config, flags *flag.FlagSet, cnf srv.ConfigLoader
 	certFile := serverconf.GetDefault("DEFAULT", "cert_file", "")
 	keyFile := serverconf.GetDefault("DEFAULT", "key_file", "")
 
+	readAff := serverconf.GetDefault("app:proxy-server", "read_affinity", "")
+	writeAff := serverconf.GetDefault("app:proxy-server", "write_affinity", "")
+	writeAffCount := serverconf.GetDefault("app:proxy-server", "write_affinity_node_count", "")
 	logLevelString := serverconf.GetDefault("app:proxy-server", "log_level", "INFO")
 	server.logLevel = zap.NewAtomicLevel()
 	server.logLevel.UnmarshalText([]byte(strings.ToLower(logLevelString)))
@@ -200,7 +203,8 @@ func NewServer(serverconf conf.Config, flags *flag.FlagSet, cnf srv.ConfigLoader
 	if err != nil {
 		return ipPort, nil, nil, err
 	}
-	server.proxyDirectClient, err = client.NewProxyDirectClient(policies, cnf, server.logger, certFile, keyFile)
+	server.proxyDirectClient, err = client.NewProxyDirectClient(
+		policies, cnf, server.logger, certFile, keyFile, readAff, writeAff, writeAffCount)
 	if err != nil {
 		return ipPort, nil, nil, fmt.Errorf("Error setting up proxyDirectClient: %v", err)
 	}

--- a/tools/main.go
+++ b/tools/main.go
@@ -658,7 +658,7 @@ func NewAdmin(serverconf conf.Config, flags *flag.FlagSet, cnf srv.ConfigLoader)
 	port := int(serverconf.GetInt("andrewd", "bind_port", common.DefaultAndrewdPort))
 	certFile := serverconf.GetDefault("andrewd", "cert_file", "")
 	keyFile := serverconf.GetDefault("andrewd", "key_file", "")
-	pdc, pdcerr := client.NewProxyDirectClient(policies, srv.DefaultConfigLoader{}, logger, certFile, keyFile)
+	pdc, pdcerr := client.NewProxyDirectClient(policies, srv.DefaultConfigLoader{}, logger, certFile, keyFile, "", "", "")
 	if pdcerr != nil {
 		return ipPort, nil, nil, fmt.Errorf("Could not make client: %v", pdcerr)
 	}


### PR DESCRIPTION
Which is a pretty grandiose name for using slightly different node
sorting strategies.  Implemented (mostly) as described here:

https://docs.openstack.org/swift/ocata/overview_global_cluster.html

This lets you set read and write affinity.  Nobody should probably
ever use write affinity, but it is included for feature parity and
because it's not that complicated.

I didn't implement sorting_method, it just uses read affinity if it's
set.