### PR TITLE
Some s3api nitpicks.

### DIFF
--- a/proxyserver/middleware/s3api.go
+++ b/proxyserver/middleware/s3api.go
@@ -338,6 +338,8 @@ func (w *s3ResponseWriterWrapper) Header() http.Header {
 }
 
 func (w *s3ResponseWriterWrapper) WriteHeader(statusCode int) {
+	w.writer.Header().Set("x-amz-id-2", w.requestId)
+	w.writer.Header().Set("x-amz-request-id", w.requestId)
 	if statusCode/100 != 2 {
 		// We are going to hijack to return an S3 style result
 		w.hijack = true
@@ -432,6 +434,16 @@ func validBucketName(s string) bool {
 func InvalidBucketNameResponse(writer http.ResponseWriter, request *http.Request) {
 	writer.WriteHeader(400)
 	writer.Write(nil)
+}
+
+func s3DateString(s string) string {
+	if strings.HasSuffix(s, "Z") {
+		s = s[:len(s)-1]
+	}
+	if len(s) < 3 {
+		return s
+	}
+	return s[:len(s)-3] + "Z"
 }
 
 func (s *s3ApiHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
@@ -955,7 +967,7 @@ func (s *s3ApiHandler) handleContainerRequest(writer http.ResponseWriter, reques
 			}
 			obj := s3ObjectInfo{
 				Name:         o.Name,
-				LastModified: o.LastModified + "Z",
+				LastModified: s3DateString(o.LastModified),
 				ETag:         "\"" + o.ETag + "\"",
 				Size:         o.Size,
 				StorageClass: "STANDARD",

--- a/proxyserver/middleware/s3api.go
+++ b/proxyserver/middleware/s3api.go
@@ -437,6 +437,9 @@ func InvalidBucketNameResponse(writer http.ResponseWriter, request *http.Request
 }
 
 func s3DateString(s string) string {
+	// This is just trimming out some extra precision off our seconds for
+	// the swift s3api func tests.
+	// r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
 	if strings.HasSuffix(s, "Z") {
 		s = s[:len(s)-1]
 	}

--- a/proxyserver/middleware/s3api_test.go
+++ b/proxyserver/middleware/s3api_test.go
@@ -19,3 +19,12 @@ func TestValidBucketName(t *testing.T) {
 	assert.False(t, validBucketName("bucket+invalid"))
 	assert.True(t, validBucketName("boring.bucket.name"))
 }
+
+func TestS3DateString(t *testing.T) {
+	// Removes 3 of the last 6 digits
+	assert.Equal(t, "2018-07-05T18:16:09.295Z", s3DateString("2018-07-05T18:16:09.295890Z"))
+	// Always adds a Z
+	assert.Equal(t, "123456Z", s3DateString("123456789"))
+	// Doesn't index out of range.
+	assert.Equal(t, "no", s3DateString("no"))
+}


### PR DESCRIPTION
Add a couple headers that aws sends that are just duplicates of the
request id.

Add a helper for the proper date format. Not all date occurences
are fixed yet.