### PR TITLE
HUM-725 Rework RingMD5 a bit

### DIFF
--- a/tools/ringscan.go
+++ b/tools/ringscan.go
@@ -237,6 +237,7 @@ func (rs *ringScan) runOnce() time.Duration {
 			}
 		}
 	}
+	fullpass := true
 	if rs.fastScan {
 		var wg sync.WaitGroup
 		fastScanURLs := make(chan string, rs.fastScanConcurrency)
@@ -263,6 +264,7 @@ func (rs *ringScan) runOnce() time.Duration {
 		for _, url := range urls {
 			select {
 			case <-rs.aa.fastRingScan:
+				fullpass = false
 				rs.aa.fastRingScan <- struct{}{}
 				break STANDARDSCAN
 			case <-time.After(rs.delay):
@@ -272,7 +274,7 @@ func (rs *ringScan) runOnce() time.Duration {
 	}
 	close(cancel)
 	<-progressDone
-	if !rs.fastScan {
+	if !rs.fastScan && fullpass && delays > 0 {
 		rs.delay = rs.passTimeTarget / time.Duration(delays)
 	}
 	sleepFor := time.Until(start.Add(rs.passTimeTarget))


### PR DESCRIPTION
RingMD5s are no longer cached by default; the code that uses RingMD5s
can cache if it wants to. This will ensure we can somewhat reason about
when the data underlying the RingMD5 can change. Before the ring monitor
and the ring scanner could affect one another, mid-pass.

I also improved the ring scan to break out of a slow scan when a fast
scan is requested, mid-pass.

I improved the ring monitor's auto-rebalancer to take into account
zero-weight devices. It should now continue to rebalance when
zero-weight devices still have assignements, even if the last rebalance
changed a very tiny number of assignments. This required a new
AssignmentCount method on the RingMD5s.

I also fixed a bug in the logic from before where it would not queue up
replication jobs for auto-rebalance changes.