### PR TITLE
HUM-848 : audit object before tempfile accepts it as already there

### DIFF
--- a/common/expects_test.go
+++ b/common/expects_test.go
@@ -55,7 +55,7 @@ func TestExpectorSuccesses(t *testing.T) {
 		require.Nil(t, err)
 		e.AddRequest(req)
 	}
-	require.Equal(t, 3, e.Successes(time.Second, false))
+	require.Equal(t, 3, e.Successes(time.Second, []int{2}...))
 }
 
 func TestExpectorSuccessesWith404Fail(t *testing.T) {
@@ -72,7 +72,7 @@ func TestExpectorSuccessesWith404Fail(t *testing.T) {
 		require.Nil(t, err)
 		e.AddRequest(req)
 	}
-	require.Equal(t, 2, e.Successes(time.Second, false))
+	require.Equal(t, 2, e.Successes(time.Second, []int{2}...))
 }
 
 func TestExpectorSuccessesWith404Pass(t *testing.T) {
@@ -89,7 +89,7 @@ func TestExpectorSuccessesWith404Pass(t *testing.T) {
 		require.Nil(t, err)
 		e.AddRequest(req)
 	}
-	require.Equal(t, 3, e.Successes(time.Second, true))
+	require.Equal(t, 3, e.Successes(time.Second, []int{2, 404}...))
 }
 
 func TestExpectorReady(t *testing.T) {
@@ -137,7 +137,7 @@ func TestExpectorErrorRetry(t *testing.T) {
 	require.Nil(t, err)
 	e.AddRequest(req)
 
-	require.Equal(t, 3, e.Successes(time.Second, false))
+	require.Equal(t, 3, e.Successes(time.Second, []int{2}...))
 	_, ready := e.Wait(time.Second)
 	require.Equal(t, 4, len(ready))
 	require.Equal(t, false, ready[0])

--- a/objectserver/auditor_test.go
+++ b/objectserver/auditor_test.go
@@ -39,6 +39,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeIndexDBAuditor struct{}
+
+func (fakeIndexDBAuditor) AuditItem(path string, item *IndexDBItem, md5BytesPerSec int64) (int64, error) {
+	return 0, nil
+}
+
 type fakeECAuditFunc struct {
 	paths        []string
 	shards       []string
@@ -529,7 +535,7 @@ func TestAuditDB(t *testing.T) {
 	policydir := filepath.Join(dir, "objects-2")
 	dbdir := filepath.Join(policydir, "hec.db")
 	hecdir := filepath.Join(policydir, "hec")
-	db, err := NewIndexDB(dbdir, hecdir, dir, 2, 1, 32, 0, zap.L())
+	db, err := NewIndexDB(dbdir, hecdir, dir, 2, 1, 32, 0, zap.L(), fakeIndexDBAuditor{})
 	assert.Nil(t, err)
 	body := "some shard content nonsense"
 	shardHash := "d3ac5112fe464b81184352ccba743001"
@@ -690,7 +696,7 @@ func TestQuarantineShard(t *testing.T) {
 	policydir := filepath.Join(dir, "objects")
 	dbdir := filepath.Join(policydir, "hec.db")
 	hecdir := filepath.Join(policydir, "hec")
-	db, err := NewIndexDB(dbdir, hecdir, dir, 2, 1, 32, 0, zap.L())
+	db, err := NewIndexDB(dbdir, hecdir, dir, 2, 1, 32, 0, zap.L(), fakeIndexDBAuditor{})
 	timestamp := time.Now().UnixNano()
 	hash := "00000000000000000000000000000000"
 	body := "nonsense"

--- a/objectserver/ecobj_test.go
+++ b/objectserver/ecobj_test.go
@@ -29,6 +29,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/stretchr/testify/require"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/test"
@@ -285,6 +287,7 @@ func TestDontStabilizeWithFailure(t *testing.T) {
 			{Id: 4, Scheme: u.Scheme, ReplicationIp: u.Hostname(), ReplicationPort: port, Device: "sdd"},
 		},
 	}
+	logger, _ := zap.NewProduction()
 	to := &ecObject{
 		IndexDBItem: IndexDBItem{
 			Hash:     "00000011111122222233333344444455",
@@ -301,12 +304,14 @@ func TestDontStabilizeWithFailure(t *testing.T) {
 			"Content-Length": "7",
 		},
 		nurseryReplicas: 3,
+		logger:          logger,
+		txnId:           "abcde",
 	}
 
 	node := &ring.Device{Scheme: u.Scheme, ReplicationIp: u.Hostname(), ReplicationPort: port - 1, Device: "sda"}
 	err = to.Stabilize(node)
 	require.NotNil(t, err)
-	require.Equal(t, "Failed to stabilize object", err.Error())
+	require.Equal(t, "Failed to stabilize object: abcde", err.Error())
 }
 
 func TestParseECScheme(t *testing.T) {

--- a/objectserver/ecutils.go
+++ b/objectserver/ecutils.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/klauspost/reedsolomon"
+	"github.com/troubling/hummingbird/common/srv"
 	"go.uber.org/zap"
 )
 
@@ -70,7 +71,7 @@ func ecSplit(dataChunks, parityChunks int, fp io.Reader, chunkSize int, contentL
 	return nil
 }
 
-func ecReconstruct(dataChunks, parityChunks int, bodies []io.Reader, chunkSize int, contentLength int64, dsts []io.Writer, dstChunkNum []int, logger *zap.Logger) error {
+func ecReconstruct(dataChunks, parityChunks int, bodies []io.Reader, chunkSize int, contentLength int64, dsts []io.Writer, dstChunkNum []int, logger srv.LowLevelLogger) error {
 	logger.Info(fmt.Sprintf("ecReconstruct, dsts: %+v", dsts))
 	logger.Info(fmt.Sprintf("ecReconstruct, dstChunkNum: %+v", dstChunkNum))
 	enc, err := reedsolomon.New(dataChunks, parityChunks)

--- a/objectserver/indexdb_test.go
+++ b/objectserver/indexdb_test.go
@@ -30,7 +30,7 @@ func md5hash(data string) string {
 
 func newTestIndexDB(t *testing.T, pth string) *IndexDB {
 	t.Helper()
-	ot, err := NewIndexDB(pth, pth, pth, 2, 1, 1, 0, zap.L())
+	ot, err := NewIndexDB(pth, pth, pth, 2, 1, 1, 0, zap.L(), fakeIndexDBAuditor{})
 	errnil(t, err)
 	return ot
 }
@@ -571,7 +571,7 @@ func TestIndexDB_ListDefaults(t *testing.T) {
 func TestIndexDB_RingPartRange(t *testing.T) {
 	pth, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(pth)
-	ot, err := NewIndexDB(pth, pth, pth, 4, 1, 1, 0, zap.L())
+	ot, err := NewIndexDB(pth, pth, pth, 4, 1, 1, 0, zap.L(), fakeIndexDBAuditor{})
 	errnil(t, err)
 	defer ot.Close()
 	startHash, stopHash := ot.RingPartRange(0)
@@ -595,7 +595,7 @@ func TestIndexDB_RingPartRange(t *testing.T) {
 	if stopHash != "ffffffffffffffffffffffffffffffff" {
 		t.Fatal(stopHash)
 	}
-	ot, err = NewIndexDB(pth, pth, pth, 8, 1, 1, 0, zap.L())
+	ot, err = NewIndexDB(pth, pth, pth, 8, 1, 1, 0, zap.L(), fakeIndexDBAuditor{})
 	errnil(t, err)
 	defer ot.Close()
 	startHash, stopHash = ot.RingPartRange(0)

--- a/objectserver/repobj.go
+++ b/objectserver/repobj.go
@@ -325,7 +325,7 @@ func (ro *repObject) Replicate(prirep PriorityRepJob) error {
 		return fmt.Errorf("error syncing obj %s: %v", ro.Hash, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode/100 != 2 {
+	if !(resp.StatusCode/100 == 2 || resp.StatusCode == 409) {
 		return fmt.Errorf("bad status code %d syncing obj with  %s", resp.StatusCode, ro.Hash)
 	}
 	if isHandoff {


### PR DESCRIPTION
and change everybody to use srv.LowLevelLogger

StablePut now returns a 409 if the file is already there

Expector Successes refactor