### PR TITLE
HUM-773 Errors with auth now 500

### DIFF
--- a/proxyserver/middleware/authtoken_test.go
+++ b/proxyserver/middleware/authtoken_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/troubling/hummingbird/common/test"
@@ -246,11 +245,7 @@ func TestExpiredToken(t *testing.T) {
 	}
 	at.ServeHTTP(rec, req)
 	require.Equal(t, 0, len(fakeCache.MockValues))
-	require.Equal(t, 1, logs.Len())
-	want := []observer.LoggedEntry{{
-		Entry:   zapcore.Entry{Level: zap.DebugLevel, Message: "Failed to validate token"},
-		Context: []zapcore.Field{zap.Error(errors.New("Returned token is not valid"))}}}
-	require.Equal(t, want[0], logs.AllUntimed()[0])
+	require.Equal(t, 0, logs.Len())
 	if rec.Code != 200 {
 		t.Fatalf("wrong code, got %d want %d", rec.Code, 200)
 	}


### PR DESCRIPTION
To test this I used Keystone auth and then deliberately added an error to our doValidate function. i.e.:

```
diff --git a/proxyserver/middleware/authtoken.go b/proxyserver/middleware/authtoken.go
index a9cfa30..9095072 100644
--- a/proxyserver/middleware/authtoken.go
+++ b/proxyserver/middleware/authtoken.go
@@ -414,6 +414,9 @@ func (at *authToken) doValidateS3(ctx context.Context, proxyCtx *ProxyContext, s
 }

 func (at *authToken) doValidate(ctx context.Context, proxyCtx *ProxyContext, tken string) (*token, error) {
+    if at != nil {
+        return nil, errors.New("GLH")
+    }
        if !strings.HasSuffix(at.authURL, "/") {
                at.authURL += "/"
        }
```

Without this PR the response to the client would be a 401 Unauthorized. That technically means the client should talk to auth again and get a fresh token. Which won't solve the problem since the token isn't the problem.

Anyway, with this PR the response to the client is a 500 Internal Server Error, which should either just error out on the client or invoke the client's retry logic.