### PR TITLE
HUM-655 Simplify StablePost

### DIFF
--- a/objectserver/indexdb.go
+++ b/objectserver/indexdb.go
@@ -749,18 +749,11 @@ func (ot *IndexDB) StablePut(hsh string, shardIndex int, request *http.Request) 
 }
 
 func (ot *IndexDB) StablePost(hsh string, shardIndex int, request *http.Request) (int, error) {
-	item, err := ot.Lookup(hsh, shardIndex, false)
-	if err != nil || item == nil || item.Deletion {
-		return http.StatusNotFound, err
-	}
 	timestampTime, err := common.ParseDate(request.Header.Get("X-Timestamp"))
 	if err != nil {
 		return http.StatusBadRequest, fmt.Errorf("invalid timestamp")
 	}
 	timestamp := timestampTime.UnixNano()
-	if timestamp <= item.Timestamp {
-		return http.StatusConflict, nil
-	}
 	metadata := make(map[string]string)
 	for key := range request.Header {
 		if strings.HasPrefix(key, "Meta-") {


### PR DESCRIPTION
There does not seem to be a need for the extra lookup. It just offers the ability to return a 404 or a 409 and the far end doesn't really care and Commit does the same check albeit without returning the exact status codes.