### PR TITLE
HUM-810 Move tracing middleware in proxy server in front of context m…

### DIFF
--- a/client/directclient.go
+++ b/client/directclient.go
@@ -175,7 +175,7 @@ func (c *ProxyDirectClient) quorumResponse(r ringFilter, partition uint64, devTo
 			var firstResp *http.Response
 			for dev := devs[index]; dev != nil; dev = more.Next() {
 				if req, err := devToRequest(index, dev); err != nil {
-					c.Logger.Error("unable to get response", zap.Error(err))
+					c.Logger.Error("unable to create request", zap.Error(err))
 					resp = nectarutil.ResponseStub(http.StatusInternalServerError, err.Error())
 				} else if r, err := c.client.Do(req); err != nil {
 					c.Logger.Error("unable to get response", zap.Error(err))

--- a/objectserver/update.go
+++ b/objectserver/update.go
@@ -27,13 +27,14 @@ import (
 	"strings"
 	"time"
 
+	"context"
+
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/pickle"
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/middleware"
 	"go.uber.org/zap"
-	"golang.org/x/net/context"
 )
 
 /*This hash is used to represent a zero byte async file that is

--- a/proxyserver/main.go
+++ b/proxyserver/main.go
@@ -179,8 +179,8 @@ func (server *ProxyServer) GetHandler(config conf.Config, metricsPrefix string) 
 			{middleware.NewXlo, "filter:slo"},
 		}
 	}
-	pipeline := alice.New(middleware.NewContext(config.GetBool("debug", "debug_x_source_code", false),
-		server.mc, server.logger, server.proxyDirectClient), globalmiddleware.ServerTracer(server.tracer))
+	pipeline := alice.New(globalmiddleware.ServerTracer(server.tracer), middleware.NewContext(config.GetBool("debug", "debug_x_source_code", false),
+		server.mc, server.logger, server.proxyDirectClient))
 	for _, m := range middlewares {
 		mid, err := m.construct(config.GetSection(m.section), metricsScope)
 		if err != nil {

--- a/proxyserver/middleware/authtoken_test.go
+++ b/proxyserver/middleware/authtoken_test.go
@@ -26,11 +26,12 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
-	"golang.org/x/net/context"
 
 	"github.com/troubling/hummingbird/common/test"
 )


### PR DESCRIPTION
…iddleware

It seems like Proxy's context middleware make some container/account info calls,
so in order to capture those calls in same trace, we need to move tracing middleware in front.

Also use context package everywhere instead of golang.org/x/net/context.