### PR TITLE
HUM-647 Add X-Timestamp to Replicate functions

### DIFF
--- a/objectserver/ecobj.go
+++ b/objectserver/ecobj.go
@@ -409,6 +409,7 @@ func (o *ecObject) Replicate(prirep PriorityRepJob) error {
 			return err
 		}
 		req.ContentLength = ecShardLength(o.ContentLength(), o.dataShards)
+		req.Header.Set("X-Timestamp", o.metadata["X-Timestamp"])
 		req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(o.policy))
 		req.Header.Set("X-Trans-Id", o.txnId)
 		req.Header.Set("User-Agent", "nursery-stabilizer")

--- a/objectserver/repobj.go
+++ b/objectserver/repobj.go
@@ -315,6 +315,7 @@ func (ro *repObject) Replicate(prirep PriorityRepJob) error {
 		return err
 	}
 	req.ContentLength = ro.ContentLength()
+	req.Header.Set("X-Timestamp", ro.metadata["X-Timestamp"])
 	req.Header.Set("X-Backend-Storage-Policy-Index", strconv.Itoa(ro.policy))
 	req.Header.Set("X-Trans-Id", ro.txnId)
 	for k, v := range ro.metadata {


### PR DESCRIPTION
To be honest, I'm not 100% sure why I'm doing this; the JIRA had little explanation. I'm guessing it is so that the timestamp is in the logs.