### PR TITLE
HUM-522 Just require load to be >= 0

### DIFF
--- a/middleware/recon_test.go
+++ b/middleware/recon_test.go
@@ -181,7 +181,7 @@ func TestGetLoad(t *testing.T) {
 	require.True(t, ok)
 	m5f, ok := m5.(float64)
 	require.True(t, ok)
-	require.True(t, m5f > 0.0)
+	require.True(t, m5f >= 0.0)
 }
 
 func TestQuarantineDetail(t *testing.T) {


### PR DESCRIPTION
If you're running go test locally in the middleware dir on a fairly idle
box, this test would often fail since the system load would often be
zero.