### PR TITLE
HUM-891 Fix context canceled error msg in proxy.

### DIFF
--- a/client/objclient.go
+++ b/client/objclient.go
@@ -13,6 +13,7 @@ import (
 	"github.com/troubling/hummingbird/common"
 	"github.com/troubling/hummingbird/common/ring"
 	"github.com/troubling/hummingbird/common/srv"
+	"github.com/troubling/hummingbird/common/tracing"
 	"github.com/troubling/nectar/nectarutil"
 	"go.uber.org/zap"
 )
@@ -114,7 +115,7 @@ func (oc *standardObjectClient) putObject(ctx context.Context, account, containe
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		req.Header.Set("Content-Type", "application/octet-stream")
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
@@ -217,7 +218,7 @@ func (oc *standardObjectClient) postObject(ctx context.Context, account, contain
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -237,7 +238,7 @@ func (oc *standardObjectClient) getObject(ctx context.Context, account, containe
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -255,7 +256,7 @@ func (oc *standardObjectClient) grepObject(ctx context.Context, account, contain
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(oc.policy))
 		return req, nil
 	})
@@ -270,7 +271,7 @@ func (oc *standardObjectClient) headObject(ctx context.Context, account, contain
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -292,7 +293,7 @@ func (oc *standardObjectClient) deleteObject(ctx context.Context, account, conta
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}

--- a/client/proxyclient.go
+++ b/client/proxyclient.go
@@ -378,7 +378,7 @@ func (c *requestClient) PutAccount(ctx context.Context, account string, headers 
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -394,7 +394,7 @@ func (c *requestClient) PostAccount(ctx context.Context, account string, headers
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -412,7 +412,7 @@ func (c *requestClient) GetAccountRaw(ctx context.Context, account string, optio
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -429,7 +429,7 @@ func (c *requestClient) HeadAccount(ctx context.Context, account string, headers
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -445,7 +445,7 @@ func (c *requestClient) DeleteAccount(ctx context.Context, account string, heade
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -477,7 +477,7 @@ func (c *requestClient) PutContainer(ctx context.Context, account string, contai
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -501,7 +501,7 @@ func (c *requestClient) PostContainer(ctx context.Context, account string, conta
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -519,7 +519,7 @@ func (c *requestClient) GetContainerRaw(ctx context.Context, account string, con
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -628,7 +628,7 @@ func (c *requestClient) HeadContainer(ctx context.Context, account string, conta
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}
@@ -649,7 +649,7 @@ func (c *requestClient) DeleteContainer(ctx context.Context, account string, con
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
+		req = req.WithContext(tracing.CopySpanFromContext(ctx))
 		for key := range headers {
 			req.Header.Set(key, headers.Get(key))
 		}


### PR DESCRIPTION
As we are using goroutine in quorumResponse & firstResponse and bailing out earlier,
passing the proxy context as it is down the stack causes "context cancelled" error.
This patch extract the tracing span from the proxy request's Context and
inject it into a new Context which is passed down the stack.