### PR TITLE
HUM-722 Andrewd unmounted monitor optimization

### DIFF
--- a/tools/dispersionpopulatecontainers.go
+++ b/tools/dispersionpopulatecontainers.go
@@ -70,7 +70,10 @@ func (dpc *dispersionPopulateContainers) runOnce() time.Duration {
 			case <-time.After(dpc.reportInterval):
 				s := atomic.LoadInt64(&successes)
 				e := atomic.LoadInt64(&errors)
-				eta := time.Duration(int64(time.Since(start)) / (s + e) * (int64(containerRing.PartitionCount()) - s - e))
+				var eta time.Duration
+				if s+e > 0 {
+					eta = time.Duration(int64(time.Since(start)) / (s + e) * (int64(containerRing.PartitionCount()) - s - e))
+				}
 				logger.Debug("progress", zap.Int64("successes", s), zap.Int64("errors", e), zap.String("eta", eta.String()))
 				if err := dpc.aa.db.progressProcessPass("dispersion populate", "container", 0, fmt.Sprintf("%d of %d partitions, %d successes, %d errors, %s eta", s+e, containerRing.PartitionCount(), s, e, eta)); err != nil {
 					logger.Error("progressProcessPass", zap.Error(err))

--- a/tools/dispersionpopulateobjects.go
+++ b/tools/dispersionpopulateobjects.go
@@ -129,7 +129,10 @@ func (dpo *dispersionPopulateObjects) putDispersionObjects(logger *zap.Logger, p
 			case <-time.After(dpo.reportInterval):
 				s := atomic.LoadInt64(&successes)
 				e := atomic.LoadInt64(&errors)
-				eta := time.Duration(int64(time.Since(start)) / (s + e) * (int64(objectRing.PartitionCount()) - s - e))
+				var eta time.Duration
+				if s+e > 0 {
+					eta = time.Duration(int64(time.Since(start)) / (s + e) * (int64(objectRing.PartitionCount()) - s - e))
+				}
 				logger.Debug("progress", zap.Int64("successes", s), zap.Int64("errors", e), zap.String("eta", eta.String()))
 				if err := dpo.aa.db.progressProcessPass("dispersion populate", "object", policy.Index, fmt.Sprintf("%d of %d partitions, %d successes, %d errors, %s eta", s+e, objectRing.PartitionCount(), s, e, eta)); err != nil {
 					logger.Error("progressProcessPass", zap.Error(err))

--- a/tools/dispersionscancontainers.go
+++ b/tools/dispersionscancontainers.go
@@ -105,7 +105,10 @@ func (dsc *dispersionScanContainers) runOnce() time.Duration {
 				return
 			case <-time.After(dsc.reportInterval):
 				d := atomic.LoadInt64(&delays)
-				eta := time.Duration(int64(time.Since(start)) / d * (int64(ctx.ring.PartitionCount()) - d))
+				var eta time.Duration
+				if d > 0 {
+					eta = time.Duration(int64(time.Since(start)) / d * (int64(ctx.ring.PartitionCount()) - d))
+				}
 				logger.Debug("progress", zap.Int64("partitions", d), zap.String("eta", eta.String()))
 				if err := dsc.aa.db.progressProcessPass("dispersion scan", "container", 0, fmt.Sprintf("%d of %d partitions, %d not found, %d errored, %s eta", d, ctx.ring.PartitionCount(), atomic.LoadInt64(&ctx.notFound), atomic.LoadInt64(&ctx.errored), eta)); err != nil {
 					logger.Error("progressProcessPass", zap.Error(err))

--- a/tools/dispersionscanobjects.go
+++ b/tools/dispersionscanobjects.go
@@ -165,7 +165,10 @@ func (dso *dispersionScanObjects) scanDispersionObjects(logger *zap.Logger, poli
 				return
 			case <-time.After(dso.reportInterval):
 				d := atomic.LoadInt64(&delays)
-				eta := time.Duration(int64(time.Since(start)) / d * (int64(ctx.ring.PartitionCount()) - d))
+				var eta time.Duration
+				if d > 0 {
+					eta = time.Duration(int64(time.Since(start)) / d * (int64(ctx.ring.PartitionCount()) - d))
+				}
 				logger.Debug("progress", zap.Int64("partitions", d), zap.String("eta", eta.String()))
 				if err := dso.aa.db.progressProcessPass("dispersion scan", "object", policy.Index, fmt.Sprintf("%d of %d partitions, %d not found, %d errored, %s eta", d, ctx.ring.PartitionCount(), atomic.LoadInt64(&ctx.notFound), atomic.LoadInt64(&ctx.errored), eta)); err != nil {
 					logger.Error("progressProcessPass", zap.Error(err))

--- a/tools/quarantinehistory.go
+++ b/tools/quarantinehistory.go
@@ -90,7 +90,10 @@ func (qh *quarantineHistory) runOnce() time.Duration {
 				e := atomic.LoadInt64(&errors)
 				p := atomic.LoadInt64(&itemsPurged)
 				l := atomic.LoadInt64(&itemsLeft)
-				eta := time.Duration(int64(time.Since(start)) / d * (int64(len(urls)) - d))
+				var eta time.Duration
+				if d > 0 {
+					eta = time.Duration(int64(time.Since(start)) / d * (int64(len(urls)) - d))
+				}
 				logger.Debug("progress", zap.Int64("urls so far", d), zap.Int("total urls", len(urls)), zap.String("eta", eta.String()))
 				if err := qh.aa.db.progressProcessPass("quarantine history", "", 0, fmt.Sprintf("%d of %d urls, %d errors, %d purged, %d left for next pass, eta %s", d, len(urls), e, p, l, eta)); err != nil {
 					logger.Error("progressProcessPass", zap.Error(err))

--- a/tools/quarantinerepair.go
+++ b/tools/quarantinerepair.go
@@ -78,7 +78,10 @@ func (qr *quarantineRepair) runOnce() time.Duration {
 				d := atomic.LoadInt64(&delays)
 				r := atomic.LoadInt64(&repairsMade)
 				p := atomic.LoadInt64(&partitionReplicationsQueued)
-				eta := time.Duration(int64(time.Since(start)) / d * (int64(len(urls)) - d))
+				var eta time.Duration
+				if d > 0 {
+					eta = time.Duration(int64(time.Since(start)) / d * (int64(len(urls)) - d))
+				}
 				logger.Debug("progress", zap.Int64("urls so far", d), zap.Int("total urls", len(urls)), zap.String("eta", eta.String()))
 				if err := qr.aa.db.progressProcessPass("quarantine repair", "", 0, fmt.Sprintf("%d of %d urls, %d repairs made, %d partition replications queued, eta %s", d, len(urls), r, p, eta)); err != nil {
 					logger.Error("progressProcessPass", zap.Error(err))

--- a/tools/replication.go
+++ b/tools/replication.go
@@ -136,7 +136,10 @@ func (r *replication) progress(ctx *replicationContext) {
 			ctx.ipDevsInUseLock.Unlock()
 			countLeft := atomic.LoadInt64(&ctx.countLeft)
 			countDone := atomic.LoadInt64(&ctx.countDone)
-			eta := time.Duration(int64(time.Since(ctx.start)) / countDone * countLeft)
+			var eta time.Duration
+			if countDone > 0 {
+				eta = time.Duration(int64(time.Since(ctx.start)) / countDone * countLeft)
+			}
 			ctx.logger.Debug("progress", zap.Int64("jobs done", countDone), zap.Int64("jobs left", countLeft), zap.Int("active devices", activeDevs), zap.String("eta", eta.String()))
 			if err := r.aa.db.progressProcessPass("replication", "", 0, fmt.Sprintf("%d jobs done, %d jobs left, %d active devices, %s eta", countDone, countLeft, activeDevs, eta)); err != nil {
 				ctx.logger.Error("progressProcessPass", zap.Error(err))

--- a/tools/ringmonitor.go
+++ b/tools/ringmonitor.go
@@ -121,7 +121,10 @@ func (rm *ringMonitor) runOnce() time.Duration {
 				d := atomic.LoadInt64(&delays)
 				e := atomic.LoadInt64(&errors)
 				p := atomic.LoadInt64(&partitionCopiesChanged)
-				eta := time.Duration(int64(time.Since(start)) / d * (int64(len(ringTasks)) - d))
+				var eta time.Duration
+				if d > 0 {
+					eta = time.Duration(int64(time.Since(start)) / d * (int64(len(ringTasks)) - d))
+				}
 				logger.Debug("progress", zap.Int64("rings so far", d), zap.Int("total rings", len(ringTasks)), zap.Int64("errors", e), zap.Int64("partition copies changed", p), zap.String("eta", eta.String()))
 				if err := rm.aa.db.progressProcessPass("ring monitor", "", 0, fmt.Sprintf("%d of %d rings, %d errors, %d partition copies changed, eta %s", d, len(ringTasks), e, p, eta)); err != nil {
 					logger.Error("progressProcessPass", zap.Error(err))

--- a/tools/ringscan.go
+++ b/tools/ringscan.go
@@ -124,7 +124,10 @@ func (rs *ringScan) runOnce() time.Duration {
 			case <-time.After(rs.reportInterval):
 				d := atomic.LoadInt64(&delays)
 				e := atomic.LoadInt64(&errors)
-				eta := time.Duration(int64(time.Since(start)) / d * (int64(len(urls)) - d))
+				var eta time.Duration
+				if d > 0 {
+					eta = time.Duration(int64(time.Since(start)) / d * (int64(len(urls)) - d))
+				}
 				logger.Debug("progress", zap.Int64("urls so far", d), zap.Int("total urls", len(urls)), zap.String("eta", eta.String()))
 				if err := rs.aa.db.progressProcessPass("ring scan", "", 0, fmt.Sprintf("%d of %d urls, %d errors, eta %s", d, len(urls), e, eta)); err != nil {
 					logger.Error("progressProcessPass", zap.Error(err))


### PR DESCRIPTION
Now when a device is cleared from a ring, or attempted to be cleared
from a ring, any more attempts to clear it from that ring will be
ignored for a while (4 hours by default).

This is needed because the servers report all unmounted devices for
forever and forever trying to remove them from the builders is more
wasteful than I thought. Loading those builders up just to check if the
device is in the ring takes a lot more time than I thought, especially
with 2**22 rings.

Anyway, we can't permanently ignore them after ensuring they're cleared
because someone could add them back in outside of Andrewd. So... ignore
durations!