### PR TITLE
HUM-897 close some race conditions in account

### DIFF
--- a/accountserver/engine_test.go
+++ b/accountserver/engine_test.go
@@ -28,6 +28,10 @@ type hashDatabase struct {
 	hash string
 }
 
+func (h hashDatabase) Ping() error {
+	return nil
+}
+
 func (h hashDatabase) ID() string {
 	return h.hash
 }

--- a/accountserver/replicator_test.go
+++ b/accountserver/replicator_test.go
@@ -163,6 +163,9 @@ func testServer(t *testing.T, h http.Handler) (*ring.Device, func()) {
 
 type fakeDatabase struct{}
 
+func (f fakeDatabase) Ping() error {
+	return nil
+}
 func (f fakeDatabase) GetInfo() (*AccountInfo, error) {
 	return nil, errors.New("")
 }
@@ -352,10 +355,6 @@ func TestReplicatorChooseReplicationStrategy(t *testing.T) {
 	require.Equal(t, "hashmatch", rd.chooseReplicationStrategy(
 		&AccountInfo{Hash: "somehash", MaxRow: 10},
 		&AccountInfo{Hash: "somehash", Point: 9},
-		100))
-	require.Equal(t, "rsync_then_merge", rd.chooseReplicationStrategy(
-		&AccountInfo{Hash: "somehash1", MaxRow: 1000},
-		&AccountInfo{Hash: "somehash2", Point: 9},
 		100))
 	require.Equal(t, "diff", rd.chooseReplicationStrategy(
 		&AccountInfo{Hash: "somehash1", MaxRow: 10},

--- a/accountserver/sqlite_backend.go
+++ b/accountserver/sqlite_backend.go
@@ -1175,9 +1175,10 @@ func sqliteCreateAccount(accountFile string, account string, putTimestamp string
 	if err := tx.Commit(); err != nil {
 		return err
 	}
-	dbConn.Close()
-	sqliteRename(tempFile, accountFile)
-	return nil
+	if err := dbConn.Close(); err != nil {
+		return err
+	}
+	return sqliteRename(tempFile, accountFile)
 }
 
 func sqliteOpenAccount(accountFile string) (ReplicableAccount, error) {

--- a/common/fs/main.go
+++ b/common/fs/main.go
@@ -117,3 +117,15 @@ func Exists(file string) bool {
 	}
 	return true
 }
+
+func Inode(file string) (uint64, error) {
+	fileinfo, err := os.Stat(file)
+	if err != nil {
+		return 0, err
+	}
+	stat, ok := fileinfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("Unable to cast stat object")
+	}
+	return stat.Ino, nil
+}


### PR DESCRIPTION
Basically, make sure it grabs a flock on the hash dir *any* time it
deals with the database as a file on the filesystem.

Also, make sure that when it renames database files, any journals
move with database and old journals get removed.

When pulling a cached connection out of the pool, make sure the
underlying inode hasn't changed.

Get rid of the rsync_then_merge replication strategy, since it's not
super useful for accounts and can cause problems.