### PR TITLE
HUM-866 Fix 'context canceled' error with authToken.go preValidate call

### DIFF
--- a/common/tracing/util.go
+++ b/common/tracing/util.go
@@ -1,0 +1,31 @@
+//  Copyright (c) 2018 Rackspace
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package tracing
+
+import (
+	"context"
+
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+func CopySpanFromContext(ctx context.Context) context.Context {
+	newCtx := context.Background()
+	span := opentracing.SpanFromContext(ctx)
+	if span != nil {
+		newCtx = opentracing.ContextWithSpan(newCtx, span)
+	}
+	return newCtx
+}

--- a/containerserver/update.go
+++ b/containerserver/update.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/srv"
+	"github.com/troubling/hummingbird/common/tracing"
 	"github.com/troubling/hummingbird/middleware"
 	"go.uber.org/zap"
 )
@@ -61,8 +62,9 @@ func (server *ContainerServer) accountUpdate(writer http.ResponseWriter, request
 		for len(schemes) < len(hosts) {
 			schemes = append(schemes, "http")
 		}
+		ctx := tracing.CopySpanFromContext(request.Context())
 		for index, host := range hosts {
-			if err := accountUpdateHelper(request.Context(), info, schemes[index], host, devices[index], accpartition, vars["account"], vars["container"], request.Header.Get("X-Trans-Id"), request.Header.Get("X-Account-Override-Deleted") == "yes", server.updateClient); err != nil {
+			if err := accountUpdateHelper(ctx, info, schemes[index], host, devices[index], accpartition, vars["account"], vars["container"], request.Header.Get("X-Trans-Id"), request.Header.Get("X-Account-Override-Deleted") == "yes", server.updateClient); err != nil {
 				logger.Error(
 					"Account update failed:", zap.Error(err),
 					zap.String("schemes[index]", schemes[index]),

--- a/objectserver/update.go
+++ b/objectserver/update.go
@@ -33,6 +33,7 @@ import (
 	"github.com/troubling/hummingbird/common/fs"
 	"github.com/troubling/hummingbird/common/pickle"
 	"github.com/troubling/hummingbird/common/srv"
+	"github.com/troubling/hummingbird/common/tracing"
 	"github.com/troubling/hummingbird/middleware"
 	"go.uber.org/zap"
 )
@@ -152,7 +153,8 @@ func (server *ObjectServer) containerUpdates(writer http.ResponseWriter, request
 
 	done := make(chan struct{}, 1)
 	go func() {
-		server.updateContainer(request.Context(), metadata, request, vars, logger)
+		ctx := tracing.CopySpanFromContext(request.Context())
+		server.updateContainer(ctx, metadata, request, vars, logger)
 		done <- struct{}{}
 	}()
 	select {

--- a/proxyserver/middleware/authtoken.go
+++ b/proxyserver/middleware/authtoken.go
@@ -225,6 +225,7 @@ func (at *authToken) preValidate(ctx context.Context, proxyCtx *ProxyContext, au
 		at.preValidations[authToken] = true
 	}
 	go func() {
+		ctx = tracing.CopySpanFromContext(ctx)
 		at.validate(ctx, proxyCtx, authToken)
 		at.lock.Lock()
 		defer at.lock.Unlock()


### PR DESCRIPTION
authtoken's preValidate function creates a separate goroutine to
validate/prepopulate token in cache before expiry.
Recently we added context.Context to this call, which uses parent
request's context to propagate tracing info. However side-effect
of using parent request's context is that when parent request
ends it send cancel signal to all of its derived context. Hence preValidate
goroutine call was always failing with 'context canceled' error.

In order to fix this now we create a new Context and extract the tracing span from original
request's context. We then inject the extracted span into new Context and use this context.

This PR also fix similar problem  with containerserver's accountUpdate & objectserver's
containerUpdates functions.