### PR TITLE
HUM-836 : report stats for nursery stabilizer

### DIFF
--- a/objectserver/objengine.go
+++ b/objectserver/objengine.go
@@ -72,6 +72,7 @@ type ReplicationDevice interface {
 	Cancel()
 	PriorityReplicate(w http.ResponseWriter, pri PriorityRepJob)
 	UpdateStat(string, int64)
+	Type() string
 }
 
 // ObjectEngine is the type you have to give hummingbird to create a new object engine.

--- a/objectserver/replicator.go
+++ b/objectserver/replicator.go
@@ -219,7 +219,7 @@ func (r *Replicator) verifyRunningDevices() {
 			if _, ok := r.runningDevices[key]; !ok {
 				if rd, err := objEngine.GetReplicationDevice(oring, dev, r); err == nil {
 					r.runningDevices[key] = rd
-					r.stats["object-replicator"][key] = &DeviceStats{
+					r.stats[rd.Type()][key] = &DeviceStats{
 						LastCheckin: time.Now(), DeviceStarted: time.Now(),
 						Stats: map[string]int64{},
 					}
@@ -307,11 +307,11 @@ func (r *Replicator) reportStats() {
 	}
 }
 
-func (r *Replicator) getDeviceProgress() map[string]*DeviceStats {
+func (r *Replicator) getDeviceProgress(name string) map[string]*DeviceStats {
 	r.runningDevicesLock.Lock()
 	defer r.runningDevicesLock.Unlock()
 	deviceProgress := make(map[string]*DeviceStats)
-	for key, stats := range r.stats["object-replicator"] {
+	for key, stats := range r.stats[name] {
 		deviceProgress[key] = stats
 	}
 	return deviceProgress

--- a/objectserver/replicator_test.go
+++ b/objectserver/replicator_test.go
@@ -149,6 +149,9 @@ func (d *mockReplicationDevice) Key() string {
 	}
 	return ""
 }
+func (d *mockReplicationDevice) Type() string {
+	return "object-replicator"
+}
 func (d *mockReplicationDevice) Cancel() {
 	if d._Cancel != nil {
 		d._Cancel()
@@ -1069,7 +1072,7 @@ func TestGetDeviceProgress(t *testing.T) {
 			},
 		},
 	}
-	progress := replicator.getDeviceProgress()
+	progress := replicator.getDeviceProgress("object-replicator")
 	sdb, ok := progress["sdb"]
 	require.True(t, ok)
 	require.Equal(t, int64(100), sdb.PartitionsTotal)

--- a/objectserver/repsrv.go
+++ b/objectserver/repsrv.go
@@ -66,7 +66,8 @@ func (r *Replicator) incomingDone(device string) {
 
 // ProgressReportHandler handles HTTP requests for current replication progress
 func (r *Replicator) ProgressReportHandler(w http.ResponseWriter, req *http.Request) {
-	data, err := json.Marshal(r.getDeviceProgress())
+	vars := srv.GetVars(req)
+	data, err := json.Marshal(r.getDeviceProgress(vars["name"]))
 	if err != nil {
 		r.logger.Error("Error Marshaling device progress", zap.Error(err))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -342,7 +343,7 @@ func (r *Replicator) GetHandler(config conf.Config, metricsPrefix string) http.H
 	router.Post("/debug/pprof/:parm", http.DefaultServeMux)
 	router.Post("/priorityrep", commonHandlers.ThenFunc(r.priorityRepHandler))
 	router.Post("/stabilize/:device/:partition/:account/:container/*obj", commonHandlers.ThenFunc(r.stabilizeHandler))
-	router.Get("/progress", commonHandlers.ThenFunc(r.ProgressReportHandler))
+	router.Get("/progress/:name", commonHandlers.ThenFunc(r.ProgressReportHandler))
 	for _, policy := range r.policies {
 		router.HandlePolicy("REPCONN", "/:device/:partition", policy.Index, commonHandlers.ThenFunc(r.objRepConnHandler))
 		router.HandlePolicy("REPLICATE", "/:device/:partition/:suffixes", policy.Index, commonHandlers.ThenFunc(r.objReplicateHandler))

--- a/objectserver/swiftobjeng.go
+++ b/objectserver/swiftobjeng.go
@@ -143,7 +143,7 @@ func (q quarantineFileError) Error() string {
 }
 
 func (rd *swiftDevice) UpdateStat(stat string, amount int64) {
-	rd.r.updateStat <- statUpdate{"object-replicator", rd.Key(), stat, amount}
+	rd.r.updateStat <- statUpdate{rd.Type(), rd.Key(), stat, amount}
 }
 
 func (rd *swiftDevice) listObjFiles(objChan chan string, cancel chan struct{}, partdir string, needSuffix func(string) bool) {
@@ -538,6 +538,9 @@ func (rd *swiftDevice) Key() string {
 	return deviceKeyId(rd.dev.Device, rd.policy)
 }
 
+func (rd *swiftDevice) Type() string {
+	return "object-replicator"
+}
 func (rd *swiftDevice) cleanTemp() {
 	tempDir := TempDirPath(rd.r.deviceRoot, rd.dev.Device)
 	if tmpContents, err := ioutil.ReadDir(tempDir); err == nil {

--- a/tools/reconcli.go
+++ b/tools/reconcli.go
@@ -71,7 +71,7 @@ func queryHostRecon(client common.HTTPClient, s *ipPort, endpoint string) ([]byt
 }
 
 func queryHostReplication(client common.HTTPClient, s *ipPort) (map[string]objectserver.DeviceStats, error) {
-	serverUrl := fmt.Sprintf("http://%s:%d/progress", s.ip, s.replicationPort)
+	serverUrl := fmt.Sprintf("http://%s:%d/progress/object-replicator", s.ip, s.replicationPort)
 	req, err := http.NewRequest("GET", serverUrl, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
note: these stats are cleared at end of each run (10s)
to see them hit:

curl http://127.0.0.1:8010/progress/object-nursery | python -m json.tool