### PR TITLE
HUM-864 s3api multipart uploads

### DIFF
--- a/proxyserver/middleware/s3auth.go
+++ b/proxyserver/middleware/s3auth.go
@@ -123,6 +123,11 @@ func (s *s3AuthHandler) ServeHTTP(writer http.ResponseWriter, request *http.Requ
 	// NOTE: The following is for V2 Auth
 
 	buf.WriteString(request.URL.Path)
+	if request.URL.RawQuery != "" {
+		queryParts := strings.Split(request.URL.RawQuery, "&")
+		sort.Strings(queryParts)
+		buf.WriteString("?" + strings.Join(queryParts, "&"))
+	}
 	ctx.S3Auth = &S3AuthInfo{
 		StringToSign: buf.String(),
 		Key:          key,


### PR DESCRIPTION
Support basic multi-part uploads.  Handle the following request types:

POST /container/object?uploads                   // begin upload
PUT /container/object?partNumber=X&uploadId=XXXX // put part
POST /container/object?uploadId=XXXX             // complete upload
DELETE /container/object?uploadId=XXXX           // abort upload
GET /container/object?uploadId=XXXX              // list parts
GET /container/?uploads                          // list uploads

The object segments are stored in a side-container named
"[container name]+segments", and the object is saved as a static
large object pointing to those segments.