### PR TITLE
HUM-867 Metrics for stabilization

### DIFF
--- a/objectserver/nurserystabilizer.go
+++ b/objectserver/nurserystabilizer.go
@@ -174,10 +174,10 @@ func GetNurseryDevice(oring ring.Ring, dev *ring.Device, policy int, r *Replicat
 		canchan:   make(chan struct{}),
 		objEngine: f,
 	}
-	nrd.stabilizationAttemptsMetric = r.metricsScope.Counter(dev.Device + "_stabilization_attempts")
-	nrd.stabilizationSuccessesMetric = r.metricsScope.Counter(dev.Device + "_stabilization_successes")
-	nrd.stabilizationFailuresMetric = r.metricsScope.Counter(dev.Device + "_stabilization_failures")
-	nrd.stabilizationLastPassCountMetric = r.metricsScope.Gauge(dev.Device + "_stabilization_last_pass_count")
-	nrd.stabilizationLastPassDurationMetric = r.metricsScope.Timer(dev.Device + "_stabilization_last_pass_duration")
+	nrd.stabilizationAttemptsMetric = r.metricsScope.Counter(fmt.Sprintf("%d_%s_stabilization_attempts", policy, dev.Device))
+	nrd.stabilizationSuccessesMetric = r.metricsScope.Counter(fmt.Sprintf("%d_%s_stabilization_successes", policy, dev.Device))
+	nrd.stabilizationFailuresMetric = r.metricsScope.Counter(fmt.Sprintf("%d_%s_stabilization_failures", policy, dev.Device))
+	nrd.stabilizationLastPassCountMetric = r.metricsScope.Gauge(fmt.Sprintf("%d_%s_stabilization_last_pass_count", policy, dev.Device))
+	nrd.stabilizationLastPassDurationMetric = r.metricsScope.Timer(fmt.Sprintf("%d_%s_stabilization_last_pass_duration", policy, dev.Device))
 	return nrd, nil
 }

--- a/objectserver/replicator.go
+++ b/objectserver/replicator.go
@@ -33,6 +33,7 @@ import (
 	"github.com/troubling/hummingbird/common/srv"
 	"github.com/troubling/hummingbird/common/tracing"
 	"github.com/troubling/hummingbird/middleware"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/http2"
@@ -104,6 +105,7 @@ type Replicator struct {
 	incomingLimitPerDev int64
 	policies            conf.PolicyList
 	logLevel            zap.AtomicLevel
+	metricsScope        tally.Scope
 	metricsCloser       io.Closer
 	traceCloser         io.Closer
 	clientTraceCloser   io.Closer

--- a/objectserver/repsrv.go
+++ b/objectserver/repsrv.go
@@ -321,8 +321,7 @@ func (r *Replicator) LogRequest(next http.Handler) http.Handler {
 }
 
 func (r *Replicator) GetHandler(config conf.Config, metricsPrefix string) http.Handler {
-	var metricsScope tally.Scope
-	metricsScope, r.metricsCloser = tally.NewRootScope(tally.ScopeOptions{
+	r.metricsScope, r.metricsCloser = tally.NewRootScope(tally.ScopeOptions{
 		Prefix:         metricsPrefix,
 		Tags:           map[string]string{},
 		CachedReporter: promreporter.NewReporter(promreporter.Options{}),
@@ -357,5 +356,5 @@ func (r *Replicator) GetHandler(config conf.Config, metricsPrefix string) http.H
 			})
 		}
 	}
-	return alice.New(middleware.Metrics(metricsScope), middleware.ServerTracer(r.tracer)).Then(router)
+	return alice.New(middleware.Metrics(r.metricsScope), middleware.ServerTracer(r.tracer)).Then(router)
 }


### PR DESCRIPTION
Easiest way to mess with this is to put a `time.Sleep(15*time.Second)`  inside the `for := range c {` loop in objectserver/nurserystabilizer.go's `Scan` function and then do a quick `nectar bench-put container` or similar to get some objects in a hec or rep policy.

